### PR TITLE
Fix memory leak from unbounded session accumulation

### DIFF
--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -13,13 +13,26 @@ import {
 } from "./supabase.js";
 import { withAnalytics } from "./analytics.js";
 
+const SESSION_TTL_MS = 60 * 60 * 1000; // 60 minutes
+const CLEANUP_INTERVAL_MS = 5 * 60 * 1000; // every 5 minutes
+
 const sessions = new Map<
     string,
     {
         transport: WebStandardStreamableHTTPServerTransport;
         mcpToken: string;
+        lastActivity: number;
     }
 >();
+
+setInterval(() => {
+    const now = Date.now();
+    for (const [id, session] of sessions) {
+        if (now - session.lastActivity > SESSION_TTL_MS) {
+            sessions.delete(id);
+        }
+    }
+}, CLEANUP_INTERVAL_MS);
 
 function todayDate(): string {
     return new Date().toISOString().slice(0, 10);
@@ -458,6 +471,7 @@ export const handleMcp = async (c: Context) => {
     }
 
     if (session) {
+        session.lastActivity = Date.now();
         return session.transport.handleRequest(c.req.raw);
     }
 
@@ -468,7 +482,11 @@ export const handleMcp = async (c: Context) => {
     const transport = new WebStandardStreamableHTTPServerTransport({
         sessionIdGenerator: () => crypto.randomUUID(),
         onsessioninitialized: (id) => {
-            sessions.set(id, { transport, mcpToken });
+            sessions.set(id, {
+                transport,
+                mcpToken,
+                lastActivity: Date.now(),
+            });
         },
         onsessionclosed: (id) => {
             sessions.delete(id);

--- a/src/oauth.ts
+++ b/src/oauth.ts
@@ -33,6 +33,8 @@ function cleanExpiredSessions() {
     }
 }
 
+setInterval(cleanExpiredSessions, 60 * 1000);
+
 function base64URLEncode(buffer: Buffer): string {
     return buffer
         .toString("base64")


### PR DESCRIPTION
## Summary
- MCP sessions stored in a global Map were never cleaned up when clients disconnected abnormally (network drops, crashes), causing steady memory growth over time
- Added periodic cleanup (every 5 min) that evicts MCP sessions idle for 60+ minutes — only drops the reference without calling `transport.close()`, so active users are never affected
- Added periodic cleanup for OAuth sessions (every 1 min) instead of only cleaning expired sessions when a new `/authorize` request arrives

## Test plan
- [ ] Deploy and monitor DigitalOcean memory chart over 24-48 hours — memory should plateau instead of climbing indefinitely
- [ ] Verify existing MCP clients can still connect and use tools normally
- [ ] Verify OAuth login flow still works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)