### PR TITLE
Add hydration tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,9 +41,13 @@ Read the story behind it: [How I Replaced MyFitnessPal and Other Apps with a Sin
 | `get_nutrition_summary`   | Daily nutrition totals + goal progress for a date range    |
 | `update_meal`             | Update any fields of an existing meal                      |
 | `delete_meal`             | Delete a meal by ID                                        |
-| `set_nutrition_goals`     | Set daily calorie and macro targets                        |
+| `set_nutrition_goals`     | Set daily calorie, macro, and water targets                |
 | `get_nutrition_goals`     | Get the current daily targets                              |
 | `get_goal_progress`       | Get intake vs. targets for a given day (default: today)    |
+| `log_water`               | Log a hydration entry in milliliters                       |
+| `get_water_today`         | Get today's water intake total and entries                 |
+| `get_water_by_date`       | Get water intake for a specific date                       |
+| `delete_water`            | Delete a water log entry by ID                             |
 | `delete_account`          | Permanently delete account and all associated data         |
 
 ## Self-hosting

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "nutrition-mcp",
-    "version": "1.7.0",
+    "version": "1.8.0",
     "description": "A remote MCP server for personal nutrition tracking. Log meals, track macros, and review nutrition history through Claude.",
     "author": "akutishevsky",
     "license": "MIT",

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
     "name": "io.github.akutishevsky/nutrition-mcp",
     "title": "Nutrition MCP",
     "description": "Personal nutrition tracking — log meals, track macros, and review history through conversation.",
-    "version": "1.7.0",
+    "version": "1.8.0",
     "websiteUrl": "https://nutrition-mcp.com/",
     "repository": {
         "url": "https://github.com/akutishevsky/nutrition-mcp",

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -11,8 +11,13 @@ import {
     deleteAllUserData,
     upsertNutritionGoals,
     getNutritionGoals,
+    insertWater,
+    getWaterByDate,
+    getWaterInRange,
+    deleteWater,
     type Meal,
     type NutritionGoals,
+    type WaterEntry,
 } from "./supabase.js";
 import { withAnalytics } from "./analytics.js";
 
@@ -46,6 +51,7 @@ interface DailyTotals {
     protein_g: number;
     carbs_g: number;
     fat_g: number;
+    water_ml: number;
 }
 
 function sumMeals(meals: Meal[]): DailyTotals {
@@ -54,6 +60,7 @@ function sumMeals(meals: Meal[]): DailyTotals {
         protein_g: 0,
         carbs_g: 0,
         fat_g: 0,
+        water_ml: 0,
     };
     for (const m of meals) {
         totals.calories += m.calories ?? 0;
@@ -62,6 +69,12 @@ function sumMeals(meals: Meal[]): DailyTotals {
         totals.fat_g += m.fat_g ?? 0;
     }
     return totals;
+}
+
+function sumWater(entries: WaterEntry[]): number {
+    let total = 0;
+    for (const e of entries) total += e.amount_ml;
+    return total;
 }
 
 function formatGoalLine(
@@ -104,6 +117,12 @@ function formatProgress(
             goals?.daily_carbs_g ?? null,
         ),
         formatGoalLine("Fat", "g", totals.fat_g, goals?.daily_fat_g ?? null),
+        formatGoalLine(
+            "Water",
+            " ml",
+            totals.water_ml,
+            goals?.daily_water_ml ?? null,
+        ),
     ];
     return lines.join("\n");
 }
@@ -124,6 +143,9 @@ function formatGoals(goals: NutritionGoals | null): string {
     );
     parts.push(
         `- Fat: ${goals.daily_fat_g != null ? `${goals.daily_fat_g}g` : "not set"}`,
+    );
+    parts.push(
+        `- Water: ${goals.daily_water_ml != null ? `${goals.daily_water_ml} ml` : "not set"}`,
     );
     return parts.join("\n");
 }
@@ -370,16 +392,17 @@ function registerTools(server: McpServer, userId: string) {
             return withAnalytics(
                 "get_nutrition_summary",
                 async () => {
-                    const [meals, goals] = await Promise.all([
+                    const [meals, water, goals] = await Promise.all([
                         getMealsInRange(userId, start_date, end_date),
+                        getWaterInRange(userId, start_date, end_date),
                         getNutritionGoals(userId),
                     ]);
-                    if (meals.length === 0) {
+                    if (meals.length === 0 && water.length === 0) {
                         return {
                             content: [
                                 {
                                     type: "text",
-                                    text: `No meals found between ${start_date} and ${end_date}.`,
+                                    text: `No meals or water logged between ${start_date} and ${end_date}.`,
                                 },
                             ],
                         };
@@ -393,12 +416,22 @@ function registerTools(server: McpServer, userId: string) {
                         existing.push(meal);
                         byDate.set(date, existing);
                     }
+                    const waterByDate = new Map<string, number>();
+                    for (const entry of water) {
+                        const date = entry.logged_at.slice(0, 10);
+                        waterByDate.set(
+                            date,
+                            (waterByDate.get(date) ?? 0) + entry.amount_ml,
+                        );
+                        if (!byDate.has(date)) byDate.set(date, []);
+                    }
 
                     const sections: string[] = [];
                     for (const [date, dateMeals] of [
                         ...byDate.entries(),
                     ].sort()) {
                         const totals = sumMeals(dateMeals);
+                        totals.water_ml = waterByDate.get(date) ?? 0;
                         const header = `## ${date} (${dateMeals.length} meal${dateMeals.length === 1 ? "" : "s"})`;
                         sections.push(
                             `${header}\n${formatProgress(totals, goals)}`,
@@ -457,6 +490,13 @@ function registerTools(server: McpServer, userId: string) {
                     .nullable()
                     .optional()
                     .describe("Daily fat target (grams). Null to clear."),
+                daily_water_ml: z.coerce
+                    .number()
+                    .nullable()
+                    .optional()
+                    .describe(
+                        "Daily water target (milliliters). Null to clear.",
+                    ),
             },
         },
         async (args) => {
@@ -481,6 +521,10 @@ function registerTools(server: McpServer, userId: string) {
                             args.daily_fat_g === undefined
                                 ? (existing?.daily_fat_g ?? null)
                                 : args.daily_fat_g,
+                        daily_water_ml:
+                            args.daily_water_ml === undefined
+                                ? (existing?.daily_water_ml ?? null)
+                                : args.daily_water_ml,
                     };
                     const goals = await upsertNutritionGoals(userId, merged);
                     return {
@@ -548,12 +592,14 @@ function registerTools(server: McpServer, userId: string) {
                 "get_goal_progress",
                 async () => {
                     const targetDate = date ?? todayDate();
-                    const [meals, goals] = await Promise.all([
+                    const [meals, water, goals] = await Promise.all([
                         getMealsByDate(userId, targetDate),
+                        getWaterByDate(userId, targetDate),
                         getNutritionGoals(userId),
                     ]);
                     const totals = sumMeals(meals);
-                    const header = `Progress for ${targetDate} (${meals.length} meal${meals.length === 1 ? "" : "s"})`;
+                    totals.water_ml = sumWater(water);
+                    const header = `Progress for ${targetDate} (${meals.length} meal${meals.length === 1 ? "" : "s"}, ${water.length} water entr${water.length === 1 ? "y" : "ies"})`;
                     const body = formatProgress(totals, goals);
                     const footer = goals
                         ? ""
@@ -647,6 +693,186 @@ function registerTools(server: McpServer, userId: string) {
             );
         },
     );
+    server.registerTool(
+        "log_water",
+        {
+            title: "Log Water",
+            description:
+                "Log a hydration entry in milliliters. If the user gives a volume in another unit (cups, oz, liters), convert it: 1 cup = 240 ml, 1 fl oz = 30 ml, 1 L = 1000 ml. If only 'a glass' is mentioned, ask for the size or assume 250 ml and confirm.",
+            annotations: {
+                readOnlyHint: false,
+                destructiveHint: false,
+                idempotentHint: false,
+                openWorldHint: false,
+            },
+            inputSchema: {
+                amount_ml: z.coerce
+                    .number()
+                    .int()
+                    .positive()
+                    .describe("Amount in milliliters (integer, > 0)."),
+                logged_at: z
+                    .string()
+                    .optional()
+                    .describe(
+                        "ISO 8601 timestamp (defaults to now). If you don't know the current date or time, ask the user before calling this tool.",
+                    ),
+                notes: z
+                    .string()
+                    .optional()
+                    .describe("Optional notes (e.g. 'tea', 'post-workout')."),
+            },
+        },
+        async (args) => {
+            return withAnalytics(
+                "log_water",
+                async () => {
+                    const entry = await insertWater(userId, args);
+                    return {
+                        content: [
+                            {
+                                type: "text",
+                                text: `Water logged: ${entry.amount_ml} ml at ${entry.logged_at}${entry.notes ? ` (${entry.notes})` : ""}. ID: ${entry.id}`,
+                            },
+                        ],
+                    };
+                },
+                { userId },
+            );
+        },
+    );
+
+    server.registerTool(
+        "get_water_today",
+        {
+            title: "Get Today's Water",
+            description:
+                "Get today's total water intake (ml) and the list of entries.",
+            annotations: {
+                readOnlyHint: true,
+                destructiveHint: false,
+                idempotentHint: true,
+                openWorldHint: false,
+            },
+        },
+        async () => {
+            return withAnalytics(
+                "get_water_today",
+                async () => {
+                    const entries = await getWaterByDate(userId, todayDate());
+                    if (entries.length === 0) {
+                        return {
+                            content: [
+                                {
+                                    type: "text",
+                                    text: "No water logged today.",
+                                },
+                            ],
+                        };
+                    }
+                    const total = sumWater(entries);
+                    const lines = entries.map(
+                        (e) =>
+                            `- ${e.amount_ml} ml at ${e.logged_at}${e.notes ? ` (${e.notes})` : ""} [id: ${e.id}]`,
+                    );
+                    return {
+                        content: [
+                            {
+                                type: "text",
+                                text: `Total: ${total} ml (${entries.length} entr${entries.length === 1 ? "y" : "ies"})\n\n${lines.join("\n")}`,
+                            },
+                        ],
+                    };
+                },
+                { userId },
+            );
+        },
+    );
+
+    server.registerTool(
+        "get_water_by_date",
+        {
+            title: "Get Water by Date",
+            description: "Get water intake total and entries for a specific date.",
+            annotations: {
+                readOnlyHint: true,
+                destructiveHint: false,
+                idempotentHint: true,
+                openWorldHint: false,
+            },
+            inputSchema: {
+                date: z.string().describe("Date in YYYY-MM-DD format"),
+            },
+        },
+        async ({ date }) => {
+            return withAnalytics(
+                "get_water_by_date",
+                async () => {
+                    const entries = await getWaterByDate(userId, date);
+                    if (entries.length === 0) {
+                        return {
+                            content: [
+                                {
+                                    type: "text",
+                                    text: `No water logged on ${date}.`,
+                                },
+                            ],
+                        };
+                    }
+                    const total = sumWater(entries);
+                    const lines = entries.map(
+                        (e) =>
+                            `- ${e.amount_ml} ml at ${e.logged_at}${e.notes ? ` (${e.notes})` : ""} [id: ${e.id}]`,
+                    );
+                    return {
+                        content: [
+                            {
+                                type: "text",
+                                text: `Total on ${date}: ${total} ml (${entries.length} entr${entries.length === 1 ? "y" : "ies"})\n\n${lines.join("\n")}`,
+                            },
+                        ],
+                    };
+                },
+                { userId },
+                { date },
+            );
+        },
+    );
+
+    server.registerTool(
+        "delete_water",
+        {
+            title: "Delete Water Entry",
+            description: "Delete a water log entry by ID.",
+            annotations: {
+                readOnlyHint: false,
+                destructiveHint: true,
+                idempotentHint: true,
+                openWorldHint: false,
+            },
+            inputSchema: {
+                id: z.string().describe("UUID of the water entry to delete"),
+            },
+        },
+        async ({ id }) => {
+            return withAnalytics(
+                "delete_water",
+                async () => {
+                    await deleteWater(userId, id);
+                    return {
+                        content: [
+                            {
+                                type: "text",
+                                text: `Water entry ${id} deleted.`,
+                            },
+                        ],
+                    };
+                },
+                { userId },
+            );
+        },
+    );
+
     server.registerTool(
         "delete_account",
         {
@@ -743,7 +969,7 @@ export const handleMcp = async (c: Context) => {
     const server = new McpServer(
         {
             name: "nutrition-mcp",
-            version: "1.7.0",
+            version: "1.8.0",
             icons: [
                 {
                     src: `${baseUrl}/favicon.ico`,

--- a/src/supabase.ts
+++ b/src/supabase.ts
@@ -175,6 +175,7 @@ export interface NutritionGoals {
     daily_protein_g: number | null;
     daily_carbs_g: number | null;
     daily_fat_g: number | null;
+    daily_water_ml: number | null;
     updated_at: string;
 }
 
@@ -183,6 +184,7 @@ export interface NutritionGoalsInput {
     daily_protein_g?: number | null;
     daily_carbs_g?: number | null;
     daily_fat_g?: number | null;
+    daily_water_ml?: number | null;
 }
 
 export async function upsertNutritionGoals(
@@ -198,6 +200,7 @@ export async function upsertNutritionGoals(
                 daily_protein_g: input.daily_protein_g ?? null,
                 daily_carbs_g: input.daily_carbs_g ?? null,
                 daily_fat_g: input.daily_fat_g ?? null,
+                daily_water_ml: input.daily_water_ml ?? null,
                 updated_at: new Date().toISOString(),
             },
             { onConflict: "user_id" },
@@ -222,6 +225,85 @@ export async function getNutritionGoals(
     return (data as NutritionGoals | null) ?? null;
 }
 
+// ---------- Water log ----------
+
+export interface WaterEntry {
+    id: string;
+    user_id: string;
+    amount_ml: number;
+    logged_at: string;
+    notes: string | null;
+    created_at: string;
+}
+
+export interface WaterInput {
+    amount_ml: number;
+    logged_at?: string;
+    notes?: string;
+}
+
+export async function insertWater(
+    userId: string,
+    input: WaterInput,
+): Promise<WaterEntry> {
+    const { data, error } = await getSupabase()
+        .from("water_log")
+        .insert({
+            user_id: userId,
+            amount_ml: input.amount_ml,
+            logged_at: input.logged_at ?? new Date().toISOString(),
+            notes: input.notes ?? null,
+        })
+        .select()
+        .single();
+
+    if (error) throw new Error(`Failed to insert water: ${error.message}`);
+    return data as WaterEntry;
+}
+
+export async function getWaterByDate(
+    userId: string,
+    date: string,
+): Promise<WaterEntry[]> {
+    const { data, error } = await getSupabase()
+        .from("water_log")
+        .select("*")
+        .eq("user_id", userId)
+        .gte("logged_at", `${date}T00:00:00`)
+        .lte("logged_at", `${date}T23:59:59`)
+        .order("logged_at", { ascending: true });
+
+    if (error) throw new Error(`Failed to get water: ${error.message}`);
+    return (data as WaterEntry[]) ?? [];
+}
+
+export async function getWaterInRange(
+    userId: string,
+    startDate: string,
+    endDate: string,
+): Promise<WaterEntry[]> {
+    const { data, error } = await getSupabase()
+        .from("water_log")
+        .select("*")
+        .eq("user_id", userId)
+        .gte("logged_at", `${startDate}T00:00:00`)
+        .lte("logged_at", `${endDate}T23:59:59`)
+        .order("logged_at", { ascending: true });
+
+    if (error) throw new Error(`Failed to get water: ${error.message}`);
+    return (data as WaterEntry[]) ?? [];
+}
+
+export async function deleteWater(userId: string, id: string): Promise<void> {
+    const { error } = await getSupabase()
+        .from("water_log")
+        .delete()
+        .eq("id", id)
+        .eq("user_id", userId);
+
+    if (error) throw new Error(`Failed to delete water: ${error.message}`);
+}
+
 // ---------- Delete all user data ----------
 
 export async function deleteAllUserData(userId: string): Promise<void> {
@@ -233,6 +315,13 @@ export async function deleteAllUserData(userId: string): Promise<void> {
         .eq("user_id", userId);
     if (analyticsErr)
         throw new Error(`Failed to delete analytics: ${analyticsErr.message}`);
+
+    const { error: waterErr } = await sb
+        .from("water_log")
+        .delete()
+        .eq("user_id", userId);
+    if (waterErr)
+        throw new Error(`Failed to delete water log: ${waterErr.message}`);
 
     const { error: goalsErr } = await sb
         .from("nutrition_goals")

--- a/supabase/migrations/20260417050150_hydration.sql
+++ b/supabase/migrations/20260417050150_hydration.sql
@@ -1,0 +1,24 @@
+-- Hydration log. One row per drink; amount_ml is always positive.
+create table if not exists public.water_log (
+    id uuid primary key default gen_random_uuid(),
+    user_id uuid not null references auth.users(id) on delete cascade,
+    amount_ml integer not null check (amount_ml > 0),
+    logged_at timestamptz not null default now(),
+    notes text,
+    created_at timestamptz not null default now()
+);
+
+create index if not exists idx_water_log_user_id on public.water_log (user_id);
+create index if not exists idx_water_log_logged_at on public.water_log (logged_at);
+
+alter table public.water_log enable row level security;
+
+create policy "Users manage their own water_log"
+    on public.water_log
+    for all
+    using (auth.uid() = user_id)
+    with check (auth.uid() = user_id);
+
+-- Optional daily water target. Nullable so users can skip it.
+alter table public.nutrition_goals
+    add column if not exists daily_water_ml integer;


### PR DESCRIPTION
## Summary

- Adds a `water_log` table and four tools (`log_water`, `get_water_today`, `get_water_by_date`, `delete_water`) for daily hydration tracking — a high-frequency "come back tomorrow" hook.
- Extends `nutrition_goals` with `daily_water_ml` so `set_nutrition_goals` accepts a water target and `get_goal_progress` / `get_nutrition_summary` render water intake alongside calories and macros in the existing coaching format.

## Changes

- `supabase/migrations/20260417050150_hydration.sql` — creates `water_log` with RLS + per-user policy; adds `daily_water_ml` column to `nutrition_goals`. Already applied to production.
- `src/supabase.ts` — `WaterEntry` type, `insertWater`, `getWaterByDate`, `getWaterInRange`, `deleteWater`; wired into `deleteAllUserData`.
- `src/mcp.ts` — 4 water tools + updated summary/progress rendering; `log_water` tool description instructs the model on common unit conversions (cups, fl oz, L → ml).
- `README.md` — tools table updated.
- Version → **1.8.0** in `package.json`, `server.json`, `src/mcp.ts`.

## Test plan

- [ ] Call `log_water` with `amount_ml: 500`; confirm the entry appears in `get_water_today`.
- [ ] Call `log_water` with a cups/oz value and verify the model converts before invoking.
- [ ] `set_nutrition_goals { daily_water_ml: 2500 }` then `get_goal_progress` — confirm water line shows `500 / 2500 ml (20%, 2000 ml to go)`.
- [ ] Run `get_nutrition_summary` over a range that contains only water entries (no meals) — confirm water still renders.
- [ ] `delete_water` with the entry's id; confirm removal and updated total.
- [ ] `delete_account`; confirm `water_log` rows are also wiped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)