### PR TITLE
Add per-user timezone support

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ Read the story behind it: [How I Replaced MyFitnessPal and Other Apps with a Sin
 | `delete_water`            | Delete a water log entry by ID                             |
 | `get_trends`              | 7/14/30-day averages, std dev, streaks, day-of-week, best/worst day |
 | `get_meal_patterns`       | Pre-aggregated behavioural patterns (breakfast effect, late dinner, weekend vs weekday, outliers) |
+| `set_timezone`            | Set the user's IANA timezone (e.g. `America/Los_Angeles`)  |
+| `get_timezone`            | Get the user's configured timezone                         |
 | `delete_account`          | Permanently delete account and all associated data         |
 
 ## MCP Resources

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "nutrition-mcp",
-    "version": "1.9.0",
+    "version": "1.10.0",
     "description": "A remote MCP server for personal nutrition tracking. Log meals, track macros, and review nutrition history through Claude.",
     "author": "akutishevsky",
     "license": "MIT",

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
     "name": "io.github.akutishevsky/nutrition-mcp",
     "title": "Nutrition MCP",
     "description": "Personal nutrition tracking — log meals, track macros, and review history through conversation.",
-    "version": "1.9.0",
+    "version": "1.10.0",
     "websiteUrl": "https://nutrition-mcp.com/",
     "repository": {
         "url": "https://github.com/akutishevsky/nutrition-mcp",

--- a/src/insights.ts
+++ b/src/insights.ts
@@ -1,4 +1,5 @@
 import type { Meal, NutritionGoals, WaterEntry } from "./supabase.js";
+import { dateInTz, hourInTz } from "./tz.js";
 
 export interface DailyBucket {
     date: string; // YYYY-MM-DD
@@ -45,12 +46,14 @@ function dateDiffDays(start: string, end: string): number {
 
 const DOW = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
 
-/** Build per-day buckets for every date in [startDate, endDate], including days with no logs. */
+/** Build per-day buckets for every date in [startDate, endDate], including days with no logs.
+ * Dates are interpreted in the given IANA timezone. */
 export function buildDailyBuckets(
     meals: Meal[],
     water: WaterEntry[],
     startDate: string,
     endDate: string,
+    tz: string = "UTC",
 ): DailyBucket[] {
     const buckets = new Map<string, DailyBucket>();
     const totalDays = dateDiffDays(startDate, endDate);
@@ -69,7 +72,7 @@ export function buildDailyBuckets(
     }
 
     for (const m of meals) {
-        const date = m.logged_at.slice(0, 10);
+        const date = dateInTz(m.logged_at, tz);
         const b = buckets.get(date);
         if (!b) continue;
         b.meals.push(m);
@@ -81,7 +84,7 @@ export function buildDailyBuckets(
     }
 
     for (const w of water) {
-        const date = w.logged_at.slice(0, 10);
+        const date = dateInTz(w.logged_at, tz);
         const b = buckets.get(date);
         if (!b) continue;
         b.waterMl += w.amount_ml;
@@ -293,7 +296,10 @@ export function computeTrends(
     return sections.join("\n\n");
 }
 
-export function computeMealPatterns(buckets: DailyBucket[]): string {
+export function computeMealPatterns(
+    buckets: DailyBucket[],
+    tz: string = "UTC",
+): string {
     const logged = buckets.filter(nonEmpty);
     if (logged.length === 0) return "No data in range.";
 
@@ -349,11 +355,11 @@ export function computeMealPatterns(buckets: DailyBucket[]): string {
         );
     }
 
-    // Late-dinner effect (dinner logged after 20:00 local — using UTC hour, fine for v1)
+    // Late-dinner effect (dinner logged at or after 20:00 local time)
     const isLateDinner = (b: DailyBucket) =>
         b.meals.some((m) => {
             if (m.meal_type !== "dinner") return false;
-            const h = new Date(m.logged_at).getUTCHours();
+            const h = hourInTz(m.logged_at, tz);
             return h >= 20 || h < 4;
         });
     const lateDinnerDays = logged.filter(isLateDinner);
@@ -363,7 +369,7 @@ export function computeMealPatterns(buckets: DailyBucket[]): string {
     if (lateDinnerDays.length > 0 && earlyDinnerDays.length > 0) {
         sections.push(
             [
-                "Late-dinner effect (dinner ≥ 20:00 UTC):",
+                "Late-dinner effect (dinner ≥ 20:00 local):",
                 `  Late-dinner days: ${lateDinnerDays.length} — avg ${round(mean(lateDinnerDays.map((b) => b.calories)))} kcal, ${round(mean(lateDinnerDays.map((b) => b.protein_g)))}g P`,
                 `  Early-dinner days: ${earlyDinnerDays.length} — avg ${round(mean(earlyDinnerDays.map((b) => b.calories)))} kcal, ${round(mean(earlyDinnerDays.map((b) => b.protein_g)))}g P`,
             ].join("\n"),

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -15,11 +15,20 @@ import {
     getWaterByDate,
     getWaterInRange,
     deleteWater,
+    getUserTimezone,
+    upsertProfile,
+    getProfile,
     type Meal,
     type NutritionGoals,
     type WaterEntry,
 } from "./supabase.js";
 import { withAnalytics } from "./analytics.js";
+import {
+    todayInTz,
+    validateTz,
+    shiftLocalDate,
+    dateInTz,
+} from "./tz.js";
 import {
     buildDailyBuckets,
     computeTrends,
@@ -47,16 +56,6 @@ setInterval(() => {
         }
     }
 }, CLEANUP_INTERVAL_MS);
-
-function todayDate(): string {
-    return new Date().toISOString().slice(0, 10);
-}
-
-function shiftDate(date: string, days: number): string {
-    const d = new Date(`${date}T00:00:00Z`);
-    d.setUTCDate(d.getUTCDate() + days);
-    return d.toISOString().slice(0, 10);
-}
 
 interface DailyTotals {
     calories: number;
@@ -254,7 +253,12 @@ function registerTools(server: McpServer, userId: string) {
             return withAnalytics(
                 "get_meals_today",
                 async () => {
-                    const meals = await getMealsByDate(userId, todayDate());
+                    const tz = await getUserTimezone(userId);
+                    const meals = await getMealsByDate(
+                        userId,
+                        todayInTz(tz),
+                        tz,
+                    );
                     if (meals.length === 0) {
                         return {
                             content: [
@@ -292,7 +296,8 @@ function registerTools(server: McpServer, userId: string) {
             return withAnalytics(
                 "get_meals_by_date",
                 async () => {
-                    const meals = await getMealsByDate(userId, date);
+                    const tz = await getUserTimezone(userId);
+                    const meals = await getMealsByDate(userId, date, tz);
                     if (meals.length === 0) {
                         return {
                             content: [
@@ -333,10 +338,12 @@ function registerTools(server: McpServer, userId: string) {
             return withAnalytics(
                 "get_meals_by_date_range",
                 async () => {
+                    const tz = await getUserTimezone(userId);
                     const meals = await getMealsInRange(
                         userId,
                         start_date,
                         end_date,
+                        tz,
                     );
                     if (meals.length === 0) {
                         return {
@@ -404,9 +411,10 @@ function registerTools(server: McpServer, userId: string) {
             return withAnalytics(
                 "get_nutrition_summary",
                 async () => {
+                    const tz = await getUserTimezone(userId);
                     const [meals, water, goals] = await Promise.all([
-                        getMealsInRange(userId, start_date, end_date),
-                        getWaterInRange(userId, start_date, end_date),
+                        getMealsInRange(userId, start_date, end_date, tz),
+                        getWaterInRange(userId, start_date, end_date, tz),
                         getNutritionGoals(userId),
                     ]);
                     if (meals.length === 0 && water.length === 0) {
@@ -420,17 +428,17 @@ function registerTools(server: McpServer, userId: string) {
                         };
                     }
 
-                    // Group by date
+                    // Group by date (local to user timezone)
                     const byDate = new Map<string, Meal[]>();
                     for (const meal of meals) {
-                        const date = meal.logged_at.slice(0, 10);
+                        const date = dateInTz(meal.logged_at, tz);
                         const existing = byDate.get(date) ?? [];
                         existing.push(meal);
                         byDate.set(date, existing);
                     }
                     const waterByDate = new Map<string, number>();
                     for (const entry of water) {
-                        const date = entry.logged_at.slice(0, 10);
+                        const date = dateInTz(entry.logged_at, tz);
                         waterByDate.set(
                             date,
                             (waterByDate.get(date) ?? 0) + entry.amount_ml,
@@ -603,10 +611,11 @@ function registerTools(server: McpServer, userId: string) {
             return withAnalytics(
                 "get_goal_progress",
                 async () => {
-                    const targetDate = date ?? todayDate();
+                    const tz = await getUserTimezone(userId);
+                    const targetDate = date ?? todayInTz(tz);
                     const [meals, water, goals] = await Promise.all([
-                        getMealsByDate(userId, targetDate),
-                        getWaterByDate(userId, targetDate),
+                        getMealsByDate(userId, targetDate, tz),
+                        getWaterByDate(userId, targetDate, tz),
                         getNutritionGoals(userId),
                     ]);
                     const totals = sumMeals(meals);
@@ -626,7 +635,7 @@ function registerTools(server: McpServer, userId: string) {
                     };
                 },
                 { userId },
-                { date: date ?? todayDate() },
+                { date: date ?? "today" },
             );
         },
     );
@@ -771,7 +780,12 @@ function registerTools(server: McpServer, userId: string) {
             return withAnalytics(
                 "get_water_today",
                 async () => {
-                    const entries = await getWaterByDate(userId, todayDate());
+                    const tz = await getUserTimezone(userId);
+                    const entries = await getWaterByDate(
+                        userId,
+                        todayInTz(tz),
+                        tz,
+                    );
                     if (entries.length === 0) {
                         return {
                             content: [
@@ -820,7 +834,8 @@ function registerTools(server: McpServer, userId: string) {
             return withAnalytics(
                 "get_water_by_date",
                 async () => {
-                    const entries = await getWaterByDate(userId, date);
+                    const tz = await getUserTimezone(userId);
+                    const entries = await getWaterByDate(userId, date, tz);
                     if (entries.length === 0) {
                         return {
                             content: [
@@ -915,12 +930,13 @@ function registerTools(server: McpServer, userId: string) {
             return withAnalytics(
                 "get_trends",
                 async () => {
-                    const endDate = end_date ?? todayDate();
+                    const tz = await getUserTimezone(userId);
+                    const endDate = end_date ?? todayInTz(tz);
                     const windowDays = days ?? 30;
-                    const startDate = shiftDate(endDate, -(windowDays - 1));
+                    const startDate = shiftLocalDate(endDate, -(windowDays - 1));
                     const [meals, water, goals] = await Promise.all([
-                        getMealsInRange(userId, startDate, endDate),
-                        getWaterInRange(userId, startDate, endDate),
+                        getMealsInRange(userId, startDate, endDate, tz),
+                        getWaterInRange(userId, startDate, endDate, tz),
                         getNutritionGoals(userId),
                     ]);
                     const buckets = buildDailyBuckets(
@@ -928,6 +944,7 @@ function registerTools(server: McpServer, userId: string) {
                         water,
                         startDate,
                         endDate,
+                        tz,
                     );
                     return {
                         content: [
@@ -936,7 +953,7 @@ function registerTools(server: McpServer, userId: string) {
                     };
                 },
                 { userId },
-                { start_date: shiftDate(end_date ?? todayDate(), -((days ?? 30) - 1)), end_date: end_date ?? todayDate() },
+                { days: days ?? 30 },
             );
         },
     );
@@ -971,27 +988,32 @@ function registerTools(server: McpServer, userId: string) {
             return withAnalytics(
                 "get_meal_patterns",
                 async () => {
-                    const endDate = end_date ?? todayDate();
+                    const tz = await getUserTimezone(userId);
+                    const endDate = end_date ?? todayInTz(tz);
                     const windowDays = days ?? 30;
-                    const startDate = shiftDate(endDate, -(windowDays - 1));
+                    const startDate = shiftLocalDate(endDate, -(windowDays - 1));
                     const [meals, water] = await Promise.all([
-                        getMealsInRange(userId, startDate, endDate),
-                        getWaterInRange(userId, startDate, endDate),
+                        getMealsInRange(userId, startDate, endDate, tz),
+                        getWaterInRange(userId, startDate, endDate, tz),
                     ]);
                     const buckets = buildDailyBuckets(
                         meals,
                         water,
                         startDate,
                         endDate,
+                        tz,
                     );
                     return {
                         content: [
-                            { type: "text", text: computeMealPatterns(buckets) },
+                            {
+                                type: "text",
+                                text: computeMealPatterns(buckets, tz),
+                            },
                         ],
                     };
                 },
                 { userId },
-                { start_date: shiftDate(end_date ?? todayDate(), -((days ?? 30) - 1)), end_date: end_date ?? todayDate() },
+                { days: days ?? 30 },
             );
         },
     );
@@ -1006,14 +1028,21 @@ function registerTools(server: McpServer, userId: string) {
             mimeType: "text/plain",
         },
         async (uri) => {
-            const endDate = todayDate();
-            const startDate = shiftDate(endDate, -6);
+            const tz = await getUserTimezone(userId);
+            const endDate = todayInTz(tz);
+            const startDate = shiftLocalDate(endDate, -6);
             const [meals, water, goals] = await Promise.all([
-                getMealsInRange(userId, startDate, endDate),
-                getWaterInRange(userId, startDate, endDate),
+                getMealsInRange(userId, startDate, endDate, tz),
+                getWaterInRange(userId, startDate, endDate, tz),
                 getNutritionGoals(userId),
             ]);
-            const buckets = buildDailyBuckets(meals, water, startDate, endDate);
+            const buckets = buildDailyBuckets(
+                meals,
+                water,
+                startDate,
+                endDate,
+                tz,
+            );
             return {
                 contents: [
                     {
@@ -1023,6 +1052,92 @@ function registerTools(server: McpServer, userId: string) {
                     },
                 ],
             };
+        },
+    );
+
+    server.registerTool(
+        "set_timezone",
+        {
+            title: "Set Timezone",
+            description:
+                "Set the user's IANA timezone (e.g. 'America/Los_Angeles', 'Europe/Berlin', 'Asia/Tokyo'). This controls which calendar day meals and water are grouped into — e.g. a meal logged at 11pm in LA counts on that LA day, not the next UTC day. If the user hasn't set one yet and logs a meal or asks about 'today', offer to set it.",
+            annotations: {
+                readOnlyHint: false,
+                destructiveHint: false,
+                idempotentHint: true,
+                openWorldHint: false,
+            },
+            inputSchema: {
+                timezone: z
+                    .string()
+                    .describe(
+                        "IANA timezone identifier (e.g. 'America/New_York'). Must be a valid tzdata name.",
+                    ),
+            },
+        },
+        async ({ timezone }) => {
+            return withAnalytics(
+                "set_timezone",
+                async () => {
+                    if (!validateTz(timezone)) {
+                        throw new Error(
+                            `Invalid timezone: ${timezone}. Use an IANA identifier like 'America/Los_Angeles' or 'Europe/London'.`,
+                        );
+                    }
+                    const profile = await upsertProfile(userId, timezone);
+                    return {
+                        content: [
+                            {
+                                type: "text",
+                                text: `Timezone set to ${profile.timezone}. Local today is ${todayInTz(profile.timezone)}.`,
+                            },
+                        ],
+                    };
+                },
+                { userId },
+            );
+        },
+    );
+
+    server.registerTool(
+        "get_timezone",
+        {
+            title: "Get Timezone",
+            description:
+                "Get the user's configured IANA timezone. Returns UTC if no profile has been set.",
+            annotations: {
+                readOnlyHint: true,
+                destructiveHint: false,
+                idempotentHint: true,
+                openWorldHint: false,
+            },
+        },
+        async () => {
+            return withAnalytics(
+                "get_timezone",
+                async () => {
+                    const profile = await getProfile(userId);
+                    if (!profile) {
+                        return {
+                            content: [
+                                {
+                                    type: "text",
+                                    text: "No timezone set yet (defaulting to UTC). Call set_timezone to configure one so 'today' matches the user's local calendar day.",
+                                },
+                            ],
+                        };
+                    }
+                    return {
+                        content: [
+                            {
+                                type: "text",
+                                text: `Timezone: ${profile.timezone}. Local today is ${todayInTz(profile.timezone)}.`,
+                            },
+                        ],
+                    };
+                },
+                { userId },
+            );
         },
     );
 
@@ -1122,7 +1237,7 @@ export const handleMcp = async (c: Context) => {
     const server = new McpServer(
         {
             name: "nutrition-mcp",
-            version: "1.9.0",
+            version: "1.10.0",
             icons: [
                 {
                     src: `${baseUrl}/favicon.ico`,

--- a/src/supabase.ts
+++ b/src/supabase.ts
@@ -1,4 +1,5 @@
 import { createClient, type SupabaseClient } from "@supabase/supabase-js";
+import { zonedDayStartUtc, zonedNextDayStartUtc } from "./tz.js";
 
 let supabase: SupabaseClient;
 
@@ -96,16 +97,17 @@ export async function insertMeal(
 export async function getMealsByDate(
     userId: string,
     date: string,
+    tz: string = "UTC",
 ): Promise<Meal[]> {
-    const startOfDay = `${date}T00:00:00`;
-    const endOfDay = `${date}T23:59:59`;
+    const startUtc = zonedDayStartUtc(date, tz);
+    const endUtc = zonedNextDayStartUtc(date, tz);
 
     const { data, error } = await getSupabase()
         .from("meals")
         .select("*")
         .eq("user_id", userId)
-        .gte("logged_at", startOfDay)
-        .lte("logged_at", endOfDay)
+        .gte("logged_at", startUtc.toISOString())
+        .lt("logged_at", endUtc.toISOString())
         .order("logged_at", { ascending: true });
 
     if (error) throw new Error(`Failed to get meals: ${error.message}`);
@@ -116,13 +118,17 @@ export async function getMealsInRange(
     userId: string,
     startDate: string,
     endDate: string,
+    tz: string = "UTC",
 ): Promise<Meal[]> {
+    const startUtc = zonedDayStartUtc(startDate, tz);
+    const endUtc = zonedNextDayStartUtc(endDate, tz);
+
     const { data, error } = await getSupabase()
         .from("meals")
         .select("*")
         .eq("user_id", userId)
-        .gte("logged_at", `${startDate}T00:00:00`)
-        .lte("logged_at", `${endDate}T23:59:59`)
+        .gte("logged_at", startUtc.toISOString())
+        .lt("logged_at", endUtc.toISOString())
         .order("logged_at", { ascending: true });
 
     if (error) throw new Error(`Failed to get meals: ${error.message}`);
@@ -165,6 +171,52 @@ export async function updateMeal(
 
     if (error) throw new Error(`Failed to update meal: ${error.message}`);
     return data as Meal;
+}
+
+// ---------- Profiles ----------
+
+export interface Profile {
+    user_id: string;
+    timezone: string;
+    created_at: string;
+    updated_at: string;
+}
+
+export async function getProfile(userId: string): Promise<Profile | null> {
+    const { data, error } = await getSupabase()
+        .from("profiles")
+        .select("*")
+        .eq("user_id", userId)
+        .maybeSingle();
+
+    if (error) throw new Error(`Failed to get profile: ${error.message}`);
+    return (data as Profile | null) ?? null;
+}
+
+export async function getUserTimezone(userId: string): Promise<string> {
+    const profile = await getProfile(userId);
+    return profile?.timezone ?? "UTC";
+}
+
+export async function upsertProfile(
+    userId: string,
+    timezone: string,
+): Promise<Profile> {
+    const { data, error } = await getSupabase()
+        .from("profiles")
+        .upsert(
+            {
+                user_id: userId,
+                timezone,
+                updated_at: new Date().toISOString(),
+            },
+            { onConflict: "user_id" },
+        )
+        .select()
+        .single();
+
+    if (error) throw new Error(`Failed to save profile: ${error.message}`);
+    return data as Profile;
 }
 
 // ---------- Nutrition goals ----------
@@ -264,13 +316,17 @@ export async function insertWater(
 export async function getWaterByDate(
     userId: string,
     date: string,
+    tz: string = "UTC",
 ): Promise<WaterEntry[]> {
+    const startUtc = zonedDayStartUtc(date, tz);
+    const endUtc = zonedNextDayStartUtc(date, tz);
+
     const { data, error } = await getSupabase()
         .from("water_log")
         .select("*")
         .eq("user_id", userId)
-        .gte("logged_at", `${date}T00:00:00`)
-        .lte("logged_at", `${date}T23:59:59`)
+        .gte("logged_at", startUtc.toISOString())
+        .lt("logged_at", endUtc.toISOString())
         .order("logged_at", { ascending: true });
 
     if (error) throw new Error(`Failed to get water: ${error.message}`);
@@ -281,13 +337,17 @@ export async function getWaterInRange(
     userId: string,
     startDate: string,
     endDate: string,
+    tz: string = "UTC",
 ): Promise<WaterEntry[]> {
+    const startUtc = zonedDayStartUtc(startDate, tz);
+    const endUtc = zonedNextDayStartUtc(endDate, tz);
+
     const { data, error } = await getSupabase()
         .from("water_log")
         .select("*")
         .eq("user_id", userId)
-        .gte("logged_at", `${startDate}T00:00:00`)
-        .lte("logged_at", `${endDate}T23:59:59`)
+        .gte("logged_at", startUtc.toISOString())
+        .lt("logged_at", endUtc.toISOString())
         .order("logged_at", { ascending: true });
 
     if (error) throw new Error(`Failed to get water: ${error.message}`);
@@ -329,6 +389,13 @@ export async function deleteAllUserData(userId: string): Promise<void> {
         .eq("user_id", userId);
     if (goalsErr)
         throw new Error(`Failed to delete goals: ${goalsErr.message}`);
+
+    const { error: profileErr } = await sb
+        .from("profiles")
+        .delete()
+        .eq("user_id", userId);
+    if (profileErr)
+        throw new Error(`Failed to delete profile: ${profileErr.message}`);
 
     const { error: mealsErr } = await sb
         .from("meals")

--- a/src/tz.ts
+++ b/src/tz.ts
@@ -1,0 +1,120 @@
+export function validateTz(tz: string): boolean {
+    try {
+        // The TZ constructor throws RangeError on unknown identifiers.
+        new Intl.DateTimeFormat("en-US", { timeZone: tz });
+        return true;
+    } catch {
+        return false;
+    }
+}
+
+/** Current local date (YYYY-MM-DD) in the given IANA timezone. */
+export function todayInTz(tz: string): string {
+    return new Intl.DateTimeFormat("en-CA", {
+        timeZone: tz,
+        year: "numeric",
+        month: "2-digit",
+        day: "2-digit",
+    }).format(new Date());
+}
+
+/** Local date (YYYY-MM-DD) of an absolute instant in the given IANA timezone. */
+export function dateInTz(instant: Date | string, tz: string): string {
+    const d = instant instanceof Date ? instant : new Date(instant);
+    return new Intl.DateTimeFormat("en-CA", {
+        timeZone: tz,
+        year: "numeric",
+        month: "2-digit",
+        day: "2-digit",
+    }).format(d);
+}
+
+/** Local hour (0-23) of an absolute instant in the given IANA timezone. */
+export function hourInTz(instant: Date | string, tz: string): number {
+    const d = instant instanceof Date ? instant : new Date(instant);
+    const parts = new Intl.DateTimeFormat("en-US", {
+        timeZone: tz,
+        hour12: false,
+        hour: "2-digit",
+    }).formatToParts(d);
+    const h = Number(parts.find((p) => p.type === "hour")!.value);
+    return h === 24 ? 0 : h;
+}
+
+/** Local day-of-week (0=Sun..6=Sat) of an absolute instant in the given IANA timezone. */
+export function dowInTz(instant: Date | string, tz: string): number {
+    const d = instant instanceof Date ? instant : new Date(instant);
+    const name = new Intl.DateTimeFormat("en-US", {
+        timeZone: tz,
+        weekday: "short",
+    }).format(d);
+    const map: Record<string, number> = {
+        Sun: 0,
+        Mon: 1,
+        Tue: 2,
+        Wed: 3,
+        Thu: 4,
+        Fri: 5,
+        Sat: 6,
+    };
+    return map[name] ?? 0;
+}
+
+/**
+ * UTC instant corresponding to 00:00:00 local on `date` in `tz`.
+ * Works correctly across DST transitions.
+ */
+export function zonedDayStartUtc(date: string, tz: string): Date {
+    const [y, m, d] = date.split("-").map(Number);
+    if (y == null || m == null || d == null) {
+        throw new Error(`Invalid date string: ${date}`);
+    }
+    const utcGuess = Date.UTC(y, m - 1, d, 0, 0, 0);
+    const parts = new Intl.DateTimeFormat("en-US", {
+        timeZone: tz,
+        hour12: false,
+        year: "numeric",
+        month: "2-digit",
+        day: "2-digit",
+        hour: "2-digit",
+        minute: "2-digit",
+        second: "2-digit",
+    }).formatToParts(new Date(utcGuess));
+    const getPart = (t: string) =>
+        Number(parts.find((p) => p.type === t)!.value);
+    let lh = getPart("hour");
+    if (lh === 24) lh = 0;
+    const asUtc = Date.UTC(
+        getPart("year"),
+        getPart("month") - 1,
+        getPart("day"),
+        lh,
+        getPart("minute"),
+        getPart("second"),
+    );
+    const offsetMs = asUtc - utcGuess;
+    return new Date(utcGuess - offsetMs);
+}
+
+/** Exclusive upper bound: midnight of the day AFTER `date` in `tz`, as UTC. */
+export function zonedNextDayStartUtc(date: string, tz: string): Date {
+    const [y, m, d] = date.split("-").map(Number);
+    if (y == null || m == null || d == null) {
+        throw new Error(`Invalid date string: ${date}`);
+    }
+    const next = new Date(Date.UTC(y, m - 1, d));
+    next.setUTCDate(next.getUTCDate() + 1);
+    const nextStr = next.toISOString().slice(0, 10);
+    return zonedDayStartUtc(nextStr, tz);
+}
+
+/** Shift a local YYYY-MM-DD date by N days, returning YYYY-MM-DD. No TZ needed. */
+export function shiftLocalDate(date: string, days: number): string {
+    const [y, m, d] = date.split("-").map(Number);
+    if (y == null || m == null || d == null) {
+        throw new Error(`Invalid date string: ${date}`);
+    }
+    const next = new Date(Date.UTC(y, m - 1, d));
+    next.setUTCDate(next.getUTCDate() + days);
+    return next.toISOString().slice(0, 10);
+}

--- a/supabase/migrations/20260417051650_profiles.sql
+++ b/supabase/migrations/20260417051650_profiles.sql
@@ -1,0 +1,15 @@
+-- User profiles. One row per user. Extend as needed; for now stores IANA timezone.
+create table if not exists public.profiles (
+    user_id uuid primary key references auth.users(id) on delete cascade,
+    timezone text not null default 'UTC',
+    created_at timestamptz not null default now(),
+    updated_at timestamptz not null default now()
+);
+
+alter table public.profiles enable row level security;
+
+create policy "Users manage their own profile"
+    on public.profiles
+    for all
+    using (auth.uid() = user_id)
+    with check (auth.uid() = user_id);


### PR DESCRIPTION
## Summary

Dates are now interpreted in the user's configured IANA timezone instead of server UTC. An LA user logging dinner at 11pm now lands on the right local day; `today`, date-range queries, goal progress, trends, and pattern mining all use local day boundaries.

Falls back to UTC when no profile row exists — existing users who never set a TZ see no behavior change until they opt in.

## Changes

- **New `profiles` table** (`user_id`, `timezone`, `created_at`, `updated_at`) with RLS + per-user policy. Migration `supabase/migrations/20260417051650_profiles.sql` already applied to production.
- **New `src/tz.ts`** — Intl-based helpers: `validateTz`, `todayInTz`, `dateInTz`, `hourInTz`, `dowInTz`, `zonedDayStartUtc`, `zonedNextDayStartUtc`, `shiftLocalDate`. Tested across DST transitions (e.g. 2026-03-08 in LA is correctly 23 hours).
- **Two new tools**: `set_timezone` (validates via `Intl.DateTimeFormat`, rejects bogus identifiers) and `get_timezone`.
- **Corrected date boundaries**: replaces naive `\${date}T00:00:00` / `T23:59:59` strings with UTC instants computed from local midnight. Also fixes the ~1-second inclusive-upper-bound gap (→ exclusive `lt` on `startOfNextDay`).
- **Tz threading**: `getMealsByDate`, `getMealsInRange`, `getWaterByDate`, `getWaterInRange`, `buildDailyBuckets`, and `computeMealPatterns` now take a tz parameter. Every tool handler resolves the user's tz first, then passes it down.
- **`delete_account`** wipes the profile row alongside other user data.
- Version → **1.10.0**.

## Test plan

- [ ] Call `set_timezone { timezone: "America/Los_Angeles" }`; confirm the response shows local today.
- [ ] Log a meal via `log_meal` around 11pm LA time; call `get_meals_today` immediately afterwards — the meal must appear on the same local day, not next-day UTC.
- [ ] Call `get_trends` as an LA user and verify trailing-averages / day-of-week calcs group on local day boundaries.
- [ ] Call `set_timezone { timezone: "Invalid/Tz" }`; confirm it errors cleanly with a useful message.
- [ ] Connect without setting TZ; confirm all existing tools still work (UTC fallback) — no regression for users who skip the profile step.
- [ ] On a DST spring-forward day, confirm `get_meals_by_date` for that date returns the full 23-hour range (a meal logged at 03:30 local PDT on the new-DST day should be found).

🤖 Generated with [Claude Code](https://claude.com/claude-code)