### PR TITLE
Rate limiting per user and idempotency keys for log_meal/log_water

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "nutrition-mcp",
-    "version": "1.10.0",
+    "version": "1.11.0",
     "description": "A remote MCP server for personal nutrition tracking. Log meals, track macros, and review nutrition history through Claude.",
     "author": "akutishevsky",
     "license": "MIT",

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
     "name": "io.github.akutishevsky/nutrition-mcp",
     "title": "Nutrition MCP",
     "description": "Personal nutrition tracking — log meals, track macros, and review history through conversation.",
-    "version": "1.10.0",
+    "version": "1.11.0",
     "websiteUrl": "https://nutrition-mcp.com/",
     "repository": {
         "url": "https://github.com/akutishevsky/nutrition-mcp",

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@ import { Hono } from "hono";
 import { cors } from "hono/cors";
 import { bodyLimit } from "hono/body-limit";
 import { createOAuthRouter } from "./oauth.js";
-import { authenticateBearer } from "./middleware.js";
+import { authenticateBearer, rateLimit } from "./middleware.js";
 import { handleMcp } from "./mcp.js";
 
 const app = new Hono();
@@ -103,7 +103,7 @@ app.get("/.well-known/oauth-authorization-server", (c) => {
 app.route("/", createOAuthRouter());
 
 // MCP endpoint (protected)
-app.all("/mcp", authenticateBearer, handleMcp);
+app.all("/mcp", authenticateBearer, rateLimit, handleMcp);
 
 // Landing page
 app.get("/", async (c) => {

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -216,18 +216,32 @@ function registerTools(server: McpServer, userId: string) {
                         "ISO 8601 timestamp (defaults to now). If you don't know the current date or time, ask the user before calling this tool.",
                     ),
                 notes: z.string().optional().describe("Additional notes"),
+                idempotency_key: z
+                    .string()
+                    .min(1)
+                    .max(255)
+                    .optional()
+                    .describe(
+                        "Optional stable key for safe retries. If you (or the user) might replay this same log_meal call after a network hiccup, pass a UUID or other unique string — the server will return the original meal instead of creating a duplicate. Do NOT reuse a key for genuinely different meals.",
+                    ),
             },
         },
         async (args) => {
             return withAnalytics(
                 "log_meal",
                 async () => {
-                    const meal = await insertMeal(userId, args);
+                    const { meal, deduplicated } = await insertMeal(
+                        userId,
+                        args,
+                    );
+                    const header = deduplicated
+                        ? "Meal already logged (idempotent retry):"
+                        : "Meal logged:";
                     return {
                         content: [
                             {
                                 type: "text",
-                                text: `Meal logged:\n${formatMeal(meal)}`,
+                                text: `${header}\n${formatMeal(meal)}`,
                             },
                         ],
                     };
@@ -742,18 +756,32 @@ function registerTools(server: McpServer, userId: string) {
                     .string()
                     .optional()
                     .describe("Optional notes (e.g. 'tea', 'post-workout')."),
+                idempotency_key: z
+                    .string()
+                    .min(1)
+                    .max(255)
+                    .optional()
+                    .describe(
+                        "Optional stable key for safe retries. If the same call might be replayed after a network hiccup, pass a UUID — the server will return the original entry instead of duplicating it. Do NOT reuse a key for genuinely different sips.",
+                    ),
             },
         },
         async (args) => {
             return withAnalytics(
                 "log_water",
                 async () => {
-                    const entry = await insertWater(userId, args);
+                    const { entry, deduplicated } = await insertWater(
+                        userId,
+                        args,
+                    );
+                    const prefix = deduplicated
+                        ? "Already logged (idempotent retry)"
+                        : "Water logged";
                     return {
                         content: [
                             {
                                 type: "text",
-                                text: `Water logged: ${entry.amount_ml} ml at ${entry.logged_at}${entry.notes ? ` (${entry.notes})` : ""}. ID: ${entry.id}`,
+                                text: `${prefix}: ${entry.amount_ml} ml at ${entry.logged_at}${entry.notes ? ` (${entry.notes})` : ""}. ID: ${entry.id}`,
                             },
                         ],
                     };
@@ -1237,7 +1265,7 @@ export const handleMcp = async (c: Context) => {
     const server = new McpServer(
         {
             name: "nutrition-mcp",
-            version: "1.10.0",
+            version: "1.11.0",
             icons: [
                 {
                     src: `${baseUrl}/favicon.ico`,

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,5 +1,6 @@
 import type { Context, Next } from "hono";
 import { getUserIdByToken } from "./supabase.js";
+import { checkRateLimit } from "./rate-limit.js";
 
 function getBaseUrl(c: Context): string {
     const proto = c.req.header("x-forwarded-proto") || "http";
@@ -48,5 +49,27 @@ export const authenticateBearer = async (c: Context, next: Next) => {
 
     c.set("accessToken", token);
     c.set("userId", userId);
+    await next();
+};
+
+export const rateLimit = async (c: Context, next: Next) => {
+    const userId = c.get("userId") as string | undefined;
+    if (!userId) {
+        await next();
+        return;
+    }
+    const result = checkRateLimit(userId);
+    c.header("X-RateLimit-Limit", String(result.limit));
+    c.header("X-RateLimit-Remaining", String(result.remaining));
+    if (!result.allowed) {
+        c.header("Retry-After", String(result.retryAfterSeconds ?? 60));
+        return c.json(
+            {
+                error: "rate_limited",
+                error_description: `Rate limit exceeded (${result.limit} requests per minute). Retry after ${result.retryAfterSeconds}s.`,
+            },
+            429,
+        );
+    }
     await next();
 };

--- a/src/rate-limit.ts
+++ b/src/rate-limit.ts
@@ -1,0 +1,69 @@
+// In-memory sliding-window rate limiter, keyed by user id. Fine for the
+// current single-instance deployment; swap for a shared store if we ever
+// scale horizontally.
+
+const WINDOW_MS = 60_000;
+const LIMIT_PER_WINDOW = 60;
+const SWEEP_INTERVAL_MS = 5 * 60_000;
+
+const buckets = new Map<string, number[]>();
+
+// Periodically drop buckets whose newest entry is older than the window, so
+// a user who stops making requests doesn't keep a slot in the Map forever.
+setInterval(() => {
+    const cutoff = Date.now() - WINDOW_MS;
+    for (const [key, timestamps] of buckets) {
+        const last = timestamps[timestamps.length - 1];
+        if (last == null || last < cutoff) {
+            buckets.delete(key);
+        }
+    }
+}, SWEEP_INTERVAL_MS);
+
+export interface RateLimitResult {
+    allowed: boolean;
+    retryAfterSeconds?: number;
+    remaining: number;
+    limit: number;
+}
+
+export function checkRateLimit(userId: string): RateLimitResult {
+    const now = Date.now();
+    const cutoff = now - WINDOW_MS;
+    const existing = buckets.get(userId) ?? [];
+
+    // Trim in place: keep only entries within the window.
+    let keepFrom = 0;
+    while (keepFrom < existing.length && existing[keepFrom]! <= cutoff) {
+        keepFrom++;
+    }
+    const trimmed = keepFrom === 0 ? existing : existing.slice(keepFrom);
+
+    if (trimmed.length >= LIMIT_PER_WINDOW) {
+        const oldest = trimmed[0]!;
+        const retryAfterSeconds = Math.max(
+            1,
+            Math.ceil((oldest + WINDOW_MS - now) / 1000),
+        );
+        buckets.set(userId, trimmed);
+        return {
+            allowed: false,
+            retryAfterSeconds,
+            remaining: 0,
+            limit: LIMIT_PER_WINDOW,
+        };
+    }
+
+    trimmed.push(now);
+    buckets.set(userId, trimmed);
+    return {
+        allowed: true,
+        remaining: LIMIT_PER_WINDOW - trimmed.length,
+        limit: LIMIT_PER_WINDOW,
+    };
+}
+
+// Exposed for tests.
+export function _resetBuckets(): void {
+    buckets.clear();
+}

--- a/src/supabase.ts
+++ b/src/supabase.ts
@@ -57,6 +57,7 @@ export interface Meal {
     carbs_g: number | null;
     fat_g: number | null;
     notes: string | null;
+    idempotency_key: string | null;
 }
 
 export interface MealInput {
@@ -68,13 +69,33 @@ export interface MealInput {
     fat_g?: number;
     logged_at?: string;
     notes?: string;
+    idempotency_key?: string;
+}
+
+export interface MealInsertResult {
+    meal: Meal;
+    deduplicated: boolean;
 }
 
 export async function insertMeal(
     userId: string,
     input: MealInput,
-): Promise<Meal> {
-    const { data, error } = await getSupabase()
+): Promise<MealInsertResult> {
+    const sb = getSupabase();
+
+    if (input.idempotency_key) {
+        const { data: existing, error: selErr } = await sb
+            .from("meals")
+            .select("*")
+            .eq("user_id", userId)
+            .eq("idempotency_key", input.idempotency_key)
+            .maybeSingle();
+        if (selErr)
+            throw new Error(`Failed to look up meal: ${selErr.message}`);
+        if (existing) return { meal: existing as Meal, deduplicated: true };
+    }
+
+    const { data, error } = await sb
         .from("meals")
         .insert({
             user_id: userId,
@@ -86,12 +107,30 @@ export async function insertMeal(
             fat_g: input.fat_g ?? null,
             logged_at: input.logged_at ?? new Date().toISOString(),
             notes: input.notes ?? null,
+            idempotency_key: input.idempotency_key ?? null,
         })
         .select()
         .single();
 
-    if (error) throw new Error(`Failed to insert meal: ${error.message}`);
-    return data as Meal;
+    if (error) {
+        // Concurrent retry with the same idempotency key — the other request
+        // already inserted the row. Fetch and return it instead of failing.
+        if (input.idempotency_key && error.code === "23505") {
+            const { data: existing, error: raceErr } = await sb
+                .from("meals")
+                .select("*")
+                .eq("user_id", userId)
+                .eq("idempotency_key", input.idempotency_key)
+                .maybeSingle();
+            if (raceErr)
+                throw new Error(
+                    `Failed to resolve idempotent meal: ${raceErr.message}`,
+                );
+            if (existing) return { meal: existing as Meal, deduplicated: true };
+        }
+        throw new Error(`Failed to insert meal: ${error.message}`);
+    }
+    return { meal: data as Meal, deduplicated: false };
 }
 
 export async function getMealsByDate(
@@ -286,31 +325,73 @@ export interface WaterEntry {
     logged_at: string;
     notes: string | null;
     created_at: string;
+    idempotency_key: string | null;
 }
 
 export interface WaterInput {
     amount_ml: number;
     logged_at?: string;
     notes?: string;
+    idempotency_key?: string;
+}
+
+export interface WaterInsertResult {
+    entry: WaterEntry;
+    deduplicated: boolean;
 }
 
 export async function insertWater(
     userId: string,
     input: WaterInput,
-): Promise<WaterEntry> {
-    const { data, error } = await getSupabase()
+): Promise<WaterInsertResult> {
+    const sb = getSupabase();
+
+    if (input.idempotency_key) {
+        const { data: existing, error: selErr } = await sb
+            .from("water_log")
+            .select("*")
+            .eq("user_id", userId)
+            .eq("idempotency_key", input.idempotency_key)
+            .maybeSingle();
+        if (selErr)
+            throw new Error(`Failed to look up water: ${selErr.message}`);
+        if (existing)
+            return { entry: existing as WaterEntry, deduplicated: true };
+    }
+
+    const { data, error } = await sb
         .from("water_log")
         .insert({
             user_id: userId,
             amount_ml: input.amount_ml,
             logged_at: input.logged_at ?? new Date().toISOString(),
             notes: input.notes ?? null,
+            idempotency_key: input.idempotency_key ?? null,
         })
         .select()
         .single();
 
-    if (error) throw new Error(`Failed to insert water: ${error.message}`);
-    return data as WaterEntry;
+    if (error) {
+        if (input.idempotency_key && error.code === "23505") {
+            const { data: existing, error: raceErr } = await sb
+                .from("water_log")
+                .select("*")
+                .eq("user_id", userId)
+                .eq("idempotency_key", input.idempotency_key)
+                .maybeSingle();
+            if (raceErr)
+                throw new Error(
+                    `Failed to resolve idempotent water: ${raceErr.message}`,
+                );
+            if (existing)
+                return {
+                    entry: existing as WaterEntry,
+                    deduplicated: true,
+                };
+        }
+        throw new Error(`Failed to insert water: ${error.message}`);
+    }
+    return { entry: data as WaterEntry, deduplicated: false };
 }
 
 export async function getWaterByDate(

--- a/supabase/migrations/20260417052713_idempotency_keys.sql
+++ b/supabase/migrations/20260417052713_idempotency_keys.sql
@@ -1,0 +1,18 @@
+-- Optional idempotency keys for logging tools. Clients can pass a stable
+-- random string with a retry-safe write; a partial unique index ensures a
+-- second call with the same (user_id, idempotency_key) returns the original
+-- row instead of creating a duplicate. Keys are opt-in; existing rows stay.
+
+alter table public.meals
+    add column if not exists idempotency_key text;
+
+alter table public.water_log
+    add column if not exists idempotency_key text;
+
+create unique index if not exists uniq_meals_user_idem
+    on public.meals (user_id, idempotency_key)
+    where idempotency_key is not null;
+
+create unique index if not exists uniq_water_log_user_idem
+    on public.water_log (user_id, idempotency_key)
+    where idempotency_key is not null;


### PR DESCRIPTION
## Summary

Two hardening features:

- **Per-user rate limiting** on `/mcp`: in-memory sliding-window limiter, 60 req/min per user. Exceeding the window returns HTTP 429 with `Retry-After` and `X-RateLimit-{Limit,Remaining}` headers. Applied as a middleware after `authenticateBearer` so unknown tokens still 401 first.
- **Idempotency keys** on `log_meal` and `log_water`: optional `idempotency_key` parameter; retries with the same `(user_id, idempotency_key)` return the original row instead of creating duplicates. Network retries from flaky connections no longer double-log.

## Changes

- **`supabase/migrations/20260417052713_idempotency_keys.sql`** — adds nullable `idempotency_key` column to both `meals` and `water_log`, plus a partial unique index on `(user_id, idempotency_key) WHERE idempotency_key IS NOT NULL`. Applied to production. Existing rows stay untouched.
- **`src/rate-limit.ts`** — new module. Sliding-window `checkRateLimit(userId)` with a periodic sweep that evicts stale buckets. Bucket keys are trimmed in-place on each check so memory stays bounded.
- **`src/middleware.ts`** — new `rateLimit` middleware that reads `userId` set by `authenticateBearer`, writes response headers, and returns 429 on overflow.
- **`src/index.ts`** — `/mcp` route chains `authenticateBearer → rateLimit → handleMcp`.
- **`src/supabase.ts`** — `insertMeal` / `insertWater` now return `{ meal|entry, deduplicated }`. Handle both pre-insert SELECT (key already present) and concurrent race (catch Postgres `23505`, re-SELECT).
- **`src/mcp.ts`** — `log_meal` and `log_water` accept optional `idempotency_key` (1–255 chars). Tool descriptions instruct the model to generate a stable UUID when a retry might happen, and warn against reusing keys for genuinely different entries.
- Version → **1.11.0**.

## Test plan

- [ ] Fire ~65 `get_meals_today` calls rapidly from one session; confirm the 61st returns 429 with `Retry-After: 60` and the correct `X-RateLimit-Remaining: 0`.
- [ ] From a different user/token, confirm rate-limit state is isolated (not global).
- [ ] Call `log_meal` with `idempotency_key: \"abc-123\"`; confirm it logs normally.
- [ ] Call the same `log_meal` with identical `idempotency_key: \"abc-123\"`; confirm the response says \"already logged\" and the returned meal ID matches the first call.
- [ ] Call `log_meal` with a *different* `idempotency_key` but otherwise identical payload; confirm a new row is created (no false de-dup).
- [ ] Run `supabase db push` on a fresh project; confirm the migration applies cleanly and idempotency works end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)