### PR TITLE
Show daily nutrition progress after logging a meal

### DIFF
--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -237,11 +237,31 @@ function registerTools(server: McpServer, userId: string) {
                     const header = deduplicated
                         ? "Meal already logged (idempotent retry):"
                         : "Meal logged:";
+
+                    const tz = await getUserTimezone(userId);
+                    const mealDate = dateInTz(meal.logged_at, tz);
+                    const [meals, waterEntries, goals] = await Promise.all([
+                        getMealsByDate(userId, mealDate, tz),
+                        getWaterByDate(userId, mealDate, tz),
+                        getNutritionGoals(userId),
+                    ]);
+
+                    const totals = sumMeals(meals);
+                    totals.water_ml = sumWater(waterEntries);
+
+                    let progressSection: string;
+                    if (goals) {
+                        progressSection = `\n\nDaily progress (${mealDate}):\n${formatProgress(totals, goals)}`;
+                    } else {
+                        progressSection =
+                            "\n\nNo nutrition goals set — use the set_nutrition_goals tool to track progress against daily targets.";
+                    }
+
                     return {
                         content: [
                             {
                                 type: "text",
-                                text: `${header}\n${formatMeal(meal)}`,
+                                text: `${header}\n${formatMeal(meal)}${progressSection}`,
                             },
                         ],
                     };


### PR DESCRIPTION
## Summary

- After `log_meal` inserts a meal, the response now includes a daily nutrition progress summary for the meal's date
- Fetches today's meals (including the new one), water entries, and nutrition goals in parallel to minimize latency
- If goals are set: shows per-macro progress (`actual / target`, %, and delta to go/over)
- If no goals are set: prompts the user to use `set_nutrition_goals` to unlock progress tracking

## Test plan

- [ ] Log a meal with goals set — confirm progress lines appear with correct totals and percentages
- [ ] Log a meal with no goals set — confirm the set_nutrition_goals nudge appears
- [ ] Log a meal with `logged_at` set to a past date — confirm progress is shown for that date, not today
- [ ] Idempotent retry (same `idempotency_key`) — confirm progress is still shown correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)