### PR TITLE
Decode literal escape sequences in meal text before persisting

### DIFF
--- a/src/normalize.ts
+++ b/src/normalize.ts
@@ -1,0 +1,36 @@
+// Defensive normalization for text that arrives already-escaped.
+//
+// Some MCP clients/models emit non-Latin scripts (Cyrillic, CJK, emoji, …) as
+// *literal* escape-sequence text — e.g. the six characters `П` instead of
+// the actual `П`. When that literal text survives JSON parsing it gets stored
+// verbatim, so a meal description ends up reading `Domino's Пі...`
+// rather than `Domino's Пі...`. The server can't control client encoding, so
+// we decode any literal `\uXXXX`, `\u{…}`, and `\xXX` sequences before saving.
+
+const UNICODE_CODEPOINT = /\\u\{([0-9a-fA-F]+)\}/g;
+const UNICODE_UNIT = /\\u([0-9a-fA-F]{4})/g;
+const HEX_BYTE = /\\x([0-9a-fA-F]{2})/g;
+
+/**
+ * Decode literal escape sequences in a string into their actual characters.
+ *
+ * Handles `\u{1f355}` (ES6 code point), `\uXXXX` (UTF-16 code unit — including
+ * surrogate pairs, which concatenate correctly), and `\xXX` (single byte).
+ * Strings without a backslash are returned untouched, and sequences that don't
+ * match (e.g. a Windows path like `C:\users`) are left as-is.
+ */
+export function decodeEscapeSequences(input: string): string {
+    if (!input.includes("\\")) return input;
+    return input
+        .replace(UNICODE_CODEPOINT, (match, hex) => {
+            const code = parseInt(hex, 16);
+            if (code > 0x10ffff) return match;
+            return String.fromCodePoint(code);
+        })
+        .replace(UNICODE_UNIT, (_match, hex) =>
+            String.fromCharCode(parseInt(hex, 16)),
+        )
+        .replace(HEX_BYTE, (_match, hex) =>
+            String.fromCharCode(parseInt(hex, 16)),
+        );
+}

--- a/src/supabase.ts
+++ b/src/supabase.ts
@@ -1,5 +1,6 @@
 import { createClient, type SupabaseClient } from "@supabase/supabase-js";
 import { zonedDayStartUtc, zonedNextDayStartUtc } from "./tz.js";
+import { decodeEscapeSequences } from "./normalize.js";
 
 let supabase: SupabaseClient;
 
@@ -112,14 +113,15 @@ export async function insertMeal(
         .from("meals")
         .insert({
             user_id: userId,
-            description: input.description,
+            description: decodeEscapeSequences(input.description),
             meal_type: input.meal_type,
             calories: input.calories ?? null,
             protein_g: input.protein_g ?? null,
             carbs_g: input.carbs_g ?? null,
             fat_g: input.fat_g ?? null,
             logged_at: input.logged_at ?? new Date().toISOString(),
-            notes: input.notes ?? null,
+            notes:
+                input.notes != null ? decodeEscapeSequences(input.notes) : null,
             idempotency_key: input.idempotency_key ?? null,
         })
         .select()
@@ -204,14 +206,18 @@ export async function updateMeal(
 ): Promise<Meal> {
     const update: Record<string, unknown> = {};
     if (fields.description !== undefined)
-        update.description = fields.description;
+        update.description = decodeEscapeSequences(fields.description);
     if (fields.meal_type !== undefined) update.meal_type = fields.meal_type;
     if (fields.calories !== undefined) update.calories = fields.calories;
     if (fields.protein_g !== undefined) update.protein_g = fields.protein_g;
     if (fields.carbs_g !== undefined) update.carbs_g = fields.carbs_g;
     if (fields.fat_g !== undefined) update.fat_g = fields.fat_g;
     if (fields.logged_at !== undefined) update.logged_at = fields.logged_at;
-    if (fields.notes !== undefined) update.notes = fields.notes;
+    if (fields.notes !== undefined)
+        update.notes =
+            fields.notes != null
+                ? decodeEscapeSequences(fields.notes)
+                : fields.notes;
 
     const { data, error } = await getSupabase()
         .from("meals")


### PR DESCRIPTION
## Summary

Resolves #13.

Some MCP clients/models emit non-Latin scripts (Cyrillic, CJK, emoji) as **literal** escape-sequence text rather than actual characters, so meal descriptions were stored as e.g. `Domino's П...` instead of `Domino's Пі...`. The server can't control client encoding, so this adds defensive server-side normalization.

## Changes

- **New `src/normalize.ts`** — `decodeEscapeSequences()` decodes literal `\uXXXX` (UTF-16 code units, incl. surrogate pairs → emoji), `\u{...}` (ES6 code points), and `\xXX` (bytes). Fast-paths strings with no backslash and leaves non-matching sequences (e.g. `C:\users\food`) untouched.
- **`src/supabase.ts`** — normalize `description` and `notes` at the persistence chokepoint in `insertMeal` and `updateMeal`, covering both the `log_meal` and `update_meal` tools without duplicating logic.

## Verification

- `bunx tsc --noEmit` passes
- Prettier formatting applied
- Manual sanity check confirms Cyrillic, `\xXX`, `\u{...}`, and surrogate-pair emoji decode correctly while plain text and Windows-style paths pass through unchanged

## Notes

Scope is input normalization only — no tests or backfill script included (per request).

🤖 Generated with [Claude Code](https://claude.com/claude-code)