### PR TITLE
Always populate idempotency_key on log_meal/log_water

### DIFF
--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -222,7 +222,7 @@ function registerTools(server: McpServer, userId: string) {
                     .max(255)
                     .optional()
                     .describe(
-                        "Optional stable key for safe retries. If you (or the user) might replay this same log_meal call after a network hiccup, pass a UUID or other unique string — the server will return the original meal instead of creating a duplicate. Do NOT reuse a key for genuinely different meals.",
+                        "Optional stable key for safe retries. You normally don't need to set this: when omitted, the server derives a stable key from the meal content (including logged_at), so replaying the identical call returns the original meal instead of duplicating it. Pass a UUID only to force-override that behavior. Do NOT reuse a key for genuinely different meals.",
                     ),
             },
         },
@@ -782,7 +782,7 @@ function registerTools(server: McpServer, userId: string) {
                     .max(255)
                     .optional()
                     .describe(
-                        "Optional stable key for safe retries. If the same call might be replayed after a network hiccup, pass a UUID — the server will return the original entry instead of duplicating it. Do NOT reuse a key for genuinely different sips.",
+                        "Optional stable key for safe retries. You normally don't need to set this: when omitted, the server derives a stable key from the entry content (including logged_at), so replaying the identical call returns the original entry instead of duplicating it. Pass a UUID only to force-override that behavior. Do NOT reuse a key for genuinely different sips.",
                     ),
             },
         },

--- a/src/supabase.ts
+++ b/src/supabase.ts
@@ -58,6 +58,24 @@ export async function signInUser(
     return data.user.id;
 }
 
+// ---------- Idempotency ----------
+
+// Derive a stable idempotency key from the request content so the column is
+// always populated and retries dedupe even when the client omits a key. The
+// resolved logged_at is part of the digest, so two genuinely separate but
+// otherwise-identical entries (logged at different times) get distinct keys and
+// are never wrongly merged. A retry replays the same args — including the same
+// logged_at — and therefore lands on the same key. The "auto:" prefix marks
+// server-derived keys, distinguishing them from client-supplied ones.
+function deriveIdempotencyKey(
+    parts: (string | number | null | undefined)[],
+): string {
+    const digest = new Bun.CryptoHasher("sha256")
+        .update(parts.map((p) => p ?? "").join("\u0000"))
+        .digest("hex");
+    return `auto:${digest}`;
+}
+
 // ---------- Meals ----------
 
 export interface Meal {
@@ -97,17 +115,32 @@ export async function insertMeal(
 ): Promise<MealInsertResult> {
     const sb = getSupabase();
 
-    if (input.idempotency_key) {
-        const { data: existing, error: selErr } = await sb
-            .from("meals")
-            .select("*")
-            .eq("user_id", userId)
-            .eq("idempotency_key", input.idempotency_key)
-            .maybeSingle();
-        if (selErr)
-            throw new Error(`Failed to look up meal: ${selErr.message}`);
-        if (existing) return { meal: existing as Meal, deduplicated: true };
-    }
+    // Resolve logged_at once so the digest and the persisted row agree.
+    const loggedAt = input.logged_at ?? new Date().toISOString();
+    // Always populate the key: use the client's if given, otherwise derive a
+    // stable one from the request content (see deriveIdempotencyKey).
+    const idempotencyKey =
+        input.idempotency_key ??
+        deriveIdempotencyKey([
+            userId,
+            input.description,
+            input.meal_type,
+            input.calories,
+            input.protein_g,
+            input.carbs_g,
+            input.fat_g,
+            input.notes,
+            loggedAt,
+        ]);
+
+    const { data: existing, error: selErr } = await sb
+        .from("meals")
+        .select("*")
+        .eq("user_id", userId)
+        .eq("idempotency_key", idempotencyKey)
+        .maybeSingle();
+    if (selErr) throw new Error(`Failed to look up meal: ${selErr.message}`);
+    if (existing) return { meal: existing as Meal, deduplicated: true };
 
     const { data, error } = await sb
         .from("meals")
@@ -119,10 +152,10 @@ export async function insertMeal(
             protein_g: input.protein_g ?? null,
             carbs_g: input.carbs_g ?? null,
             fat_g: input.fat_g ?? null,
-            logged_at: input.logged_at ?? new Date().toISOString(),
+            logged_at: loggedAt,
             notes:
                 input.notes != null ? decodeEscapeSequences(input.notes) : null,
-            idempotency_key: input.idempotency_key ?? null,
+            idempotency_key: idempotencyKey,
         })
         .select()
         .single();
@@ -130,12 +163,12 @@ export async function insertMeal(
     if (error) {
         // Concurrent retry with the same idempotency key — the other request
         // already inserted the row. Fetch and return it instead of failing.
-        if (input.idempotency_key && error.code === "23505") {
+        if (error.code === "23505") {
             const { data: existing, error: raceErr } = await sb
                 .from("meals")
                 .select("*")
                 .eq("user_id", userId)
-                .eq("idempotency_key", input.idempotency_key)
+                .eq("idempotency_key", idempotencyKey)
                 .maybeSingle();
             if (raceErr)
                 throw new Error(
@@ -365,38 +398,42 @@ export async function insertWater(
 ): Promise<WaterInsertResult> {
     const sb = getSupabase();
 
-    if (input.idempotency_key) {
-        const { data: existing, error: selErr } = await sb
-            .from("water_log")
-            .select("*")
-            .eq("user_id", userId)
-            .eq("idempotency_key", input.idempotency_key)
-            .maybeSingle();
-        if (selErr)
-            throw new Error(`Failed to look up water: ${selErr.message}`);
-        if (existing)
-            return { entry: existing as WaterEntry, deduplicated: true };
-    }
+    // Resolve logged_at once so the digest and the persisted row agree.
+    const loggedAt = input.logged_at ?? new Date().toISOString();
+    // Always populate the key: use the client's if given, otherwise derive a
+    // stable one from the request content (see deriveIdempotencyKey).
+    const idempotencyKey =
+        input.idempotency_key ??
+        deriveIdempotencyKey([userId, input.amount_ml, input.notes, loggedAt]);
+
+    const { data: existing, error: selErr } = await sb
+        .from("water_log")
+        .select("*")
+        .eq("user_id", userId)
+        .eq("idempotency_key", idempotencyKey)
+        .maybeSingle();
+    if (selErr) throw new Error(`Failed to look up water: ${selErr.message}`);
+    if (existing) return { entry: existing as WaterEntry, deduplicated: true };
 
     const { data, error } = await sb
         .from("water_log")
         .insert({
             user_id: userId,
             amount_ml: input.amount_ml,
-            logged_at: input.logged_at ?? new Date().toISOString(),
+            logged_at: loggedAt,
             notes: input.notes ?? null,
-            idempotency_key: input.idempotency_key ?? null,
+            idempotency_key: idempotencyKey,
         })
         .select()
         .single();
 
     if (error) {
-        if (input.idempotency_key && error.code === "23505") {
+        if (error.code === "23505") {
             const { data: existing, error: raceErr } = await sb
                 .from("water_log")
                 .select("*")
                 .eq("user_id", userId)
-                .eq("idempotency_key", input.idempotency_key)
+                .eq("idempotency_key", idempotencyKey)
                 .maybeSingle();
             if (raceErr)
                 throw new Error(


### PR DESCRIPTION
Fixes #15.

## Problem

`idempotency_key` was an optional client-supplied argument. The model passed it only intermittently, so the column ended up populated some of the time and null the rest — the inconsistency reported in the issue.

## Fix

Derive a stable key **server-side** when the client omits one, so the column is always set *and* idempotency actually works regardless of whether the model cooperates.

- New `deriveIdempotencyKey()` hashes the meaningful request fields plus the resolved `logged_at` into an `auto:`-prefixed sha256 (null-byte–separated to avoid field-boundary collisions).
  - **Meals:** `user_id, description, meal_type, calories, protein_g, carbs_g, fat_g, notes, logged_at`
  - **Water:** `user_id, amount_ml, notes, logged_at`
- `logged_at` is resolved **once** up front so the digest and the persisted row agree. Including it means two genuinely separate but otherwise-identical entries get distinct keys (no false merge over time), while a replayed call — same args, same `logged_at` — lands on the same key and dedupes.
- With the key always present, the pre-insert lookup and the `23505` concurrent-race recovery now run unconditionally.
- Client-supplied keys still win (override), so explicit retry keys keep working.
- Tool descriptions updated: clients normally don't need to set the key.

## Notes

- Only affects **new** writes — existing rows with `idempotency_key = null` stay null. A backfill migration can follow separately if desired.
- `bunx tsc --noEmit` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)