### PR TITLE
Add export_meals tool: download all meals as CSV

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,27 +34,28 @@ Read the story behind it: [How I Replaced MyFitnessPal and Other Apps with a Sin
 
 ## MCP Tools
 
-| Tool                      | Description                                                |
-| ------------------------- | ---------------------------------------------------------- |
-| `log_meal`                | Log a meal with description, type, calories, macros, notes |
-| `get_meals_today`         | Get all meals logged today                                 |
-| `get_meals_by_date`       | Get meals for a specific date (YYYY-MM-DD)                 |
-| `get_meals_by_date_range` | Get meals between two dates (inclusive)                    |
-| `get_nutrition_summary`   | Daily nutrition totals + goal progress for a date range    |
-| `update_meal`             | Update any fields of an existing meal                      |
-| `delete_meal`             | Delete a meal by ID                                        |
-| `set_nutrition_goals`     | Set daily calorie, macro, and water targets                |
-| `get_nutrition_goals`     | Get the current daily targets                              |
-| `get_goal_progress`       | Get intake vs. targets for a given day (default: today)    |
-| `log_water`               | Log a hydration entry in milliliters                       |
-| `get_water_today`         | Get today's water intake total and entries                 |
-| `get_water_by_date`       | Get water intake for a specific date                       |
-| `delete_water`            | Delete a water log entry by ID                             |
-| `get_trends`              | 7/14/30-day averages, std dev, streaks, day-of-week, best/worst day |
+| Tool                      | Description                                                                                       |
+| ------------------------- | ------------------------------------------------------------------------------------------------- |
+| `log_meal`                | Log a meal with description, type, calories, macros, notes                                        |
+| `get_meals_today`         | Get all meals logged today                                                                        |
+| `get_meals_by_date`       | Get meals for a specific date (YYYY-MM-DD)                                                        |
+| `get_meals_by_date_range` | Get meals between two dates (inclusive)                                                           |
+| `get_nutrition_summary`   | Daily nutrition totals + goal progress for a date range                                           |
+| `update_meal`             | Update any fields of an existing meal                                                             |
+| `delete_meal`             | Delete a meal by ID                                                                               |
+| `set_nutrition_goals`     | Set daily calorie, macro, and water targets                                                       |
+| `get_nutrition_goals`     | Get the current daily targets                                                                     |
+| `get_goal_progress`       | Get intake vs. targets for a given day (default: today)                                           |
+| `log_water`               | Log a hydration entry in milliliters                                                              |
+| `get_water_today`         | Get today's water intake total and entries                                                        |
+| `get_water_by_date`       | Get water intake for a specific date                                                              |
+| `delete_water`            | Delete a water log entry by ID                                                                    |
+| `get_trends`              | 7/14/30-day averages, std dev, streaks, day-of-week, best/worst day                               |
 | `get_meal_patterns`       | Pre-aggregated behavioural patterns (breakfast effect, late dinner, weekend vs weekday, outliers) |
-| `set_timezone`            | Set the user's IANA timezone (e.g. `America/Los_Angeles`)  |
-| `get_timezone`            | Get the user's configured timezone                         |
-| `delete_account`          | Permanently delete account and all associated data         |
+| `export_meals`            | Export all meals as a CSV and return a 60-minute download link                                    |
+| `set_timezone`            | Set the user's IANA timezone (e.g. `America/Los_Angeles`)                                         |
+| `get_timezone`            | Get the user's configured timezone                                                                |
+| `delete_account`          | Permanently delete account and all associated data                                                |
 
 ## MCP Resources
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "nutrition-mcp",
-    "version": "1.11.1",
+    "version": "1.12.0",
     "description": "A remote MCP server for personal nutrition tracking. Log meals, track macros, and review nutrition history through Claude.",
     "author": "akutishevsky",
     "license": "MIT",

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
     "name": "io.github.akutishevsky/nutrition-mcp",
     "title": "Nutrition MCP",
     "description": "Personal nutrition tracking — log meals, track macros, and review history through conversation.",
-    "version": "1.11.1",
+    "version": "1.12.0",
     "websiteUrl": "https://nutrition-mcp.com/",
     "repository": {
         "url": "https://github.com/akutishevsky/nutrition-mcp",

--- a/src/export.test.ts
+++ b/src/export.test.ts
@@ -1,0 +1,75 @@
+import { test, expect } from "bun:test";
+import { buildMealsCsv } from "./export.js";
+import type { Meal } from "./supabase.js";
+
+function meal(overrides: Partial<Meal> = {}): Meal {
+    return {
+        id: "11111111-1111-1111-1111-111111111111",
+        user_id: "user-1",
+        logged_at: "2026-06-20T14:30:00.000Z",
+        meal_type: "lunch",
+        description: "Grilled chicken",
+        calories: 500,
+        protein_g: 40,
+        carbs_g: 10,
+        fat_g: 20,
+        notes: null,
+        idempotency_key: null,
+        ...overrides,
+    };
+}
+
+const HEADER =
+    "id,logged_at,timezone,meal_type,description,calories,protein_g,carbs_g,fat_g,notes";
+
+test("emits a header even with no meals", () => {
+    expect(buildMealsCsv([], "UTC")).toBe(HEADER);
+});
+
+test("renders timestamps in UTC when tz is UTC", () => {
+    const csv = buildMealsCsv([meal()], "UTC");
+    const [, row] = csv.split("\n");
+    expect(row).toContain("2026-06-20 14:30:00");
+    expect(row).toContain("UTC");
+});
+
+test("renders timestamps in the user's timezone when set", () => {
+    // 14:30 UTC is 16:30 in Berlin (CEST, summer).
+    const csv = buildMealsCsv([meal()], "Europe/Berlin");
+    const [, row] = csv.split("\n");
+    expect(row).toContain("2026-06-20 16:30:00");
+    expect(row).toContain("Europe/Berlin");
+});
+
+test("leaves null macros and notes as empty fields", () => {
+    const csv = buildMealsCsv(
+        [
+            meal({
+                calories: null,
+                protein_g: null,
+                carbs_g: null,
+                fat_g: null,
+                notes: null,
+            }),
+        ],
+        "UTC",
+    );
+    const row = csv.split("\n")[1]!;
+    // trailing empty notes + empty macros
+    expect(row.endsWith(",,,,,")).toBe(true);
+});
+
+test("quotes and escapes fields containing commas, quotes, and newlines", () => {
+    const csv = buildMealsCsv(
+        [
+            meal({
+                description: 'Salad, "the big one"',
+                notes: "line1\nline2",
+            }),
+        ],
+        "UTC",
+    );
+    const row = csv.split("\n").slice(1).join("\n");
+    expect(row).toContain('"Salad, ""the big one"""');
+    expect(row).toContain('"line1\nline2"');
+});

--- a/src/export.ts
+++ b/src/export.ts
@@ -1,0 +1,166 @@
+import {
+    getSupabase,
+    getAllMeals,
+    getUserTimezone,
+    type Meal,
+} from "./supabase.js";
+import { formatLocalDateTime } from "./tz.js";
+
+const EXPORT_BUCKET = "exports";
+// Signed link lifetime. The cleanup sweep ages files out on the same horizon.
+const EXPORT_TTL_SECONDS = 60 * 60; // 60 minutes
+const SWEEP_INTERVAL_MS = 10 * 60 * 1000; // every 10 minutes
+
+const CSV_COLUMNS = [
+    "id",
+    "logged_at",
+    "timezone",
+    "meal_type",
+    "description",
+    "calories",
+    "protein_g",
+    "carbs_g",
+    "fat_g",
+    "notes",
+] as const;
+
+/** Quote a CSV field only when it contains a delimiter, quote, or newline. */
+function csvEscape(value: string | number | null | undefined): string {
+    if (value == null) return "";
+    const str = String(value);
+    if (/[",\r\n]/.test(str)) {
+        return `"${str.replace(/"/g, '""')}"`;
+    }
+    return str;
+}
+
+/**
+ * Build a CSV from meals. `logged_at` is rendered in `tz` (the user's timezone,
+ * or "UTC" when none is set), and the `timezone` column records which zone the
+ * timestamp is expressed in so the file is self-describing.
+ */
+export function buildMealsCsv(meals: Meal[], tz: string): string {
+    const rows = [CSV_COLUMNS.join(",")];
+    for (const m of meals) {
+        rows.push(
+            [
+                csvEscape(m.id),
+                csvEscape(formatLocalDateTime(m.logged_at, tz)),
+                csvEscape(tz),
+                csvEscape(m.meal_type),
+                csvEscape(m.description),
+                csvEscape(m.calories),
+                csvEscape(m.protein_g),
+                csvEscape(m.carbs_g),
+                csvEscape(m.fat_g),
+                csvEscape(m.notes),
+            ].join(","),
+        );
+    }
+    return rows.join("\n");
+}
+
+export interface MealsExportResult {
+    count: number;
+    url?: string;
+}
+
+/**
+ * Generate a CSV of all the user's meals, upload it to the private `exports`
+ * bucket under a fixed per-user path (so each export overwrites the previous
+ * one), and return a signed download link valid for EXPORT_TTL_SECONDS.
+ */
+export async function exportMeals(userId: string): Promise<MealsExportResult> {
+    const meals = await getAllMeals(userId);
+    if (meals.length === 0) return { count: 0 };
+
+    const tz = await getUserTimezone(userId);
+    const csv = buildMealsCsv(meals, tz);
+    const path = `${userId}/meals.csv`;
+
+    const storage = getSupabase().storage.from(EXPORT_BUCKET);
+
+    const { error: uploadErr } = await storage.upload(path, csv, {
+        contentType: "text/csv",
+        upsert: true,
+    });
+    if (uploadErr)
+        throw new Error(`Failed to upload export: ${uploadErr.message}`);
+
+    const { data, error: signErr } = await storage.createSignedUrl(
+        path,
+        EXPORT_TTL_SECONDS,
+    );
+    if (signErr || !data)
+        throw new Error(
+            `Failed to create download link: ${signErr?.message ?? "unknown error"}`,
+        );
+
+    return { count: meals.length, url: data.signedUrl };
+}
+
+/**
+ * Delete export files older than the link TTL. Runs as a background sweep so no
+ * export file outlives its signed URL by more than one sweep interval, even
+ * across server restarts and for users who never export again.
+ */
+export async function sweepStaleExports(): Promise<void> {
+    const storage = getSupabase().storage.from(EXPORT_BUCKET);
+    const cutoff = Date.now() - EXPORT_TTL_SECONDS * 1000;
+
+    // Files live under per-user folders, so list the root to enumerate folders,
+    // then list each folder to reach the files (with their timestamps).
+    const { data: folders, error: rootErr } = await storage.list("", {
+        limit: 1000,
+    });
+    if (rootErr) {
+        console.warn("Export sweep: failed to list bucket:", rootErr.message);
+        return;
+    }
+    if (!folders) return;
+
+    const stalePaths: string[] = [];
+    for (const folder of folders) {
+        const { data: files, error: listErr } = await storage.list(
+            folder.name,
+            { limit: 1000 },
+        );
+        if (listErr) {
+            console.warn(
+                `Export sweep: failed to list ${folder.name}:`,
+                listErr.message,
+            );
+            continue;
+        }
+        for (const file of files ?? []) {
+            const ts = file.updated_at ?? file.created_at;
+            if (ts && new Date(ts).getTime() < cutoff) {
+                stalePaths.push(`${folder.name}/${file.name}`);
+            }
+        }
+    }
+
+    if (stalePaths.length === 0) return;
+    const { error: removeErr } = await storage.remove(stalePaths);
+    if (removeErr) {
+        console.warn(
+            "Export sweep: failed to remove files:",
+            removeErr.message,
+        );
+        return;
+    }
+    console.log(`Export sweep: removed ${stalePaths.length} stale file(s).`);
+}
+
+let sweepRunning = false;
+
+/** Start the periodic export-cleanup sweep. Call once at server startup. */
+export function startExportCleanup(): void {
+    setInterval(() => {
+        if (sweepRunning) return;
+        sweepRunning = true;
+        sweepStaleExports().finally(() => {
+            sweepRunning = false;
+        });
+    }, SWEEP_INTERVAL_MS);
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ import { bodyLimit } from "hono/body-limit";
 import { createOAuthRouter } from "./oauth.js";
 import { authenticateBearer, rateLimit } from "./middleware.js";
 import { handleMcp } from "./mcp.js";
+import { startExportCleanup } from "./export.js";
 
 const app = new Hono();
 
@@ -145,6 +146,9 @@ app.onError((_err, c) => {
 const port = parseInt(process.env.PORT || "8080");
 
 console.log(`Nutrition MCP server listening on 0.0.0.0:${port}`);
+
+// Periodically delete expired meal-export files from the storage bucket.
+startExportCleanup();
 
 export default {
     port,

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -1328,7 +1328,7 @@ export const handleMcp = async (c: Context) => {
     const server = new McpServer(
         {
             name: "nutrition-mcp",
-            version: "1.11.1",
+            version: "1.12.0",
             icons: [
                 {
                     src: `${baseUrl}/favicon.ico`,

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -35,6 +35,7 @@ import {
     computeMealPatterns,
     computeWeeklyDigest,
 } from "./insights.js";
+import { exportMeals } from "./export.js";
 
 const SESSION_TTL_MS = 60 * 60 * 1000; // 60 minutes
 const CLEANUP_INTERVAL_MS = 5 * 60 * 1000; // every 5 minutes
@@ -1062,6 +1063,48 @@ function registerTools(server: McpServer, userId: string) {
                 },
                 { userId },
                 { days: days ?? 30 },
+            );
+        },
+    );
+
+    server.registerTool(
+        "export_meals",
+        {
+            title: "Export Meals",
+            description:
+                "Export all of the user's logged meals as a CSV file and return a private, time-limited download link (valid 60 minutes). Timestamps use the user's timezone if set, otherwise UTC. Share the link with the user so they can download their data.",
+            annotations: {
+                readOnlyHint: false,
+                destructiveHint: false,
+                idempotentHint: false,
+                openWorldHint: false,
+            },
+        },
+        async () => {
+            return withAnalytics(
+                "export_meals",
+                async () => {
+                    const { count, url } = await exportMeals(userId);
+                    if (count === 0) {
+                        return {
+                            content: [
+                                {
+                                    type: "text",
+                                    text: "No meals to export yet.",
+                                },
+                            ],
+                        };
+                    }
+                    return {
+                        content: [
+                            {
+                                type: "text",
+                                text: `Exported ${count} meal${count === 1 ? "" : "s"} to CSV.\nDownload (link valid for 60 minutes): ${url}`,
+                            },
+                        ],
+                    };
+                },
+                { userId },
             );
         },
     );

--- a/src/supabase.ts
+++ b/src/supabase.ts
@@ -222,6 +222,17 @@ export async function getMealsInRange(
     return (data as Meal[]) ?? [];
 }
 
+export async function getAllMeals(userId: string): Promise<Meal[]> {
+    const { data, error } = await getSupabase()
+        .from("meals")
+        .select("*")
+        .eq("user_id", userId)
+        .order("logged_at", { ascending: true });
+
+    if (error) throw new Error(`Failed to get meals: ${error.message}`);
+    return (data as Meal[]) ?? [];
+}
+
 export async function deleteMeal(userId: string, id: string): Promise<void> {
     const { error } = await getSupabase()
         .from("meals")
@@ -533,6 +544,14 @@ export async function deleteAllUserData(userId: string): Promise<void> {
         .eq("user_id", userId);
     if (profileErr)
         throw new Error(`Failed to delete profile: ${profileErr.message}`);
+
+    // Remove any meal-export file from the "exports" storage bucket. Missing
+    // paths are not an error, so this is a no-op for users who never exported.
+    const { error: exportErr } = await sb.storage
+        .from("exports")
+        .remove([`${userId}/meals.csv`]);
+    if (exportErr)
+        throw new Error(`Failed to delete exports: ${exportErr.message}`);
 
     const { error: mealsErr } = await sb
         .from("meals")

--- a/src/tz.ts
+++ b/src/tz.ts
@@ -29,6 +29,30 @@ export function dateInTz(instant: Date | string, tz: string): string {
     }).format(d);
 }
 
+/**
+ * Local wall-clock timestamp ("YYYY-MM-DD HH:mm:ss") of an absolute instant in
+ * the given IANA timezone. With tz="UTC" this yields the raw UTC time.
+ */
+export function formatLocalDateTime(
+    instant: Date | string,
+    tz: string,
+): string {
+    const d = instant instanceof Date ? instant : new Date(instant);
+    const parts = new Intl.DateTimeFormat("en-US", {
+        timeZone: tz,
+        hour12: false,
+        year: "numeric",
+        month: "2-digit",
+        day: "2-digit",
+        hour: "2-digit",
+        minute: "2-digit",
+        second: "2-digit",
+    }).formatToParts(d);
+    const get = (t: string) => parts.find((p) => p.type === t)!.value;
+    const hour = get("hour") === "24" ? "00" : get("hour");
+    return `${get("year")}-${get("month")}-${get("day")} ${hour}:${get("minute")}:${get("second")}`;
+}
+
 /** Local hour (0-23) of an absolute instant in the given IANA timezone. */
 export function hourInTz(instant: Date | string, tz: string): number {
     const d = instant instanceof Date ? instant : new Date(instant);

--- a/supabase/migrations/20260620120000_exports_bucket.sql
+++ b/supabase/migrations/20260620120000_exports_bucket.sql
@@ -1,0 +1,6 @@
+-- Private storage bucket for on-demand meal CSV exports. Files are written and
+-- read only via the service-role client, and handed to users as short-lived
+-- signed URLs, so no public access or extra storage policies are required.
+insert into storage.buckets (id, name, public)
+values ('exports', 'exports', false)
+on conflict (id) do nothing;


### PR DESCRIPTION
## Summary

Adds an `export_meals` MCP tool that exports all of a user's logged meals as a CSV and returns a **private, time-limited download link** (valid 60 minutes), backed by a private Supabase Storage bucket.

### How it works
- The tool builds a CSV in memory, uploads it to a private `exports` bucket under a fixed per-user path (`{userId}/meals.csv`, `upsert`), and returns a 60-minute **signed URL**.
- Fixed per-user path means a user never accumulates more than one export file.
- Timestamps are rendered in the user's timezone if set, otherwise raw UTC, with a self-describing `timezone` column.

### Cleanup (no data left behind)
- A background sweep runs every 10 min and deletes any export file older than the 60-minute link TTL — survives restarts and covers users who never export again.
- `delete_account` now also removes the user's export file immediately, so account deletion leaves nothing in storage.

### Notes
- No new public HTTP route and no extra rate-limiting needed — the download link points at Supabase, not the server; the tool call itself is already rate-limited.
- New private `exports` bucket migration (`20260620120000_exports_bucket.sql`) — **already applied** to the linked project (bucket confirmed `public=false`).
- Version bumped to **1.12.0** (`package.json`, `server.json`, `src/mcp.ts`).

## Test plan
- [x] `bunx tsc --noEmit` clean
- [x] `bun test` green (CSV builder: header, UTC vs. timezone rendering, null fields, comma/quote/newline escaping)
- [ ] End-to-end: call `export_meals`, open the link, confirm CSV downloads with timezone-correct timestamps

🤖 Generated with [Claude Code](https://claude.com/claude-code)