### PR TITLE
Add dark theme and theme switcher to landing page

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -155,6 +155,17 @@
         </script>
     </head>
     <body class="landing">
+        <script>
+            // Apply a saved theme override before paint to avoid a flash.
+            // With no saved preference, the OS setting drives it via CSS.
+            (function () {
+                try {
+                    var t = localStorage.getItem("theme");
+                    if (t === "dark" || t === "light")
+                        document.body.setAttribute("data-theme", t);
+                } catch (e) {}
+            })();
+        </script>
         <header class="nav">
             <a class="nav-brand" href="/">
                 <span class="nav-mark" aria-hidden="true"
@@ -162,19 +173,30 @@
                 ></span>
                 <span>Nutrition&nbsp;MCP</span>
             </a>
-            <nav class="nav-links">
-                <a href="#how">How it works</a>
-                <a href="#install">Install</a>
-                <a href="#try">Examples</a>
-                <a href="#support">Support</a>
-                <a href="#faq">FAQ</a>
-                <a
-                    href="https://github.com/akutishevsky/nutrition-mcp"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    >GitHub</a
+            <div class="nav-right">
+                <nav class="nav-links">
+                    <a href="#how">How it works</a>
+                    <a href="#install">Install</a>
+                    <a href="#try">Examples</a>
+                    <a href="#support">Support</a>
+                    <a href="#faq">FAQ</a>
+                    <a
+                        href="https://github.com/akutishevsky/nutrition-mcp"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        >GitHub</a
+                    >
+                </nav>
+                <button
+                    class="theme-toggle"
+                    type="button"
+                    id="theme-toggle"
+                    aria-label="Toggle dark mode"
+                    title="Toggle dark mode"
                 >
-            </nav>
+                    <i class="fa-solid fa-moon" aria-hidden="true"></i>
+                </button>
+            </div>
         </header>
 
         <main>
@@ -1636,6 +1658,56 @@
 
         <script>
             (function () {
+                // ---------- theme toggle (dark / light, default = system) ----------
+                var themeBtn = document.getElementById("theme-toggle");
+                if (themeBtn) {
+                    var themeIcon = themeBtn.querySelector("i");
+                    var metaTheme = document.querySelector(
+                        'meta[name="theme-color"]',
+                    );
+                    var darkQuery = window.matchMedia(
+                        "(prefers-color-scheme: dark)",
+                    );
+                    // The effective theme = explicit override, else the OS setting.
+                    function effectiveTheme() {
+                        var override = document.body.getAttribute("data-theme");
+                        if (override) return override;
+                        return darkQuery.matches ? "dark" : "light";
+                    }
+                    // Reflect the current theme in the icon, label, and meta color.
+                    function syncUI() {
+                        var dark = effectiveTheme() === "dark";
+                        if (themeIcon)
+                            themeIcon.className = dark
+                                ? "fa-solid fa-sun"
+                                : "fa-solid fa-moon";
+                        var label = dark
+                            ? "Switch to light mode"
+                            : "Switch to dark mode";
+                        themeBtn.setAttribute("aria-label", label);
+                        themeBtn.setAttribute("title", label);
+                        if (metaTheme)
+                            metaTheme.setAttribute(
+                                "content",
+                                dark ? "#161617" : "#4a7c59",
+                            );
+                    }
+                    themeBtn.addEventListener("click", function () {
+                        var next =
+                            effectiveTheme() === "dark" ? "light" : "dark";
+                        document.body.setAttribute("data-theme", next);
+                        try {
+                            localStorage.setItem("theme", next);
+                        } catch (e) {}
+                        syncUI();
+                    });
+                    // While following the OS (no override), track system changes.
+                    darkQuery.addEventListener("change", function () {
+                        if (!document.body.getAttribute("data-theme")) syncUI();
+                    });
+                    syncUI();
+                }
+
                 // ---------- copy-URL buttons in the install guides ----------
                 document.querySelectorAll(".copy-mini").forEach(function (btn) {
                     var icon = btn.querySelector("i");

--- a/public/styles.css
+++ b/public/styles.css
@@ -1623,3 +1623,129 @@ html:has(body.landing) {
         animation: none;
     }
 }
+
+/* =====================================================================
+   Dark theme (landing page only)
+   - Follows the OS setting automatically via prefers-color-scheme.
+   - The nav theme toggle sets data-theme="dark"|"light" on <body> to
+     override the OS preference; that override always wins.
+   The dark palette is defined once below and applied through both the
+   media query (auto) and the explicit override selector.
+   ===================================================================== */
+
+/* Theme toggle button */
+.nav-right {
+    display: flex;
+    align-items: center;
+    gap: clamp(0.9rem, 2vw, 1.6rem);
+}
+.theme-toggle {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 34px;
+    height: 34px;
+    flex-shrink: 0;
+    border-radius: 50%;
+    border: 1px solid var(--line);
+    background: var(--bg-alt);
+    color: var(--ink-2);
+    font-size: 0.9rem;
+    cursor: pointer;
+    transition:
+        background 0.2s ease,
+        color 0.2s ease,
+        border-color 0.2s ease,
+        transform 0.15s ease;
+}
+.theme-toggle:hover {
+    color: var(--ink);
+    border-color: var(--ink-2);
+    transform: translateY(-1px);
+}
+
+/* Shared dark palette — applied for OS-dark (no manual override) ... */
+@media (prefers-color-scheme: dark) {
+    body.landing:not([data-theme="light"]) {
+        --bg: #161617;
+        --bg-alt: #1f1f21;
+        --ink: #f5f5f7;
+        --ink-2: #a1a1a6;
+        --ink-3: #6e6e73;
+        --line: #38383b;
+        --accent: #5e9b6f;
+        --accent-hover: #74b487;
+        color-scheme: dark;
+    }
+}
+/* ... and for the explicit "dark" override from the toggle. */
+body.landing[data-theme="dark"] {
+    --bg: #161617;
+    --bg-alt: #1f1f21;
+    --ink: #f5f5f7;
+    --ink-2: #a1a1a6;
+    --ink-3: #6e6e73;
+    --line: #38383b;
+    --accent: #5e9b6f;
+    --accent-hover: #74b487;
+    color-scheme: dark;
+}
+
+/* Patches for hardcoded light colors when dark is active (either path). */
+@media (prefers-color-scheme: dark) {
+    body.landing:not([data-theme="light"]) .card {
+        border-color: rgba(255, 255, 255, 0.08);
+        box-shadow: 0 4px 24px rgba(0, 0, 0, 0.4);
+    }
+    body.landing:not([data-theme="light"]) .btn-secondary:hover {
+        background: #2a2a2c;
+    }
+    body.landing:not([data-theme="light"])
+        #itab-claude:checked
+        ~ .seg
+        .seg-claude,
+    body.landing:not([data-theme="light"])
+        #itab-chatgpt:checked
+        ~ .seg
+        .seg-chatgpt,
+    body.landing:not([data-theme="light"])
+        #itab-other:checked
+        ~ .seg
+        .seg-other {
+        background: #2f2f31;
+        box-shadow: 0 1px 4px rgba(0, 0, 0, 0.4);
+    }
+    body.landing:not([data-theme="light"]) .prog-bar {
+        background: rgba(255, 255, 255, 0.12);
+    }
+    body.landing:not([data-theme="light"]) .step3-icon,
+    body.landing:not([data-theme="light"]) .cw-avatar {
+        background: rgba(94, 155, 111, 0.18);
+    }
+    body.landing:not([data-theme="light"]) .section.cta {
+        background: #234a33;
+    }
+}
+body.landing[data-theme="dark"] .card {
+    border-color: rgba(255, 255, 255, 0.08);
+    box-shadow: 0 4px 24px rgba(0, 0, 0, 0.4);
+}
+body.landing[data-theme="dark"] .btn-secondary:hover {
+    background: #2a2a2c;
+}
+body.landing[data-theme="dark"] #itab-claude:checked ~ .seg .seg-claude,
+body.landing[data-theme="dark"] #itab-chatgpt:checked ~ .seg .seg-chatgpt,
+body.landing[data-theme="dark"] #itab-other:checked ~ .seg .seg-other {
+    background: #2f2f31;
+    box-shadow: 0 1px 4px rgba(0, 0, 0, 0.4);
+}
+body.landing[data-theme="dark"] .prog-bar {
+    background: rgba(255, 255, 255, 0.12);
+}
+body.landing[data-theme="dark"] .step3-icon,
+body.landing[data-theme="dark"] .cw-avatar {
+    background: rgba(94, 155, 111, 0.18);
+}
+body.landing[data-theme="dark"] .section.cta {
+    background: #234a33;
+}


### PR DESCRIPTION
## Summary
Adds a dark theme to the landing page (`public/index.html`) that follows the system color scheme automatically, plus a nav toggle to override it manually.

- **Automatic:** dark palette applied via `prefers-color-scheme: dark` — no JS needed.
- **Switcher:** a sun/moon toggle in the nav flips light/dark, persists the choice to `localStorage` (override always wins over the OS), and updates the icon, ARIA label, and `theme-color` meta. While no override is set, it live-tracks OS changes.
- **No flash:** an early inline script applies a saved preference before paint.
- **Scoped:** everything lives under `body.landing`, so the login and privacy pages are untouched.
- Patched the handful of hardcoded light colors variables didn't cover (cards, active install tab, progress-bar track, step/avatar icon tints) and toned down the closing CTA band so it isn't glaring in dark mode.

## Testing
Verified in-browser via DevTools color-scheme emulation:
- OS dark → page renders dark automatically.
- Toggle forces light even while OS is dark (and vice versa), persisting across reloads.
- Closing CTA band confirmed as a deep muted green rather than full-brightness accent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)