### PR TITLE
feat: barcode lookup via Open Food Facts (v1.13.0)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,4 +8,8 @@ OAUTH_CLIENT_SECRET=your-client-secret
 GOOGLE_CLIENT_ID=your-google-client-id
 GOOGLE_CLIENT_SECRET=your-google-client-secret
 
+# Open Food Facts requires a User-Agent identifying your app + contact, in the
+# form "AppName (email)". Used for barcode lookups (lookup_barcode tool).
+OFF_USER_AGENT=nutrition-mcp (you@example.com)
+
 PORT=8080

--- a/README.md
+++ b/README.md
@@ -34,28 +34,29 @@ Read the story behind it: [How I Replaced MyFitnessPal and Other Apps with a Sin
 
 ## MCP Tools
 
-| Tool                      | Description                                                                                       |
-| ------------------------- | ------------------------------------------------------------------------------------------------- |
-| `log_meal`                | Log a meal with description, type, calories, macros, notes                                        |
-| `get_meals_today`         | Get all meals logged today                                                                        |
-| `get_meals_by_date`       | Get meals for a specific date (YYYY-MM-DD)                                                        |
-| `get_meals_by_date_range` | Get meals between two dates (inclusive)                                                           |
-| `get_nutrition_summary`   | Daily nutrition totals + goal progress for a date range                                           |
-| `update_meal`             | Update any fields of an existing meal                                                             |
-| `delete_meal`             | Delete a meal by ID                                                                               |
-| `set_nutrition_goals`     | Set daily calorie, macro, and water targets                                                       |
-| `get_nutrition_goals`     | Get the current daily targets                                                                     |
-| `get_goal_progress`       | Get intake vs. targets for a given day (default: today)                                           |
-| `log_water`               | Log a hydration entry in milliliters                                                              |
-| `get_water_today`         | Get today's water intake total and entries                                                        |
-| `get_water_by_date`       | Get water intake for a specific date                                                              |
-| `delete_water`            | Delete a water log entry by ID                                                                    |
-| `get_trends`              | 7/14/30-day averages, std dev, streaks, day-of-week, best/worst day                               |
-| `get_meal_patterns`       | Pre-aggregated behavioural patterns (breakfast effect, late dinner, weekend vs weekday, outliers) |
-| `export_meals`            | Export all meals as a CSV and return a 60-minute download link                                    |
-| `set_timezone`            | Set the user's IANA timezone (e.g. `America/Los_Angeles`)                                         |
-| `get_timezone`            | Get the user's configured timezone                                                                |
-| `delete_account`          | Permanently delete account and all associated data                                                |
+| Tool                      | Description                                                                                              |
+| ------------------------- | -------------------------------------------------------------------------------------------------------- |
+| `log_meal`                | Log a meal with description, type, calories, macros, notes                                               |
+| `lookup_barcode`          | Look up a packaged product's verified macros by barcode via Open Food Facts (read from a photo or typed) |
+| `get_meals_today`         | Get all meals logged today                                                                               |
+| `get_meals_by_date`       | Get meals for a specific date (YYYY-MM-DD)                                                               |
+| `get_meals_by_date_range` | Get meals between two dates (inclusive)                                                                  |
+| `get_nutrition_summary`   | Daily nutrition totals + goal progress for a date range                                                  |
+| `update_meal`             | Update any fields of an existing meal                                                                    |
+| `delete_meal`             | Delete a meal by ID                                                                                      |
+| `set_nutrition_goals`     | Set daily calorie, macro, and water targets                                                              |
+| `get_nutrition_goals`     | Get the current daily targets                                                                            |
+| `get_goal_progress`       | Get intake vs. targets for a given day (default: today)                                                  |
+| `log_water`               | Log a hydration entry in milliliters                                                                     |
+| `get_water_today`         | Get today's water intake total and entries                                                               |
+| `get_water_by_date`       | Get water intake for a specific date                                                                     |
+| `delete_water`            | Delete a water log entry by ID                                                                           |
+| `get_trends`              | 7/14/30-day averages, std dev, streaks, day-of-week, best/worst day                                      |
+| `get_meal_patterns`       | Pre-aggregated behavioural patterns (breakfast effect, late dinner, weekend vs weekday, outliers)        |
+| `export_meals`            | Export all meals as a CSV and return a 60-minute download link                                           |
+| `set_timezone`            | Set the user's IANA timezone (e.g. `America/Los_Angeles`)                                                |
+| `get_timezone`            | Get the user's configured timezone                                                                       |
+| `delete_account`          | Permanently delete account and all associated data                                                       |
 
 ## MCP Resources
 
@@ -82,15 +83,16 @@ Read the story behind it: [How I Replaced MyFitnessPal and Other Apps with a Sin
 
 ### 2. Environment variables
 
-| Variable               | Description                                                   |
-| ---------------------- | ------------------------------------------------------------- |
-| `SUPABASE_URL`         | Your Supabase project URL                                     |
-| `SUPABASE_SECRET_KEY`  | Supabase service role key (bypasses RLS)                      |
-| `OAUTH_CLIENT_ID`      | Random string for OAuth client identification                 |
-| `OAUTH_CLIENT_SECRET`  | Random string for OAuth client authentication                 |
-| `GOOGLE_CLIENT_ID`     | _(optional)_ Google OAuth client ID for "Sign in with Google" |
-| `GOOGLE_CLIENT_SECRET` | _(optional)_ Google OAuth client secret                       |
-| `PORT`                 | Server port (default: `8080`)                                 |
+| Variable               | Description                                                                   |
+| ---------------------- | ----------------------------------------------------------------------------- |
+| `SUPABASE_URL`         | Your Supabase project URL                                                     |
+| `SUPABASE_SECRET_KEY`  | Supabase service role key (bypasses RLS)                                      |
+| `OAUTH_CLIENT_ID`      | Random string for OAuth client identification                                 |
+| `OAUTH_CLIENT_SECRET`  | Random string for OAuth client authentication                                 |
+| `GOOGLE_CLIENT_ID`     | _(optional)_ Google OAuth client ID for "Sign in with Google"                 |
+| `GOOGLE_CLIENT_SECRET` | _(optional)_ Google OAuth client secret                                       |
+| `OFF_USER_AGENT`       | Open Food Facts User-Agent for barcode lookups, in the form `AppName (email)` |
+| `PORT`                 | Server port (default: `8080`)                                                 |
 
 > **Note:** The HTML files in `public/` include a Google Analytics tag (`G-1K4HRB2R8X`). If you're self-hosting, remove or replace the gtag snippet in `public/index.html`, `public/login.html`, and `public/privacy.html`.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "nutrition-mcp",
-    "version": "1.12.0",
+    "version": "1.13.0",
     "description": "A remote MCP server for personal nutrition tracking. Log meals, track macros, and review nutrition history through Claude.",
     "author": "akutishevsky",
     "license": "MIT",

--- a/public/index.html
+++ b/public/index.html
@@ -1310,6 +1310,17 @@
                         </article>
                         <article class="card feature">
                             <span class="feature-icon" aria-hidden="true"
+                                ><i class="fa-solid fa-barcode"></i
+                            ></span>
+                            <h3>Scan a barcode</h3>
+                            <p>
+                                Snap or type a product barcode and pull verified
+                                macros from Open Food Facts, scaled to how much
+                                you ate.
+                            </p>
+                        </article>
+                        <article class="card feature">
+                            <span class="feature-icon" aria-hidden="true"
                                 ><i class="fa-solid fa-bullseye"></i
                             ></span>
                             <h3>Goals &amp; progress</h3>
@@ -1369,8 +1380,8 @@
                         <p class="eyebrow">Why Nutrition MCP</p>
                         <h2 class="section-title">Talking beats tapping.</h2>
                         <p class="section-sub">
-                            No barcode scanning, no database digging, no
-                            separate app to open.
+                            Snap a barcode or just say what you ate — no
+                            database digging, no separate app to open.
                         </p>
                     </div>
                     <div class="compare">
@@ -1384,8 +1395,8 @@
                                     database for every item
                                 </li>
                                 <li>
-                                    <i class="fa-solid fa-xmark"></i> Scan
-                                    barcodes and fix wrong entries
+                                    <i class="fa-solid fa-xmark"></i> Fix wrong
+                                    database entries by hand
                                 </li>
                                 <li>
                                     <i class="fa-solid fa-xmark"></i> Yet

--- a/public/index.html
+++ b/public/index.html
@@ -8,11 +8,11 @@
         <meta charset="utf-8" />
         <meta
             name="description"
-            content="Track meals, macros, and nutrition history through conversation with Claude or ChatGPT. Free MCP server for AI-powered food logging, calorie counting, and diet tracking."
+            content="Track meals, macros, and nutrition history through conversation with Claude or ChatGPT. Free MCP server for AI-powered food logging, barcode scanning, calorie counting, and diet tracking."
         />
         <meta
             name="keywords"
-            content="nutrition tracker, meal tracker, MCP server, Claude AI, ChatGPT, calorie counter, macro tracker, food logging, diet tracker, AI nutrition, Model Context Protocol"
+            content="nutrition tracker, meal tracker, MCP server, Claude AI, ChatGPT, calorie counter, macro tracker, barcode scanner, food logging, diet tracker, AI nutrition, Model Context Protocol"
         />
         <meta
             property="og:title"
@@ -20,7 +20,7 @@
         />
         <meta
             property="og:description"
-            content="Track meals, macros, and nutrition history through conversation with Claude or ChatGPT. Free MCP server for AI-powered food logging."
+            content="Track meals, macros, and nutrition history through conversation with Claude or ChatGPT. Free MCP server for AI-powered food logging and barcode scanning."
         />
         <meta property="og:type" content="website" />
         <meta property="og:url" content="https://nutrition-mcp.com" />
@@ -35,7 +35,7 @@
         />
         <meta
             name="twitter:description"
-            content="Track meals, macros, and nutrition history through conversation with Claude or ChatGPT. Free MCP server for AI-powered food logging."
+            content="Track meals, macros, and nutrition history through conversation with Claude or ChatGPT. Free MCP server for AI-powered food logging and barcode scanning."
         />
         <link rel="canonical" href="https://nutrition-mcp.com" />
         <link rel="icon" href="/favicon.ico" />
@@ -46,7 +46,7 @@
                 "@context": "https://schema.org",
                 "@type": "SoftwareApplication",
                 "name": "Nutrition MCP",
-                "description": "Track meals, macros, and nutrition history through conversation with Claude or ChatGPT. Free MCP server for AI-powered food logging, calorie counting, and diet tracking.",
+                "description": "Track meals, macros, and nutrition history through conversation with Claude or ChatGPT. Free MCP server for AI-powered food logging, barcode scanning, calorie counting, and diet tracking.",
                 "url": "https://nutrition-mcp.com",
                 "applicationCategory": "HealthApplication",
                 "operatingSystem": "Any",
@@ -115,7 +115,7 @@
                         "name": "What can I track?",
                         "acceptedAnswer": {
                             "@type": "Answer",
-                            "text": "Calories, protein, carbohydrates, fat, and water for every entry. You can view daily summaries, query meals by date range, update or delete past entries, set goals, and monitor trends over time."
+                            "text": "Calories, protein, carbohydrates, fat, and water for every entry — described in plain language or pulled from a product barcode via Open Food Facts. You can view daily summaries, query meals by date range, update or delete past entries, set goals, and monitor trends over time."
                         }
                     },
                     {
@@ -1617,10 +1617,11 @@
                             <summary>What can I track?</summary>
                             <p>
                                 Calories, protein, carbohydrates, fat, and water
-                                for every entry. You can view daily summaries,
-                                query meals by date range, update or delete past
-                                entries, set goals, and monitor trends over
-                                time.
+                                for every entry — described in plain language or
+                                pulled from a product barcode via Open Food
+                                Facts. You can view daily summaries, query meals
+                                by date range, update or delete past entries,
+                                set goals, and monitor trends over time.
                             </p>
                         </details>
                         <details>

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
     "name": "io.github.akutishevsky/nutrition-mcp",
     "title": "Nutrition MCP",
     "description": "Personal nutrition tracking — log meals, track macros, and review history through conversation.",
-    "version": "1.12.0",
+    "version": "1.13.0",
     "websiteUrl": "https://nutrition-mcp.com/",
     "repository": {
         "url": "https://github.com/akutishevsky/nutrition-mcp",

--- a/src/foods.test.ts
+++ b/src/foods.test.ts
@@ -1,0 +1,193 @@
+import { test, expect, mock, beforeEach, afterEach, describe } from "bun:test";
+import {
+    normalizeBarcode,
+    fetchProductFromOFF,
+    formatFoodResult,
+    type FoodResult,
+} from "./foods.js";
+
+const realFetch = globalThis.fetch;
+
+function mockFetch(impl: (url: string) => Response | Promise<Response>) {
+    globalThis.fetch = mock((input: string | URL | Request) =>
+        Promise.resolve(impl(String(input))),
+    ) as unknown as typeof fetch;
+}
+
+function jsonResponse(body: unknown, status = 200): Response {
+    return new Response(JSON.stringify(body), {
+        status,
+        headers: { "Content-Type": "application/json" },
+    });
+}
+
+beforeEach(() => {
+    process.env.OFF_USER_AGENT = "nutrition-mcp-test (test@example.com)";
+});
+
+afterEach(() => {
+    globalThis.fetch = realFetch;
+});
+
+describe("normalizeBarcode", () => {
+    test("keeps valid digit strings", () => {
+        expect(normalizeBarcode("737628064502")).toBe("737628064502");
+    });
+
+    test("strips spaces and separators", () => {
+        expect(normalizeBarcode(" 7376-2806 4502 ")).toBe("737628064502");
+    });
+
+    test("accepts EAN-8 lower bound and GTIN-14 upper bound", () => {
+        expect(normalizeBarcode("12345678")).toBe("12345678");
+        expect(normalizeBarcode("12345678901234")).toBe("12345678901234");
+    });
+
+    test("rejects too-short and too-long inputs", () => {
+        expect(normalizeBarcode("1234567")).toBeNull();
+        expect(normalizeBarcode("123456789012345")).toBeNull();
+    });
+
+    test("rejects non-numeric junk", () => {
+        expect(normalizeBarcode("abc")).toBeNull();
+        expect(normalizeBarcode("")).toBeNull();
+    });
+});
+
+describe("fetchProductFromOFF", () => {
+    test("normalizes per-serving values when a serving size is present", async () => {
+        mockFetch(() =>
+            jsonResponse({
+                status: 1,
+                product: {
+                    product_name: "Coconut Milk",
+                    brands: "Thai Kitchen, Simply Asia",
+                    serving_size: "80 ml",
+                    nutriments: {
+                        "energy-kcal_serving": 120,
+                        "energy-kcal_100g": 150,
+                        proteins_serving: 1.2,
+                        carbohydrates_serving: 2,
+                        fat_serving: 12.34,
+                    },
+                },
+            }),
+        );
+
+        const food = await fetchProductFromOFF("737628064502");
+        expect(food).not.toBeNull();
+        expect(food!.name).toBe("Coconut Milk");
+        expect(food!.brand).toBe("Thai Kitchen"); // first brand only
+        expect(food!.serving).toBe("80 ml");
+        expect(food!.calories).toBe(120);
+        expect(food!.protein_g).toBe(1.2);
+        expect(food!.carbs_g).toBe(2);
+        expect(food!.fat_g).toBe(12.3); // rounded to one decimal
+        expect(food!.source).toBe("off:737628064502");
+    });
+
+    test("falls back to per-100g basis when no serving energy", async () => {
+        mockFetch(() =>
+            jsonResponse({
+                status: 1,
+                product: {
+                    product_name: "Olive Oil",
+                    nutriments: {
+                        "energy-kcal_100g": 884,
+                        proteins_100g: 0,
+                        carbohydrates_100g: 0,
+                        fat_100g: 100,
+                    },
+                },
+            }),
+        );
+
+        const food = await fetchProductFromOFF("123456789");
+        expect(food!.serving).toBe("100 g");
+        expect(food!.calories).toBe(884);
+        expect(food!.fat_g).toBe(100);
+        expect(food!.brand).toBeNull();
+    });
+
+    test("returns null when OFF reports status 0", async () => {
+        mockFetch(() => jsonResponse({ status: 0 }));
+        expect(await fetchProductFromOFF("000000000000")).toBeNull();
+    });
+
+    test("returns null on HTTP 404", async () => {
+        mockFetch(() => jsonResponse({ status: 0 }, 404));
+        expect(await fetchProductFromOFF("000000000000")).toBeNull();
+    });
+
+    test("throws on unexpected HTTP error so the caller can degrade", async () => {
+        mockFetch(() => jsonResponse({}, 500));
+        expect(fetchProductFromOFF("737628064502")).rejects.toThrow(
+            /Open Food Facts request failed: 500/,
+        );
+    });
+
+    test("missing nutriments yield null macros but keep the name", async () => {
+        mockFetch(() =>
+            jsonResponse({
+                status: 1,
+                product: { product_name: "Mystery Snack" },
+            }),
+        );
+        const food = await fetchProductFromOFF("737628064502");
+        expect(food!.name).toBe("Mystery Snack");
+        expect(food!.calories).toBeNull();
+        expect(food!.protein_g).toBeNull();
+    });
+
+    test("sends the configured User-Agent and throws when it is unset", async () => {
+        const seen: { ua: string | null } = { ua: null };
+        globalThis.fetch = mock(
+            (_input: string | URL | Request, init?: RequestInit) => {
+                seen.ua = new Headers(init?.headers).get("User-Agent");
+                return Promise.resolve(jsonResponse({ status: 0 }));
+            },
+        ) as unknown as typeof fetch;
+
+        await fetchProductFromOFF("737628064502");
+        expect(seen.ua).toBe("nutrition-mcp-test (test@example.com)");
+
+        delete process.env.OFF_USER_AGENT;
+        expect(fetchProductFromOFF("737628064502")).rejects.toThrow(
+            /OFF_USER_AGENT is not configured/,
+        );
+    });
+});
+
+describe("formatFoodResult", () => {
+    const base: FoodResult = {
+        name: "Coconut Milk",
+        brand: "Thai Kitchen",
+        serving: "80 ml",
+        calories: 120,
+        protein_g: 1.2,
+        carbs_g: 2,
+        fat_g: 12,
+        source: "off:737628064502",
+        source_name: "openfoodfacts",
+        barcode: "737628064502",
+    };
+
+    test("includes brand, serving, macros, and source", () => {
+        const text = formatFoodResult(base);
+        expect(text).toContain("Coconut Milk (Thai Kitchen)");
+        expect(text).toContain("Serving: 80 ml");
+        expect(text).toContain("120 kcal");
+        expect(text).toContain("barcode 737628064502");
+    });
+
+    test("renders n/a for missing macros and omits empty brand", () => {
+        const text = formatFoodResult({
+            ...base,
+            brand: null,
+            calories: null,
+        });
+        expect(text).toContain("Coconut Milk\n");
+        expect(text).not.toContain("()");
+        expect(text).toContain("Calories: n/a");
+    });
+});

--- a/src/foods.ts
+++ b/src/foods.ts
@@ -1,0 +1,199 @@
+// Food database lookups. Phase 1: barcode resolution via the Open Food Facts
+// REST JSON API (https://world.openfoodfacts.org/api/v2/product/{barcode}.json).
+//
+// The model stays the parser/orchestrator; this module's only job is to return
+// canonical macros for an already-identified product. Every path degrades
+// gracefully — a miss or an outage returns null/throws and the caller falls
+// back to LLM estimation, so the lookup is always additive, never a hard
+// dependency for logging a meal.
+
+import { getSupabase } from "./supabase.js";
+
+const OFF_PRODUCT_URL = "https://world.openfoodfacts.org/api/v2/product";
+const REQUEST_TIMEOUT_MS = 8_000;
+
+const SOURCE_OFF = "openfoodfacts" as const;
+// Open Food Facts is community-edited and changes often; refresh weekly.
+const OFF_TTL_MS = 7 * 24 * 60 * 60 * 1000;
+
+// Open Food Facts requires a custom User-Agent in the form
+// `AppName (ContactEmail)` so they can reach the operator about traffic. It is
+// configuration, not a constant: every deployment (including self-hosters) must
+// set OFF_USER_AGENT to its own app + contact.
+function offUserAgent(): string {
+    const ua = process.env.OFF_USER_AGENT;
+    if (!ua) {
+        throw new Error(
+            "OFF_USER_AGENT is not configured — Open Food Facts requires a " +
+                "User-Agent like 'nutrition-mcp (you@example.com)'",
+        );
+    }
+    return ua;
+}
+
+export interface FoodResult {
+    name: string;
+    brand: string | null;
+    serving: string | null; // human label for the basis of the macros below
+    calories: number | null;
+    protein_g: number | null;
+    carbs_g: number | null;
+    fat_g: number | null;
+    source: string; // stable id, e.g. "off:737628064502"
+    source_name: typeof SOURCE_OFF;
+    barcode: string;
+}
+
+// Strip everything but digits and validate length. Real barcodes (EAN-8/13,
+// UPC-A/E, GTIN-14) are 8–14 digits. Returns the cleaned digits or null.
+export function normalizeBarcode(raw: string): string | null {
+    const digits = (raw ?? "").replace(/\D/g, "");
+    if (digits.length < 8 || digits.length > 14) return null;
+    return digits;
+}
+
+// Coerce an Open Food Facts nutriment to a finite number rounded to one
+// decimal, or null when absent/unparseable.
+function num(value: unknown): number | null {
+    const n = typeof value === "string" ? parseFloat(value) : (value as number);
+    if (typeof n !== "number" || !Number.isFinite(n)) return null;
+    return Math.round(n * 10) / 10;
+}
+
+interface OFFProduct {
+    product_name?: string;
+    brands?: string;
+    serving_size?: string;
+    nutriments?: Record<string, unknown>;
+}
+
+// Normalize an OFF product into our shape. Prefer per-serving values when the
+// product declares a serving size and a per-serving energy; otherwise fall back
+// to the always-present per-100g basis and label it as such.
+function normalizeOFFProduct(product: OFFProduct, barcode: string): FoodResult {
+    const n = product.nutriments ?? {};
+    const hasServing =
+        !!product.serving_size && n["energy-kcal_serving"] != null;
+    const pick = (servingKey: string, hundredKey: string) =>
+        hasServing ? num(n[servingKey]) : num(n[hundredKey]);
+
+    return {
+        name: product.product_name?.trim() || `Product ${barcode}`,
+        brand: product.brands?.split(",")[0]?.trim() || null,
+        serving: hasServing ? product.serving_size!.trim() : "100 g",
+        calories: pick("energy-kcal_serving", "energy-kcal_100g"),
+        protein_g: pick("proteins_serving", "proteins_100g"),
+        carbs_g: pick("carbohydrates_serving", "carbohydrates_100g"),
+        fat_g: pick("fat_serving", "fat_100g"),
+        source: `off:${barcode}`,
+        source_name: SOURCE_OFF,
+        barcode,
+    };
+}
+
+// Pure HTTP fetch + normalize, no caching. Returns null when the product is not
+// in Open Food Facts; throws on network failure or an unexpected HTTP status so
+// the caller can distinguish "not found" from "couldn't reach the service".
+export async function fetchProductFromOFF(
+    barcode: string,
+): Promise<FoodResult | null> {
+    const url = `${OFF_PRODUCT_URL}/${barcode}.json`;
+    const res = await fetch(url, {
+        headers: { "User-Agent": offUserAgent(), Accept: "application/json" },
+        signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+    });
+
+    if (res.status === 404) return null;
+    if (!res.ok) {
+        throw new Error(`Open Food Facts request failed: ${res.status}`);
+    }
+
+    const body = (await res.json()) as {
+        status?: number;
+        product?: OFFProduct;
+    };
+    if (!body || body.status === 0 || !body.product) return null;
+    return normalizeOFFProduct(body.product, barcode);
+}
+
+// ---------- Cache ----------
+// All cache access is best-effort: any failure (missing table, no Supabase
+// config, transient error) is swallowed and treated as a miss so a cache
+// problem can never break a lookup.
+
+async function getCachedFood(
+    source: string,
+    sourceId: string,
+    ttlMs: number,
+): Promise<FoodResult | null> {
+    try {
+        const { data, error } = await getSupabase()
+            .from("food_cache")
+            .select("payload, fetched_at")
+            .eq("source", source)
+            .eq("source_id", sourceId)
+            .maybeSingle();
+        if (error || !data) return null;
+        const ageMs = Date.now() - new Date(data.fetched_at).getTime();
+        if (ageMs > ttlMs) return null;
+        return data.payload as FoodResult;
+    } catch {
+        return null;
+    }
+}
+
+async function putCachedFood(
+    source: string,
+    sourceId: string,
+    payload: FoodResult,
+): Promise<void> {
+    try {
+        await getSupabase().from("food_cache").upsert(
+            {
+                source,
+                source_id: sourceId,
+                payload,
+                fetched_at: new Date().toISOString(),
+            },
+            { onConflict: "source,source_id" },
+        );
+    } catch {
+        // best-effort; ignore
+    }
+}
+
+// Cache-first barcode lookup. `barcode` must already be normalized
+// (see normalizeBarcode). Returns null when the product is unknown; throws only
+// when Open Food Facts itself is unreachable.
+export async function lookupBarcode(
+    barcode: string,
+): Promise<FoodResult | null> {
+    const cached = await getCachedFood(SOURCE_OFF, barcode, OFF_TTL_MS);
+    if (cached) return cached;
+
+    const food = await fetchProductFromOFF(barcode);
+    if (food) await putCachedFood(SOURCE_OFF, barcode, food);
+    return food;
+}
+
+// ---------- Formatting ----------
+
+function macro(value: number | null, unit: string): string {
+    return value == null ? "n/a" : `${value} ${unit}`;
+}
+
+export function formatFoodResult(food: FoodResult): string {
+    const title = food.brand ? `${food.name} (${food.brand})` : food.name;
+    return [
+        title,
+        `Serving: ${food.serving ?? "n/a"}`,
+        `Calories: ${macro(food.calories, "kcal")} · Protein: ${macro(
+            food.protein_g,
+            "g",
+        )} · Carbs: ${macro(food.carbs_g, "g")} · Fat: ${macro(
+            food.fat_g,
+            "g",
+        )}`,
+        `Source: Open Food Facts (barcode ${food.barcode})`,
+    ].join("\n");
+}

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -23,12 +23,7 @@ import {
     type WaterEntry,
 } from "./supabase.js";
 import { withAnalytics } from "./analytics.js";
-import {
-    todayInTz,
-    validateTz,
-    shiftLocalDate,
-    dateInTz,
-} from "./tz.js";
+import { todayInTz, validateTz, shiftLocalDate, dateInTz } from "./tz.js";
 import {
     buildDailyBuckets,
     computeTrends,
@@ -36,6 +31,7 @@ import {
     computeWeeklyDigest,
 } from "./insights.js";
 import { exportMeals } from "./export.js";
+import { normalizeBarcode, lookupBarcode, formatFoodResult } from "./foods.js";
 
 const SESSION_TTL_MS = 60 * 60 * 1000; // 60 minutes
 const CLEANUP_INTERVAL_MS = 5 * 60 * 1000; // every 5 minutes
@@ -183,7 +179,7 @@ function registerTools(server: McpServer, userId: string) {
         {
             title: "Log Meal",
             description:
-                "Log a meal entry with nutritional information. If the user doesn't specify the quantity or portion size, ask how much they ate before estimating calories and macros. Use web search to look up accurate nutritional data when appropriate, especially for branded products or barcode scans.",
+                "Log a meal entry with nutritional information. If the user doesn't specify the quantity or portion size, ask how much they ate before estimating calories and macros. When the user gives a barcode — typed, or read from a photo of the package (transcribe the digits printed under the barcode) — call lookup_barcode first to get verified nutritional data, then scale it to the amount eaten. Fall back to web search or estimation only when no product is found. Use web search for branded products when no barcode is available.",
             annotations: {
                 readOnlyHint: false,
                 destructiveHint: false,
@@ -268,6 +264,81 @@ function registerTools(server: McpServer, userId: string) {
                     };
                 },
                 { userId },
+            );
+        },
+    );
+
+    server.registerTool(
+        "lookup_barcode",
+        {
+            title: "Look Up Barcode",
+            description:
+                "Look up a packaged product's verified nutrition by barcode via Open Food Facts. Pass the barcode digits (EAN/UPC, 8–14 digits). The user can type them, or you can read them from a photo of the package — transcribe the human-readable digits printed beneath the barcode. Returns the product name, serving, and macros, which you can then pass to log_meal scaled to the amount eaten. If no product is found, fall back to web search or estimation.",
+            annotations: {
+                readOnlyHint: true,
+                destructiveHint: false,
+                idempotentHint: true,
+                openWorldHint: true,
+            },
+            inputSchema: {
+                barcode: z
+                    .string()
+                    .describe(
+                        "Product barcode digits (EAN-8/13, UPC-A/E, or GTIN-14). Spaces and separators are ignored.",
+                    ),
+            },
+        },
+        async ({ barcode }) => {
+            return withAnalytics(
+                "lookup_barcode",
+                async () => {
+                    const normalized = normalizeBarcode(barcode);
+                    if (!normalized) {
+                        return {
+                            content: [
+                                {
+                                    type: "text",
+                                    text: `"${barcode}" is not a valid barcode (expected 8–14 digits). Double-check the number, or estimate the macros from the product description instead.`,
+                                },
+                            ],
+                        };
+                    }
+
+                    let food;
+                    try {
+                        food = await lookupBarcode(normalized);
+                    } catch (err) {
+                        const msg =
+                            err instanceof Error ? err.message : String(err);
+                        return {
+                            content: [
+                                {
+                                    type: "text",
+                                    text: `Couldn't reach Open Food Facts right now (${msg}). Estimate the macros from the product description or ask the user, then log the meal.`,
+                                },
+                            ],
+                        };
+                    }
+
+                    if (!food) {
+                        return {
+                            content: [
+                                {
+                                    type: "text",
+                                    text: `No product found in Open Food Facts for barcode ${normalized}. Ask the user what the product is, or estimate the macros, then log the meal.`,
+                                },
+                            ],
+                        };
+                    }
+
+                    return {
+                        content: [
+                            { type: "text", text: formatFoodResult(food) },
+                        ],
+                    };
+                },
+                { userId },
+                { barcode },
             );
         },
     );
@@ -868,7 +939,8 @@ function registerTools(server: McpServer, userId: string) {
         "get_water_by_date",
         {
             title: "Get Water by Date",
-            description: "Get water intake total and entries for a specific date.",
+            description:
+                "Get water intake total and entries for a specific date.",
             annotations: {
                 readOnlyHint: true,
                 destructiveHint: false,
@@ -982,7 +1054,10 @@ function registerTools(server: McpServer, userId: string) {
                     const tz = await getUserTimezone(userId);
                     const endDate = end_date ?? todayInTz(tz);
                     const windowDays = days ?? 30;
-                    const startDate = shiftLocalDate(endDate, -(windowDays - 1));
+                    const startDate = shiftLocalDate(
+                        endDate,
+                        -(windowDays - 1),
+                    );
                     const [meals, water, goals] = await Promise.all([
                         getMealsInRange(userId, startDate, endDate, tz),
                         getWaterInRange(userId, startDate, endDate, tz),
@@ -997,7 +1072,10 @@ function registerTools(server: McpServer, userId: string) {
                     );
                     return {
                         content: [
-                            { type: "text", text: computeTrends(buckets, goals) },
+                            {
+                                type: "text",
+                                text: computeTrends(buckets, goals),
+                            },
                         ],
                     };
                 },
@@ -1026,7 +1104,9 @@ function registerTools(server: McpServer, userId: string) {
                     .min(7)
                     .max(365)
                     .optional()
-                    .describe("Window size in days (default 30, min 7, max 365)."),
+                    .describe(
+                        "Window size in days (default 30, min 7, max 365).",
+                    ),
                 end_date: z
                     .string()
                     .optional()
@@ -1040,7 +1120,10 @@ function registerTools(server: McpServer, userId: string) {
                     const tz = await getUserTimezone(userId);
                     const endDate = end_date ?? todayInTz(tz);
                     const windowDays = days ?? 30;
-                    const startDate = shiftLocalDate(endDate, -(windowDays - 1));
+                    const startDate = shiftLocalDate(
+                        endDate,
+                        -(windowDays - 1),
+                    );
                     const [meals, water] = await Promise.all([
                         getMealsInRange(userId, startDate, endDate, tz),
                         getWaterInRange(userId, startDate, endDate, tz),
@@ -1328,7 +1411,7 @@ export const handleMcp = async (c: Context) => {
     const server = new McpServer(
         {
             name: "nutrition-mcp",
-            version: "1.12.0",
+            version: "1.13.0",
             icons: [
                 {
                     src: `${baseUrl}/favicon.ico`,

--- a/supabase/migrations/20260626120000_food_cache.sql
+++ b/supabase/migrations/20260626120000_food_cache.sql
@@ -1,0 +1,19 @@
+-- Shared cache of resolved food lookups (Open Food Facts; later USDA). Global,
+-- not per-user: a given barcode resolves to the same product for everyone, so a
+-- single cached row serves every user. This caps outbound calls to third-party
+-- food APIs, cuts latency, and makes repeat logs of the same item instant. The
+-- server refreshes a row when it is older than the per-source TTL (src/foods.ts).
+create table if not exists public.food_cache (
+    source     text        not null,   -- 'openfoodfacts' (later 'usda')
+    source_id  text        not null,   -- barcode or food id within that source
+    payload    jsonb       not null,   -- normalized FoodResult
+    fetched_at timestamptz not null default now(),
+    primary key (source, source_id)
+);
+
+-- Only the server (service-role) reads or writes the cache; it is never exposed
+-- to the anon/authenticated PostgREST roles. RLS is enabled with no policy, so
+-- those roles see nothing while the service role bypasses RLS.
+alter table public.food_cache enable row level security;
+
+grant all on table public.food_cache to service_role;


### PR DESCRIPTION
## What

Phase 1 of nutrition-database integration: resolve a packaged product's **verified macros from a barcode** via the Open Food Facts REST API, instead of relying solely on LLM estimation. Closes the one capability gap the rest of the MCP nutrition field has over us.

The model stays the parser/orchestrator — this only returns canonical macros for an already-identified product. Barcodes can be typed **or read from a photo of the package** (vision-layer OCR; the server only ever receives the digits, no image decoding).

## Changes

- **`food_cache` migration** — global, service-role-only cache keyed by `(source, source_id)` so a barcode resolves once and serves every user. Caps outbound API calls, cuts latency. _(Already applied to the prod DB via Supabase MCP.)_
- **`src/foods.ts`** — Open Food Facts client, cache-first (7-day TTL). Prefers per-serving values, falls back to per-100g. 14 unit tests.
- **`lookup_barcode` tool** + updated `log_meal` guidance to prefer verified data.
- **Docs** — README tool table + `OFF_USER_AGENT` env var; landing page feature card, SEO meta, and FAQ.
- **Version** bumped to `1.13.0` (package.json, src/mcp.ts, server.json).

## Graceful degradation

Every lookup path degrades to LLM estimation — a miss, an outage, or unset config returns a clear message and the model estimates instead. Barcode lookup is always **additive**, never a hard dependency for logging a meal.

## Required before barcodes resolve in prod

Set **`OFF_USER_AGENT`** in the deployment env, in the form `AppName (email)` (Open Food Facts requires it). Until then, lookups fail gracefully.

## Testing

- 22 tests pass (14 new in `src/foods.test.ts`, hermetic/mocked).
- `src/` typechecks clean.
- Live smoke test against the real OFF API confirmed correct macros for Nutella (per-100g) and Coca-Cola (per-serving).

🤖 Generated with [Claude Code](https://claude.com/claude-code)