### PR TITLE
fix: close MCP transports on session expiry and shutdown (v1.13.2)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "nutrition-mcp",
-    "version": "1.13.1",
+    "version": "1.13.2",
     "description": "A remote MCP server for personal nutrition tracking. Log meals, track macros, and review nutrition history through Claude.",
     "author": "akutishevsky",
     "license": "MIT",

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
     "name": "io.github.akutishevsky/nutrition-mcp",
     "title": "Nutrition MCP",
     "description": "Personal nutrition tracking — log meals, track macros, and review history through conversation.",
-    "version": "1.13.1",
+    "version": "1.13.2",
     "websiteUrl": "https://nutrition-mcp.com/",
     "repository": {
         "url": "https://github.com/akutishevsky/nutrition-mcp",

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,7 @@ import { cors } from "hono/cors";
 import { bodyLimit } from "hono/body-limit";
 import { createOAuthRouter } from "./oauth.js";
 import { authenticateBearer, rateLimit } from "./middleware.js";
-import { handleMcp } from "./mcp.js";
+import { handleMcp, closeAllSessions } from "./mcp.js";
 import { startExportCleanup } from "./export.js";
 import { getLandingStats, type LandingStats } from "./supabase.js";
 import { getBaseUrl } from "./url.js";
@@ -205,6 +205,19 @@ console.log(`Nutrition MCP server listening on 0.0.0.0:${port}`);
 
 // Periodically delete expired meal-export files from the storage bucket.
 startExportCleanup();
+
+// Close live MCP transports cleanly on shutdown (e.g. deploys) so clients see a
+// graceful stream close and reconnect, rather than an abruptly severed socket.
+let shuttingDown = false;
+async function shutdown(signal: string): Promise<void> {
+    if (shuttingDown) return;
+    shuttingDown = true;
+    console.log(`Received ${signal}, closing MCP sessions...`);
+    await closeAllSessions();
+    process.exit(0);
+}
+process.on("SIGTERM", () => void shutdown("SIGTERM"));
+process.on("SIGINT", () => void shutdown("SIGINT"));
 
 export default {
     port,

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -50,9 +50,24 @@ setInterval(() => {
     for (const [id, session] of sessions) {
         if (now - session.lastActivity > SESSION_TTL_MS) {
             sessions.delete(id);
+            // Close the transport so its open SSE stream is torn down and the
+            // connected McpServer (with all its tool closures) becomes
+            // GC-eligible. Dropping the Map entry alone leaks them, because the
+            // lingering stream keeps the transport reachable. close() is async
+            // and idempotent; we don't need to await it inside the sweep.
+            void session.transport.close();
         }
     }
 }, CLEANUP_INTERVAL_MS);
+
+// Close every live session's transport. Called on shutdown so in-flight SSE
+// streams end cleanly (clients reconnect) instead of being severed when the
+// process is killed.
+export async function closeAllSessions(): Promise<void> {
+    const transports = [...sessions.values()].map((s) => s.transport);
+    sessions.clear();
+    await Promise.allSettled(transports.map((t) => t.close()));
+}
 
 interface DailyTotals {
     calories: number;
@@ -1411,7 +1426,7 @@ export const handleMcp = async (c: Context) => {
     const server = new McpServer(
         {
             name: "nutrition-mcp",
-            version: "1.13.1",
+            version: "1.13.2",
             icons: [
                 {
                     src: `${baseUrl}/favicon.ico`,


### PR DESCRIPTION
## Problem

DigitalOcean memory charts showed steady, monotonic overnight memory climbs that only ever recovered on a restart — including at least one OOM-driven restart (18 Jun) and a climb to ~63% overnight on 26→27 Jun. Run logs confirmed the process ran continuously with **no restart and zero errors** while memory rose, and that traffic was *modest and declining* during the climb. Memory growth was fully decoupled from load — the signature of a leak, not traffic.

## Root cause

The session TTL sweep in `src/mcp.ts` dropped expired sessions from the `sessions` Map but **never called `transport.close()`**:

```js
if (now - session.lastActivity > SESSION_TTL_MS) {
    sessions.delete(id);   // ← Map entry gone, but transport never closed
}
```

The SDK's `WebStandardStreamableHTTPServerTransport` holds an open SSE `ReadableStream` per session; only `close()` runs the stream cleanup. With the stream left open, the transport — and the per-session `McpServer` with **all 18 tool closures** (each capturing `userId`) — stayed reachable and never became GC-eligible. Memory grew with cumulative sessions created since the last restart, which is why frequent deploys masked it and a quiet, no-deploy night exposed it.

This is an incomplete part of the earlier `3a99f4f` leak fix (which bounded the Map but not the transport), **not** a regression from the v1.13.x barcode / date-range work.

## Fix

- Call `void session.transport.close()` in the TTL sweep so the server and its closures become GC-eligible.
- Add a `SIGTERM`/`SIGINT` handler (`closeAllSessions()`) that closes all live transports on shutdown, so deploys end SSE streams cleanly (clients reconnect) instead of severing sockets.

## Impact / safety

- **Session lifetime unchanged** — the sweep still only touches sessions idle past `SESSION_TTL_MS` (60 min). Active users are never selected.
- **No forced re-login** — authentication is token-based (`authenticateBearer`) and independent of the session Map. An expired session triggers a transparent client re-`initialize` with the same token; users never see a login screen and lose no data (state lives in Supabase).
- Expected result: memory plateaus into a normal sawtooth instead of climbing to OOM.

## Testing

- `bun test` → 29 pass, 0 fail
- `bunx tsc --noEmit` → no errors in `src/mcp.ts` or `src/index.ts` (pre-existing errors in `scripts/gen-map-data.ts` are unrelated)

Bumps version to 1.13.2 (`package.json`, `src/mcp.ts`, `server.json`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)