### PR TITLE
ci: auto-publish to MCP Registry on version tags

### DIFF
--- a/.github/workflows/publish-mcp.yml
+++ b/.github/workflows/publish-mcp.yml
@@ -1,0 +1,59 @@
+name: Publish to MCP Registry
+
+# Publishes the server entry to the official MCP Registry whenever a version
+# tag (e.g. v1.13.2) is pushed. nutrition-mcp is a *remote* server, so there is
+# no package to build — we only publish the server.json metadata that points
+# clients at https://nutrition-mcp.com/mcp.
+#
+# Auth uses GitHub OIDC, which proves this repo's identity matches the
+# io.github.akutishevsky/* namespace in server.json — no secrets required.
+#
+# Tagging flow (run after the version bump is merged to main):
+#   git tag v1.13.2 && git push origin v1.13.2
+
+on:
+  push:
+    tags: ["v*"]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write # required for OIDC authentication
+      contents: read
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@v2
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Run tests
+        run: bun test
+
+      # Guard against publishing a mismatched version: the pushed tag must match
+      # the version committed in server.json (the source of truth maintained
+      # alongside package.json and src/mcp.ts).
+      - name: Verify tag matches server.json version
+        run: |
+          TAG_VERSION="${GITHUB_REF_NAME#v}"
+          JSON_VERSION="$(jq -r .version server.json)"
+          if [ "$TAG_VERSION" != "$JSON_VERSION" ]; then
+            echo "::error::Tag '$GITHUB_REF_NAME' does not match server.json version '$JSON_VERSION'. Bump server.json before tagging."
+            exit 1
+          fi
+          echo "Publishing version $JSON_VERSION"
+
+      - name: Install mcp-publisher
+        run: |
+          curl -L "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" | tar xz mcp-publisher
+
+      - name: Authenticate to MCP Registry (GitHub OIDC)
+        run: ./mcp-publisher login github-oidc
+
+      - name: Publish server to MCP Registry
+        run: ./mcp-publisher publish

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,16 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 nutrition-mcp is a Model Context Protocol (MCP) server for nutrition-related functionality, built with Bun and TypeScript. Entry point is `src/index.ts`. Server version must be updated in three places: `package.json`, `src/mcp.ts` (McpServer constructor), and `server.json`. The server icon is at `public/favicon.ico`. Tool call analytics (duration, success/failure, error category) are tracked via `src/analytics.ts` and persisted to a `tool_analytics` Supabase table.
 
+## Releasing
+
+This is a remote MCP server: deploying to DigitalOcean makes code changes live for clients immediately (the MCP Registry is only discovery metadata pointing at `https://nutrition-mcp.com/mcp`, so republishing is not required for a fix to take effect). To refresh the registry listing on a release, bump the version in all three places above, merge to `main`, then push a matching `v*` tag:
+
+```
+git tag v1.13.3 && git push origin v1.13.3
+```
+
+The `.github/workflows/publish-mcp.yml` workflow then runs the tests, verifies the tag matches `server.json`'s version, and publishes via `mcp-publisher` using GitHub OIDC (no secrets). Each published version must be unique and is immutable once published, so always tag a fresh version — never re-tag an already-published one.
+
 ## Commands
 
 - `bun run src/index.ts` - Run the server


### PR DESCRIPTION
## What

Adds `.github/workflows/publish-mcp.yml` — a GitHub Actions workflow that publishes the `server.json` entry to the official MCP Registry automatically whenever a `v*` tag is pushed, so the registry listing stays in sync with releases without manual `mcp-publisher` runs.

## Why

nutrition-mcp is a **remote** server, so a code deploy already makes updates live for clients — the registry is just discovery metadata. This keeps that metadata (version, description, URL) current on each release without manual effort, which is the recommended freshness practice.

## How it works

Triggered on `push: tags: ["v*"]`. Steps:
1. Checkout + Bun setup + `bun install --frozen-lockfile`
2. `bun test` (gate — don't publish a broken release)
3. **Version guard** — fails if the pushed tag (`v1.13.2`) doesn't match `server.json`'s `version`, preventing a mismatched publish
4. Install `mcp-publisher`
5. `mcp-publisher login github-oidc` — **no secrets**; GitHub OIDC proves the repo identity matches the `io.github.akutishevsky/*` namespace
6. `mcp-publisher publish`

## Release flow after this merges

```
# bump version in package.json, server.json, src/mcp.ts → merge to main
git tag v1.13.3 && git push origin v1.13.3
```

The workflow does the rest. (Registry rule: each published version must be unique and is immutable once published — the version guard helps enforce a clean bump.)

## Notes

- The MCP Registry is still in preview, so the publish step's exact behavior may change upstream.
- No package publishing (npm/etc.) is included since this is a remote server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)