### PR TITLE
perf: run Bun in --smol mode to lower memory footprint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,4 +5,9 @@ RUN bun install --frozen-lockfile
 COPY . .
 USER bun
 EXPOSE 8080
-CMD ["bun", "src/index.ts"]
+# --smol runs Bun's GC more aggressively and grows the heap more slowly,
+# keeping RSS low on the 512MB instance. The memory "climb" is GC sawtooth,
+# not a leak (the heap is reclaimed without a restart); --smol lowers the
+# sawtooth peaks to reduce OOM risk under bursts. CPU sits at ~2-5%, so the
+# extra GC work is effectively free for this workload.
+CMD ["bun", "--smol", "src/index.ts"]


### PR DESCRIPTION
## Background — corrected diagnosis

Earlier we treated the production memory climb as an MCP session leak and shipped v1.13.2 (closing transports on session expiry/shutdown). That change is correct hygiene and worth keeping, but it was **not** the actual cause.

The decisive evidence: at 18:20 EEST the process **dropped ~110 MB on its own** (47% → 26%) with **no deploy and no restart** — confirmed by a single `listening` log line (11:42 UTC) and no deployment at that time. An unreachable-object leak can't be reclaimed without a restart; only **garbage collection** can. So the "climb" is normal GC sawtooth: Bun's JavaScriptCore engine lets the heap grow as requests allocate, then runs a major GC and drops back to the true working set (~26%).

The real risk is therefore **OOM headroom**, not a leak: on the 512 MB instance, a heavy burst can make allocations briefly outrun GC and hit the ceiling before a collection runs — which is what caused the single 18 Jun OOM restart.

## Change

One-line Dockerfile change: `CMD ["bun", "--smol", "src/index.ts"]`.

Per [Bun's docs](https://bun.com/docs/runtime), `--smol` grows the heap more slowly and runs GC more frequently, keeping RSS (and the sawtooth peaks) low. Trade-off is extra CPU for GC — but CPU sits at **2–5%** with large headroom, so it's effectively free for this workload.

## Expected effect

- Memory sawtooth peaks drop well below the prior ~50–63%.
- OOM risk under bursts (the 18 Jun scenario) is greatly reduced.
- No correctness or behavior change; clients are unaffected.

## Not included / follow-ups

- v1.13.2 (transport close) stays as-is — still correct.
- If peaks remain uncomfortable after this, the fallback is sizing the instance to 1 GB (`apps-s-1vcpu-1gb`).
- Recommend adding a DO memory alert at ~85% so any future ceiling-approach pages instead of silently OOM-ing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)