### PR TITLE
Add contact section with email to landing page

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -180,6 +180,7 @@
                     <a href="#try">Examples</a>
                     <a href="#support">Support</a>
                     <a href="#faq">FAQ</a>
+                    <a href="#contact">Contact</a>
                     <a
                         href="https://github.com/akutishevsky/nutrition-mcp"
                         target="_blank"
@@ -1532,6 +1533,35 @@
                 </div>
             </section>
 
+            <!-- Contact -->
+            <section class="section band" id="contact">
+                <div class="container">
+                    <div class="section-head">
+                        <p class="eyebrow">Contact</p>
+                        <h2 class="section-title">Questions or feedback?</h2>
+                        <p class="section-sub">
+                            Found a bug, want a feature, or just have a
+                            question? Email me directly — I read every message.
+                        </p>
+                    </div>
+                    <div class="card contact-card">
+                        <span class="contact-icon" aria-hidden="true"
+                            ><i class="fa-solid fa-envelope"></i
+                        ></span>
+                        <a
+                            class="contact-email"
+                            href="mailto:anton@nutrition-mcp.com"
+                            >anton@nutrition-mcp.com</a
+                        >
+                        <a
+                            class="btn btn-primary"
+                            href="mailto:anton@nutrition-mcp.com"
+                            >Send an email</a
+                        >
+                    </div>
+                </div>
+            </section>
+
             <!-- FAQ -->
             <section class="section" id="faq">
                 <div class="container">
@@ -1665,6 +1695,7 @@
                         rel="noopener noreferrer"
                         >GitHub</a
                     >
+                    <a href="mailto:anton@nutrition-mcp.com">Contact</a>
                     <a href="/privacy">Privacy &amp; Terms</a>
                 </nav>
             </div>

--- a/public/styles.css
+++ b/public/styles.css
@@ -1560,6 +1560,41 @@ html:has(body.landing) {
     flex: 1;
 }
 
+/* ---------- contact ---------- */
+.contact-card {
+    max-width: 460px;
+    margin: 0 auto;
+    padding: 2.2rem 1.9rem;
+    border-radius: 18px;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    text-align: center;
+    gap: 1rem;
+}
+.contact-icon {
+    width: 56px;
+    height: 56px;
+    border-radius: 16px;
+    background: linear-gradient(135deg, #f0f7f1 0%, #e8f0e4 100%);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 1.4rem;
+    color: var(--accent);
+}
+.contact-email {
+    font-family: var(--font-display);
+    font-weight: 700;
+    font-size: clamp(1.1rem, 2.5vw, 1.4rem);
+    letter-spacing: -0.02em;
+    color: var(--accent-hover);
+    word-break: break-all;
+}
+.contact-email:hover {
+    text-decoration: underline;
+}
+
 /* ---------- responsive ---------- */
 @media (max-width: 860px) {
     /* Stack the hero: copy on top, dashboard card below. */


### PR DESCRIPTION
## Summary

Adds a way for users to contact the maintainer via the new `anton@nutrition-mcp.com` domain email, in three places on the landing page:

- **Dedicated contact section** (`#contact`) between the closing CTA and the FAQ — eyebrow "Contact", heading "Questions or feedback?", and a centered card with an envelope icon, the clickable email, and a "Send an email" button. Reuses the existing `section band` / `card` styling plus a small `.contact-card` block in `styles.css`.
- **Header nav** — a "Contact" anchor link (`#contact`) between FAQ and GitHub.
- **Footer** — a "Contact" `mailto:` link next to GitHub / Privacy.

Scope is limited to `public/index.html` (+31) and `public/styles.css` (+35).

## Notes

- The contact card keeps a white background in dark mode (shares the `.card` rule with the Support cards), consistent with the rest of the page.
- This is a content-only change. Per `CLAUDE.md`, it goes live on the next DigitalOcean deploy — no version bump or MCP Registry republish needed.

## Verification

Rendered locally and confirmed the section, nav anchor, and footer link all point to `mailto:anton@nutrition-mcp.com`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)