### PR TITLE
obs: HTTP access logging + raise Bun idleTimeout

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,25 @@ import { getBaseUrl } from "./url.js";
 
 const app = new Hono();
 
+// Access log — records every non-health HTTP request (method, path, status,
+// duration, client IP) so traffic that never reaches a tool handler — and is
+// therefore invisible to tool analytics — is still attributable in the runtime
+// logs: unauthenticated /mcp probes (401), rate-limited hits (429), OAuth
+// discovery crawls, vuln scanners. Registered first so it runs outermost and
+// observes the final response status. /health is skipped to keep the platform's
+// frequent health checks from evicting real traffic from the log buffer.
+app.use("*", async (c, next) => {
+    const path = new URL(c.req.url).pathname;
+    if (path === "/health") return next();
+    const start = performance.now();
+    await next();
+    const ms = Math.round(performance.now() - start);
+    const ip = c.req.header("x-forwarded-for")?.split(",")[0]?.trim() ?? "-";
+    console.log(
+        `[req] ${c.req.method} ${path} ${c.res.status} ${ms}ms ip=${ip}`,
+    );
+});
+
 // Security headers
 app.use("*", async (c, next) => {
     await next();
@@ -222,5 +241,9 @@ process.on("SIGINT", () => void shutdown("SIGINT"));
 export default {
     port,
     hostname: "0.0.0.0",
+    // Long-lived MCP streams (StreamableHTTP GET/SSE) can idle between events;
+    // Bun's 10s default closes them and logs "request timed out after 10
+    // seconds". Raise it so legitimate streaming connections aren't severed.
+    idleTimeout: 120,
     fetch: app.fetch,
 };


### PR DESCRIPTION
## Why

A diagnostic into the ~90% CPU plateaus in DigitalOcean Insights (28–29 Jun) showed they **don't correlate with MCP tool usage** — during both peaks, `tool_analytics` and the runtime logs showed only ~10–15 tool calls/hour, all sub-second. The CPU was spent on requests that never reach a tool handler and are therefore invisible to analytics: unauthenticated `/mcp` probes (401), rate-limited hits (429), OAuth discovery crawls, and scanners. The app currently has **no HTTP access logging** at all, so this traffic can't be attributed.

## Changes

- **Access log middleware** (outermost): logs `method path status duration ip` for every request, so the next spike is attributable to a path/IP. Reads client IP from `x-forwarded-for` (DO App Platform proxies).
- **Skip `/health`** so the platform's frequent health checks don't evict real traffic from the small runtime-log buffer.
- **`idleTimeout: 120`** on `Bun.serve` — the 10s default was severing long-lived MCP StreamableHTTP/SSE streams and producing the stray `request timed out after 10 seconds` warnings.

## Verification

- `bun test` → 29 pass, 0 fail
- `tsc --noEmit` clean for `src/` (pre-existing errors in `scripts/gen-map-data.ts` are unrelated)

After deploy, grep runtime logs for `[req] ` during the next peak to identify the offending path/IP.

🤖 Generated with [Claude Code](https://claude.com/claude-code)