### PR TITLE
obs: mask client IP in access log

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -7,23 +7,24 @@ import { handleMcp, closeAllSessions } from "./mcp.js";
 import { startExportCleanup } from "./export.js";
 import { getLandingStats, type LandingStats } from "./supabase.js";
 import { getBaseUrl } from "./url.js";
+import { maskIp } from "./net.js";
 
 const app = new Hono();
 
 // Access log — records every non-health HTTP request (method, path, status,
-// duration, client IP) so traffic that never reaches a tool handler — and is
-// therefore invisible to tool analytics — is still attributable in the runtime
-// logs: unauthenticated /mcp probes (401), rate-limited hits (429), OAuth
-// discovery crawls, vuln scanners. Registered first so it runs outermost and
-// observes the final response status. /health is skipped to keep the platform's
-// frequent health checks from evicting real traffic from the log buffer.
+// duration, masked client subnet) so traffic that never reaches a tool handler
+// — and is therefore invisible to tool analytics — is still attributable in the
+// runtime logs: unauthenticated /mcp probes (401), rate-limited hits (429),
+// OAuth discovery crawls, vuln scanners. Registered first so it runs outermost
+// and observes the final response status. /health is skipped to keep the
+// platform's frequent health checks from evicting real traffic from the buffer.
 app.use("*", async (c, next) => {
     const path = new URL(c.req.url).pathname;
     if (path === "/health") return next();
     const start = performance.now();
     await next();
     const ms = Math.round(performance.now() - start);
-    const ip = c.req.header("x-forwarded-for")?.split(",")[0]?.trim() ?? "-";
+    const ip = maskIp(c.req.header("x-forwarded-for"));
     console.log(
         `[req] ${c.req.method} ${path} ${c.res.status} ${ms}ms ip=${ip}`,
     );

--- a/src/net.test.ts
+++ b/src/net.test.ts
@@ -1,0 +1,30 @@
+import { test, expect } from "bun:test";
+import { maskIp } from "./net.js";
+
+// All addresses below are IETF-reserved documentation ranges (RFC 5737 for
+// IPv4: 192.0.2.0/24, 198.51.100.0/24, 203.0.113.0/24; RFC 3849 for IPv6:
+// 2001:db8::/32). They are never routable to a real host.
+
+test("maskIp drops the host octet of an IPv4 address", () => {
+    expect(maskIp("203.0.113.42")).toBe("203.0.113.x");
+});
+
+test("maskIp uses only the first hop of x-forwarded-for", () => {
+    expect(maskIp("203.0.113.42, 198.51.100.7, 192.0.2.1")).toBe("203.0.113.x");
+});
+
+test("maskIp keeps the /48 prefix of an IPv6 address", () => {
+    expect(maskIp("2001:db8:85a3:1:2:3:4:5")).toBe("2001:db8:85a3:x");
+});
+
+test("maskIp handles compressed IPv6 without mangling", () => {
+    expect(maskIp("2001:db8::1")).toBe("2001:db8:x");
+});
+
+test("maskIp never leaks a full address — malformed/loopback collapse to '-'", () => {
+    expect(maskIp("::1")).toBe("-");
+    expect(maskIp("garbage")).toBe("-");
+    expect(maskIp("203.0.113")).toBe("-");
+    expect(maskIp("")).toBe("-");
+    expect(maskIp(undefined)).toBe("-");
+});

--- a/src/net.ts
+++ b/src/net.ts
@@ -1,0 +1,18 @@
+// Coarsen a client IP before it ever reaches a log line. A full IP is personal
+// data; for diagnosing traffic we only need subnet-level granularity to tell a
+// single-source flood from distributed traffic — never to identify or block an
+// individual. IPv4 keeps the first three octets, IPv6 the first three hextets,
+// with the host portion replaced by "x". The full address is never returned.
+export function maskIp(forwardedFor: string | undefined): string {
+    const raw = forwardedFor?.split(",")[0]?.trim();
+    if (!raw) return "-";
+    if (raw.includes(":")) {
+        // Take the hextets before any "::" compression — leading groups are
+        // always literal, so this never mangles a compressed address.
+        const head = raw.split("::")[0]!.split(":").filter(Boolean).slice(0, 3);
+        return head.length ? head.join(":") + ":x" : "-";
+    }
+    const octets = raw.split(".");
+    if (octets.length !== 4 || octets.some((o) => o === "")) return "-";
+    return `${octets[0]}.${octets[1]}.${octets[2]}.x`;
+}


### PR DESCRIPTION
Follow-up to #27. That access log recorded the **full** client IP; this coarsens it so a real address is never written to a log line.

## What changes
- `maskIp()` reduces an IP to its subnet before logging: IPv4 → first three octets (`203.0.113.x`), IPv6 → first three hextets (`2001:db8:85a3:x`). Malformed input and loopback collapse to `-`.
- Only the **first** hop of `x-forwarded-for` is considered (the real client per DO's proxy); later hops are ignored.
- **No flag to re-enable full IPs** — by design.
- Extracted into `src/net.ts` (pure, no side effects) so it's unit-testable without importing `index.ts`'s server-startup side effects.

## Why
A full IP is personal data. The log's only purpose is distinguishing a single-source flood from distributed traffic, which subnet granularity already answers — so there's no reason to retain more. Combined with the fact that these are ephemeral DO runtime logs (no DB persistence), this keeps a health app on the safe side of IP-privacy.

## Tests
`src/net.test.ts` — 5 cases covering IPv4, multi-hop XFF, full + compressed IPv6, and the never-leak guarantee. Full suite: **34 pass, 0 fail**. All addresses in the test use IETF documentation ranges (RFC 5737 / RFC 3849), never real hosts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)