### PR TITLE
Make /mcp stateless to survive deploys

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,7 @@ import { cors } from "hono/cors";
 import { bodyLimit } from "hono/body-limit";
 import { createOAuthRouter } from "./oauth.js";
 import { authenticateBearer, rateLimit } from "./middleware.js";
-import { handleMcp, closeAllSessions } from "./mcp.js";
+import { handleMcp } from "./mcp.js";
 import { startExportCleanup } from "./export.js";
 import { getLandingStats, type LandingStats } from "./supabase.js";
 import { getBaseUrl } from "./url.js";
@@ -226,18 +226,17 @@ console.log(`Nutrition MCP server listening on 0.0.0.0:${port}`);
 // Periodically delete expired meal-export files from the storage bucket.
 startExportCleanup();
 
-// Close live MCP transports cleanly on shutdown (e.g. deploys) so clients see a
-// graceful stream close and reconnect, rather than an abruptly severed socket.
+// Exit cleanly on shutdown signals (e.g. deploys). /mcp is stateless — no
+// server-side sessions are held, so there is nothing to tear down; just exit.
 let shuttingDown = false;
-async function shutdown(signal: string): Promise<void> {
+function shutdown(signal: string): void {
     if (shuttingDown) return;
     shuttingDown = true;
-    console.log(`Received ${signal}, closing MCP sessions...`);
-    await closeAllSessions();
+    console.log(`Received ${signal}, shutting down...`);
     process.exit(0);
 }
-process.on("SIGTERM", () => void shutdown("SIGTERM"));
-process.on("SIGINT", () => void shutdown("SIGINT"));
+process.on("SIGTERM", () => shutdown("SIGTERM"));
+process.on("SIGINT", () => shutdown("SIGINT"));
 
 export default {
     port,

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -33,42 +33,6 @@ import {
 import { exportMeals } from "./export.js";
 import { normalizeBarcode, lookupBarcode, formatFoodResult } from "./foods.js";
 
-const SESSION_TTL_MS = 60 * 60 * 1000; // 60 minutes
-const CLEANUP_INTERVAL_MS = 5 * 60 * 1000; // every 5 minutes
-
-const sessions = new Map<
-    string,
-    {
-        transport: WebStandardStreamableHTTPServerTransport;
-        mcpToken: string;
-        lastActivity: number;
-    }
->();
-
-setInterval(() => {
-    const now = Date.now();
-    for (const [id, session] of sessions) {
-        if (now - session.lastActivity > SESSION_TTL_MS) {
-            sessions.delete(id);
-            // Close the transport so its open SSE stream is torn down and the
-            // connected McpServer (with all its tool closures) becomes
-            // GC-eligible. Dropping the Map entry alone leaks them, because the
-            // lingering stream keeps the transport reachable. close() is async
-            // and idempotent; we don't need to await it inside the sweep.
-            void session.transport.close();
-        }
-    }
-}, CLEANUP_INTERVAL_MS);
-
-// Close every live session's transport. Called on shutdown so in-flight SSE
-// streams end cleanly (clients reconnect) instead of being severed when the
-// process is killed.
-export async function closeAllSessions(): Promise<void> {
-    const transports = [...sessions.values()].map((s) => s.transport);
-    sessions.clear();
-    await Promise.allSettled(transports.map((t) => t.close()));
-}
-
 interface DailyTotals {
     calories: number;
     protein_g: number;
@@ -1380,44 +1344,8 @@ function registerTools(server: McpServer, userId: string) {
     );
 }
 
-export const handleMcp = async (c: Context) => {
-    const mcpToken = c.get("accessToken") as string;
-    const userId = c.get("userId") as string;
-    const sessionId = c.req.header("mcp-session-id");
-
-    const session = sessionId ? sessions.get(sessionId) : undefined;
-
-    if (sessionId && !session) {
-        return c.json({ error: "invalid_session" }, 404);
-    }
-
-    if (session && session.mcpToken !== mcpToken) {
-        return c.json({ error: "forbidden" }, 403);
-    }
-
-    if (session) {
-        session.lastActivity = Date.now();
-        return session.transport.handleRequest(c.req.raw);
-    }
-
-    if (c.req.method !== "POST") {
-        return c.json({ error: "invalid_request" }, 400);
-    }
-
-    const transport = new WebStandardStreamableHTTPServerTransport({
-        sessionIdGenerator: () => crypto.randomUUID(),
-        onsessioninitialized: (id) => {
-            sessions.set(id, {
-                transport,
-                mcpToken,
-                lastActivity: Date.now(),
-            });
-        },
-        onsessionclosed: (id) => {
-            sessions.delete(id);
-        },
-    });
-
+// Build a fresh McpServer with this user's tools registered.
+function buildMcpServer(c: Context, userId: string): McpServer {
     const proto = c.req.header("x-forwarded-proto") || "http";
     const host =
         c.req.header("x-forwarded-host") || c.req.header("host") || "localhost";
@@ -1438,6 +1366,23 @@ export const handleMcp = async (c: Context) => {
     );
 
     registerTools(server, userId);
+    return server;
+}
+
+// Stateless: /mcp holds no per-session state. Every request builds a brand-new
+// transport + McpServer and tears it down when the response completes (the SDK
+// forbids reusing a stateless transport). Because nothing is kept in-process, a
+// restart/deploy can never strand a connected client — there is no session to
+// lose, and therefore no reconnect step for a client to wedge on. The trade-off
+// is no server-initiated streaming (standalone GET SSE / notifications), which
+// this server does not use.
+export const handleMcp = async (c: Context) => {
+    const userId = c.get("userId") as string;
+
+    const transport = new WebStandardStreamableHTTPServerTransport({
+        sessionIdGenerator: undefined,
+    });
+    const server = buildMcpServer(c, userId);
     await server.connect(transport);
 
     return transport.handleRequest(c.req.raw);


### PR DESCRIPTION
## Problem

Every deploy restarts the single app instance, which wipes the in-memory MCP session map and severs every live session. Spec-compliant clients re-`initialize` on the resulting `404 invalid_session`, but some clients don't — an observed Claude connector **wedged**: it re-authenticated fine but never re-established the MCP session, so its tools silently disappeared until the user fully removed and re-added the connector.

Traced from a real user report: account healthy (single linked user, 299 meals, valid tokens, sign-in succeeding), tools working until the exact deploy timestamp, then zero tool traffic despite a fresh token — a client-side reconnect wedge, not a data/auth problem.

## Change

Make `/mcp` **stateless**: each request builds a fresh transport + `McpServer` (`sessionIdGenerator: undefined`; the SDK forbids reusing a stateless transport) and tears it down when the response completes. With no session state held in-process, a restart has nothing to strand — so there's no reconnect step for a client to wedge on.

Removes the now-dead stateful path:
- the session `Map` + its TTL cleanup interval
- the `Mcp-Session-Id` lookup / `403` / `404` handling in `handleMcp`
- `closeAllSessions` and its shutdown call in `index.ts`

Server construction is extracted into `buildMcpServer()`.

**Trade-off:** no server-initiated streaming (standalone GET SSE / notifications) — which this server does not use.

## Verification

- `bun test` — 34/34 pass; `src/` typechecks clean.
- Boots with no flag; `/health` → 200; `/mcp` still enforces bearer auth (401).
- Validated in MCP Inspector against a real account (list tools, call tools, survives a mid-session server restart).
- In-process proof: a fresh stateless server serves a cold `tools/list` **carrying a stale session id** → `200` + tools, and issues no session id. That's exactly the post-deploy request an existing connector makes — served, not rejected. So existing clients survive a deploy without reconnecting.

## Rollout notes

- Deploy at low traffic and watch `[req] POST /mcp` — expect `200`/`202`, no spike of `404`/`500`.
- One final session drop happens at deploy time (unavoidable for any restart); healthy clients continue transparently afterward.
- Does **not** auto-fix an already-wedged client — that still needs a one-time remove + re-add.
- Rollback is a redeploy of the previous commit (no env flag).
- Remember the version bump in the three places (`package.json`, `src/mcp.ts`, `server.json`) when cutting the release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)