### PR TITLE
feat: weight management with server-side unit handling

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "nutrition-mcp",
-    "version": "1.13.3",
+    "version": "1.14.0",
     "description": "A remote MCP server for personal nutrition tracking. Log meals, track macros, and review nutrition history through Claude.",
     "author": "akutishevsky",
     "license": "MIT",

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
     "name": "io.github.akutishevsky/nutrition-mcp",
     "title": "Nutrition MCP",
     "description": "Personal nutrition tracking — log meals, track macros, and review history through conversation.",
-    "version": "1.13.3",
+    "version": "1.14.0",
     "websiteUrl": "https://nutrition-mcp.com/",
     "repository": {
         "url": "https://github.com/akutishevsky/nutrition-mcp",

--- a/src/insights.test.ts
+++ b/src/insights.test.ts
@@ -1,0 +1,84 @@
+import { test, expect } from "bun:test";
+import { computeWeightTrend } from "./insights.js";
+import type { WeightEntry } from "./supabase.js";
+
+function entry(logged_at: string, weight_g: number): WeightEntry {
+    return {
+        id: `id-${logged_at}-${weight_g}`,
+        user_id: "u1",
+        weight_g,
+        logged_at,
+        notes: null,
+        created_at: logged_at,
+        idempotency_key: null,
+    };
+}
+
+test("computeWeightTrend reports latest, change, range, and goal in kg", () => {
+    const entries = [
+        entry("2026-06-01T08:00:00Z", 80000),
+        entry("2026-06-08T08:00:00Z", 79000),
+        entry("2026-06-15T08:00:00Z", 78500),
+    ];
+    const out = computeWeightTrend(
+        entries,
+        "2026-06-01",
+        "2026-06-15",
+        "UTC",
+        75000, // target 75 kg
+        "kg",
+    );
+    expect(out).toContain(
+        "Weight trend — 2026-06-01 to 2026-06-15 (3 logged days)",
+    );
+    expect(out).toContain("Latest: 78.5 kg (on 2026-06-15)");
+    expect(out).toContain(
+        "Change over range: -1.5 kg (from 80 kg on 2026-06-01)",
+    );
+    expect(out).toContain("Min: 78.5 kg (on 2026-06-15)");
+    expect(out).toContain("Max: 80 kg (on 2026-06-01)");
+    expect(out).toContain("3.5 kg to lose to reach target of 75 kg");
+});
+
+test("computeWeightTrend averages multiple weigh-ins on the same day", () => {
+    const entries = [
+        entry("2026-06-01T07:00:00Z", 80000),
+        entry("2026-06-01T20:00:00Z", 82000), // same day -> avg 81 kg
+        entry("2026-06-02T07:00:00Z", 81000),
+    ];
+    const out = computeWeightTrend(
+        entries,
+        "2026-06-01",
+        "2026-06-02",
+        "UTC",
+        null,
+        "kg",
+    );
+    expect(out).toContain("(2 logged days)");
+    expect(out).toContain("Max: 81 kg (on 2026-06-01)"); // averaged, not 82
+    expect(out).toContain("(Tip: set a target weight with set_nutrition_goals");
+});
+
+test("computeWeightTrend renders in lb and reports gaining toward target", () => {
+    const entries = [
+        entry("2026-06-01T08:00:00Z", 74843), // 165 lb
+        entry("2026-06-10T08:00:00Z", 76203), // 168 lb
+    ];
+    const out = computeWeightTrend(
+        entries,
+        "2026-06-01",
+        "2026-06-10",
+        "UTC",
+        79379, // ~175 lb target
+        "lb",
+    );
+    expect(out).toContain("Latest: 168 lb (on 2026-06-10)");
+    expect(out).toContain("Change over range: +3 lb");
+    expect(out).toContain("to gain to reach target of 175 lb");
+});
+
+test("computeWeightTrend handles an empty range", () => {
+    expect(
+        computeWeightTrend([], "2026-06-01", "2026-06-30", "UTC", null, "kg"),
+    ).toBe("No weight logged between 2026-06-01 and 2026-06-30.");
+});

--- a/src/insights.ts
+++ b/src/insights.ts
@@ -1,5 +1,11 @@
-import type { Meal, NutritionGoals, WaterEntry } from "./supabase.js";
+import type {
+    Meal,
+    NutritionGoals,
+    WaterEntry,
+    WeightEntry,
+} from "./supabase.js";
 import { dateInTz, hourInTz } from "./tz.js";
+import { formatWeight, fromGrams, type WeightUnit } from "./units.js";
 
 export interface DailyBucket {
     date: string; // YYYY-MM-DD
@@ -93,13 +99,20 @@ export function buildDailyBuckets(
     return [...buckets.values()].sort((a, b) => a.date.localeCompare(b.date));
 }
 
-function trailingAverage(buckets: DailyBucket[], field: keyof DailyBucket, n: number): number {
+function trailingAverage(
+    buckets: DailyBucket[],
+    field: keyof DailyBucket,
+    n: number,
+): number {
     const slice = buckets.slice(-n);
     const values = slice.map((b) => b[field] as number);
     return mean(values);
 }
 
-function longestStreak(buckets: DailyBucket[], predicate: (b: DailyBucket) => boolean): number {
+function longestStreak(
+    buckets: DailyBucket[],
+    predicate: (b: DailyBucket) => boolean,
+): number {
     let best = 0;
     let cur = 0;
     for (const b of buckets) {
@@ -113,7 +126,10 @@ function longestStreak(buckets: DailyBucket[], predicate: (b: DailyBucket) => bo
     return best;
 }
 
-function currentStreak(buckets: DailyBucket[], predicate: (b: DailyBucket) => boolean): number {
+function currentStreak(
+    buckets: DailyBucket[],
+    predicate: (b: DailyBucket) => boolean,
+): number {
     let count = 0;
     for (let i = buckets.length - 1; i >= 0; i--) {
         if (predicate(buckets[i]!)) count++;
@@ -296,6 +312,106 @@ export function computeTrends(
     return sections.join("\n\n");
 }
 
+/**
+ * Weight is a point measurement (not a daily sum), and multiple weigh-ins per
+ * day are allowed — so we aggregate to one value per day by averaging that day's
+ * entries, then report trailing moving averages to smooth day-to-day noise.
+ * All output is rendered in the user's preferred unit from canonical grams.
+ */
+export function computeWeightTrend(
+    entries: WeightEntry[],
+    startDate: string,
+    endDate: string,
+    tz: string,
+    targetWeightG: number | null,
+    unit: WeightUnit,
+): string {
+    // Daily average (grams) for each day that has at least one weigh-in.
+    const sums = new Map<string, { total: number; count: number }>();
+    for (const e of entries) {
+        const date = dateInTz(e.logged_at, tz);
+        const cur = sums.get(date) ?? { total: 0, count: 0 };
+        cur.total += e.weight_g;
+        cur.count += 1;
+        sums.set(date, cur);
+    }
+    const days = [...sums.entries()]
+        .map(([date, { total, count }]) => ({ date, avg: total / count }))
+        .sort((a, b) => a.date.localeCompare(b.date));
+
+    if (days.length === 0) {
+        return `No weight logged between ${startDate} and ${endDate}.`;
+    }
+
+    const fmt = (g: number) => formatWeight(g, unit);
+    // Signed delta rendered in display units.
+    const fmtDelta = (g: number) => {
+        const v = fromGrams(Math.abs(g), unit);
+        const sign = g > 0 ? "+" : g < 0 ? "-" : "";
+        return `${sign}${v} ${unit}`;
+    };
+
+    const first = days[0]!;
+    const last = days[days.length - 1]!;
+    // Trailing average over the last n calendar days ending at endDate.
+    const trailing = (n: number): number | null => {
+        const cutoff = addDays(endDate, -(n - 1));
+        const vals = days.filter((d) => d.date >= cutoff).map((d) => d.avg);
+        return vals.length > 0 ? mean(vals) : null;
+    };
+    const avg7 = trailing(7);
+    const avg14 = trailing(14);
+    const avg30 = trailing(30);
+
+    const minDay = days.reduce((a, b) => (a.avg <= b.avg ? a : b));
+    const maxDay = days.reduce((a, b) => (a.avg >= b.avg ? a : b));
+
+    const sections: string[] = [];
+    sections.push(
+        `Weight trend — ${startDate} to ${endDate} (${days.length} logged day${days.length === 1 ? "" : "s"})`,
+    );
+
+    sections.push(
+        [
+            `Latest: ${fmt(last.avg)} (on ${last.date})`,
+            `Change over range: ${fmtDelta(last.avg - first.avg)} (from ${fmt(first.avg)} on ${first.date})`,
+        ].join("\n"),
+    );
+
+    const movingLines = ["Moving averages (smoothed):"];
+    if (avg7 != null) movingLines.push(`  7-day: ${fmt(avg7)}`);
+    if (avg14 != null) movingLines.push(`  14-day: ${fmt(avg14)}`);
+    if (avg30 != null) movingLines.push(`  30-day: ${fmt(avg30)}`);
+    sections.push(movingLines.join("\n"));
+
+    sections.push(
+        [
+            "Range:",
+            `  Min: ${fmt(minDay.avg)} (on ${minDay.date})`,
+            `  Max: ${fmt(maxDay.avg)} (on ${maxDay.date})`,
+        ].join("\n"),
+    );
+
+    if (targetWeightG != null && targetWeightG > 0) {
+        const delta = last.avg - targetWeightG; // positive = above target
+        const remaining = fromGrams(Math.abs(delta), unit);
+        let goalLine: string;
+        if (remaining === 0) {
+            goalLine = `At target (${fmt(targetWeightG)}).`;
+        } else {
+            const direction = delta > 0 ? "to lose" : "to gain";
+            goalLine = `${remaining} ${unit} ${direction} to reach target of ${fmt(targetWeightG)}`;
+        }
+        sections.push(["Goal:", `  ${goalLine}`].join("\n"));
+    } else {
+        sections.push(
+            "(Tip: set a target weight with set_nutrition_goals to track progress toward a goal.)",
+        );
+    }
+
+    return sections.join("\n\n");
+}
+
 export function computeMealPatterns(
     buckets: DailyBucket[],
     tz: string = "UTC",
@@ -317,11 +433,15 @@ export function computeMealPatterns(
             `  ${t}: ${withType.length}/${logged.length} days (${round(rate, 0)}%)`,
         );
     }
-    sections.push(["Meal-type presence (logged days):", ...presenceLines].join("\n"));
+    sections.push(
+        ["Meal-type presence (logged days):", ...presenceLines].join("\n"),
+    );
 
     // Breakfast effect
     const withBreakfast = logged.filter((b) => b.mealTypes.has("breakfast"));
-    const withoutBreakfast = logged.filter((b) => !b.mealTypes.has("breakfast"));
+    const withoutBreakfast = logged.filter(
+        (b) => !b.mealTypes.has("breakfast"),
+    );
     if (withBreakfast.length > 0 && withoutBreakfast.length > 0) {
         const avg = (xs: DailyBucket[], f: keyof DailyBucket) =>
             round(mean(xs.map((b) => b[f] as number)));
@@ -430,16 +550,27 @@ export function computeWeeklyDigest(
         `Weekly digest — ${buckets[0]!.date} to ${buckets[buckets.length - 1]!.date}`,
     );
     lines.push("");
-    lines.push(`Logged ${logged.length}/${buckets.length} days, ${totalMeals} meals total.`);
+    lines.push(
+        `Logged ${logged.length}/${buckets.length} days, ${totalMeals} meals total.`,
+    );
     lines.push("");
     lines.push("Daily averages:");
-    const line = (label: string, val: number, unit: string, target: number | null) => {
+    const line = (
+        label: string,
+        val: number,
+        unit: string,
+        target: number | null,
+    ) => {
         if (target == null || target <= 0) return `  ${label}: ${val}${unit}`;
         const pct = round((val / target) * 100, 0);
         return `  ${label}: ${val}${unit} / ${target}${unit} target (${pct}%)`;
     };
-    lines.push(line("Calories", avgCals, " kcal", goals?.daily_calories ?? null));
-    lines.push(line("Protein", avgProtein, "g", goals?.daily_protein_g ?? null));
+    lines.push(
+        line("Calories", avgCals, " kcal", goals?.daily_calories ?? null),
+    );
+    lines.push(
+        line("Protein", avgProtein, "g", goals?.daily_protein_g ?? null),
+    );
     lines.push(line("Carbs", avgCarbs, "g", goals?.daily_carbs_g ?? null));
     lines.push(line("Fat", avgFat, "g", goals?.daily_fat_g ?? null));
     lines.push(line("Water", avgWater, " ml", goals?.daily_water_ml ?? null));

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -15,21 +15,45 @@ import {
     getWaterByDate,
     getWaterInRange,
     deleteWater,
+    insertWeight,
+    getWeightByDate,
+    getWeightInRange,
+    getLatestWeight,
+    updateWeight,
+    deleteWeight,
     getUserTimezone,
+    getPreferredWeightUnit,
     upsertProfile,
     getProfile,
     type Meal,
     type NutritionGoals,
     type WaterEntry,
+    type WeightEntry,
 } from "./supabase.js";
 import { withAnalytics } from "./analytics.js";
-import { todayInTz, validateTz, shiftLocalDate, dateInTz } from "./tz.js";
+import {
+    todayInTz,
+    validateTz,
+    shiftLocalDate,
+    dateInTz,
+    validateLoggedAt,
+} from "./tz.js";
 import {
     buildDailyBuckets,
     computeTrends,
     computeMealPatterns,
     computeWeeklyDigest,
+    computeWeightTrend,
 } from "./insights.js";
+import {
+    toGrams,
+    formatWeight,
+    fromGrams,
+    isWeightUnit,
+    pickWriteUnit,
+    isPlausibleWeightGrams,
+    type WeightUnit,
+} from "./units.js";
 import { exportMeals } from "./export.js";
 import { normalizeBarcode, lookupBarcode, formatFoodResult } from "./foods.js";
 
@@ -114,7 +138,10 @@ function formatProgress(
     return lines.join("\n");
 }
 
-function formatGoals(goals: NutritionGoals | null): string {
+function formatGoals(
+    goals: NutritionGoals | null,
+    weightUnit: WeightUnit = "kg",
+): string {
     if (!goals) {
         return "No nutrition goals set. Use set_nutrition_goals to define daily targets.";
     }
@@ -134,7 +161,39 @@ function formatGoals(goals: NutritionGoals | null): string {
     parts.push(
         `- Water: ${goals.daily_water_ml != null ? `${goals.daily_water_ml} ml` : "not set"}`,
     );
+    parts.push(
+        `- Target weight: ${goals.target_weight_g != null ? formatWeight(goals.target_weight_g, weightUnit) : "not set"}`,
+    );
     return parts.join("\n");
+}
+
+function formatWeightEntry(entry: WeightEntry, unit: WeightUnit): string {
+    return `- ${formatWeight(entry.weight_g, unit)} at ${entry.logged_at}${entry.notes ? ` (${entry.notes})` : ""} [id: ${entry.id}]`;
+}
+
+// Resolve the unit to use when WRITING a weight value: an explicit unit wins,
+// otherwise the user's saved preference. If neither exists, refuse rather than
+// guess — silently assuming kg for someone who meant lb is exactly the mis-log
+// this feature exists to prevent.
+async function resolveWriteWeightUnit(
+    userId: string,
+    explicit: WeightUnit | undefined,
+): Promise<WeightUnit> {
+    return pickWriteUnit(explicit, await getPreferredWeightUnit(userId));
+}
+
+// Reject magnitude mistakes (value typed in grams, an extra digit, a sub-unit
+// typo). Suggests the other unit when the same number would be plausible there.
+function assertPlausibleWeight(grams: number, unit: WeightUnit): void {
+    if (isPlausibleWeightGrams(grams)) return;
+    const other: WeightUnit = unit === "kg" ? "lb" : "kg";
+    const asOther = toGrams(fromGrams(grams, unit), other);
+    const hint = isPlausibleWeightGrams(asOther)
+        ? ` If you meant ${fromGrams(grams, unit)} ${other}, pass unit: '${other}'.`
+        : "";
+    throw new Error(
+        `${formatWeight(grams, unit)} is outside the plausible body-weight range (20–500 kg / 44–1102 lb). Double-check the number and unit.${hint}`,
+    );
 }
 
 function formatMeal(meal: Meal): string {
@@ -567,7 +626,7 @@ function registerTools(server: McpServer, userId: string) {
         {
             title: "Set Nutrition Goals",
             description:
-                "Set the user's daily calorie and macro targets. Pass only the fields you want to update — omitted fields keep their previous value. Pass null explicitly to clear a target.",
+                "Set the user's daily calorie and macro targets, and optionally a target body weight. Pass only the fields you want to update — omitted fields keep their previous value. Pass null explicitly to clear a target.",
             annotations: {
                 readOnlyHint: false,
                 destructiveHint: false,
@@ -602,13 +661,48 @@ function registerTools(server: McpServer, userId: string) {
                     .describe(
                         "Daily water target (milliliters). Null to clear.",
                     ),
+                target_weight: z.coerce
+                    .number()
+                    .positive()
+                    .nullable()
+                    .optional()
+                    .describe(
+                        "Target body weight in `unit` (defaults to the user's preferred weight unit). Null to clear.",
+                    ),
+                unit: z
+                    .enum(["kg", "lb"])
+                    .optional()
+                    .describe(
+                        "Unit for target_weight. Defaults to the user's preferred weight unit.",
+                    ),
             },
         },
         async (args) => {
             return withAnalytics(
                 "set_nutrition_goals",
                 async () => {
-                    const existing = await getNutritionGoals(userId);
+                    const [existing, preferredUnit] = await Promise.all([
+                        getNutritionGoals(userId),
+                        getPreferredWeightUnit(userId),
+                    ]);
+                    // Only demand a unit when actually writing a numeric target.
+                    let target_weight_g: number | null;
+                    if (args.target_weight === undefined) {
+                        target_weight_g = existing?.target_weight_g ?? null;
+                    } else if (args.target_weight === null) {
+                        target_weight_g = null;
+                    } else {
+                        const writeUnit = await resolveWriteWeightUnit(
+                            userId,
+                            args.unit,
+                        );
+                        target_weight_g = toGrams(
+                            args.target_weight,
+                            writeUnit,
+                        );
+                        assertPlausibleWeight(target_weight_g, writeUnit);
+                    }
+                    const displayUnit = args.unit ?? preferredUnit ?? "kg";
                     const merged = {
                         daily_calories:
                             args.daily_calories === undefined
@@ -630,13 +724,14 @@ function registerTools(server: McpServer, userId: string) {
                             args.daily_water_ml === undefined
                                 ? (existing?.daily_water_ml ?? null)
                                 : args.daily_water_ml,
+                        target_weight_g,
                     };
                     const goals = await upsertNutritionGoals(userId, merged);
                     return {
                         content: [
                             {
                                 type: "text",
-                                text: `Goals updated.\n\n${formatGoals(goals)}`,
+                                text: `Goals updated.\n\n${formatGoals(goals, displayUnit)}`,
                             },
                         ],
                     };
@@ -663,9 +758,17 @@ function registerTools(server: McpServer, userId: string) {
             return withAnalytics(
                 "get_nutrition_goals",
                 async () => {
-                    const goals = await getNutritionGoals(userId);
+                    const [goals, unit] = await Promise.all([
+                        getNutritionGoals(userId),
+                        getPreferredWeightUnit(userId),
+                    ]);
                     return {
-                        content: [{ type: "text", text: formatGoals(goals) }],
+                        content: [
+                            {
+                                type: "text",
+                                text: formatGoals(goals, unit ?? "kg"),
+                            },
+                        ],
                     };
                 },
                 { userId },
@@ -698,15 +801,40 @@ function registerTools(server: McpServer, userId: string) {
                 async () => {
                     const tz = await getUserTimezone(userId);
                     const targetDate = date ?? todayInTz(tz);
-                    const [meals, water, goals] = await Promise.all([
-                        getMealsByDate(userId, targetDate, tz),
-                        getWaterByDate(userId, targetDate, tz),
-                        getNutritionGoals(userId),
-                    ]);
+                    const [meals, water, goals, latestWeight, weightPref] =
+                        await Promise.all([
+                            getMealsByDate(userId, targetDate, tz),
+                            getWaterByDate(userId, targetDate, tz),
+                            getNutritionGoals(userId),
+                            getLatestWeight(userId),
+                            getPreferredWeightUnit(userId),
+                        ]);
+                    const unit = weightPref ?? "kg";
                     const totals = sumMeals(meals);
                     totals.water_ml = sumWater(water);
                     const header = `Progress for ${targetDate} (${meals.length} meal${meals.length === 1 ? "" : "s"}, ${water.length} water entr${water.length === 1 ? "y" : "ies"})`;
                     const body = formatProgress(totals, goals);
+
+                    // Weight is a standing metric (latest overall), not per-date.
+                    let weightLine = "";
+                    if (latestWeight) {
+                        const loggedOn = dateInTz(latestWeight.logged_at, tz);
+                        if (goals?.target_weight_g != null) {
+                            const delta =
+                                latestWeight.weight_g - goals.target_weight_g;
+                            const remaining = fromGrams(Math.abs(delta), unit);
+                            const goalStr =
+                                remaining === 0
+                                    ? "at target"
+                                    : `${remaining} ${unit} ${delta > 0 ? "to lose" : "to gain"}`;
+                            weightLine = `\nWeight: ${formatWeight(latestWeight.weight_g, unit)} / ${formatWeight(goals.target_weight_g, unit)} target (${goalStr}, last logged ${loggedOn})`;
+                        } else {
+                            weightLine = `\nWeight: ${formatWeight(latestWeight.weight_g, unit)} (last logged ${loggedOn})`;
+                        }
+                    } else if (goals?.target_weight_g != null) {
+                        weightLine = `\nWeight: no entries yet (target ${formatWeight(goals.target_weight_g, unit)}). Log one with log_weight.`;
+                    }
+
                     const footer = goals
                         ? ""
                         : "\n\n(Tip: set daily targets with set_nutrition_goals to see progress percentages.)";
@@ -714,7 +842,7 @@ function registerTools(server: McpServer, userId: string) {
                         content: [
                             {
                                 type: "text",
-                                text: `${header}\n${body}${footer}`,
+                                text: `${header}\n${body}${weightLine}${footer}`,
                             },
                         ],
                     };
@@ -1001,6 +1129,536 @@ function registerTools(server: McpServer, userId: string) {
     );
 
     server.registerTool(
+        "log_weight",
+        {
+            title: "Log Weight",
+            description:
+                "Log a body-weight measurement. Provide the number in `weight` and its `unit` ('kg' or 'lb'); if you omit the unit, the user's saved preference is used, and if they have no preference set yet the call fails asking you to specify one. IMPORTANT: do NOT convert units yourself — pass the value in whatever unit the user stated and set `unit` accordingly. The server stores weight canonically and converts as needed. Multiple weigh-ins per day are allowed.",
+            annotations: {
+                readOnlyHint: false,
+                destructiveHint: false,
+                idempotentHint: false,
+                openWorldHint: false,
+            },
+            inputSchema: {
+                weight: z.coerce
+                    .number()
+                    .positive()
+                    .describe("Body weight value, in `unit` (> 0)."),
+                unit: z
+                    .enum(["kg", "lb"])
+                    .optional()
+                    .describe(
+                        "Unit of the weight value. Defaults to the user's preferred weight unit.",
+                    ),
+                logged_at: z
+                    .string()
+                    .optional()
+                    .describe(
+                        "ISO 8601 timestamp (defaults to now). If you don't know the current date or time, ask the user before calling this tool.",
+                    ),
+                notes: z
+                    .string()
+                    .optional()
+                    .describe(
+                        "Optional notes (e.g. 'morning, fasted', 'after workout').",
+                    ),
+                idempotency_key: z
+                    .string()
+                    .min(1)
+                    .max(255)
+                    .optional()
+                    .describe(
+                        "Optional stable key for safe retries. You normally don't need to set this: when omitted, the server derives a stable key from the entry content (including logged_at), so replaying the identical call returns the original entry instead of duplicating it. Pass a UUID only to force-override that behavior.",
+                    ),
+            },
+        },
+        async (args) => {
+            return withAnalytics(
+                "log_weight",
+                async () => {
+                    if (args.logged_at !== undefined)
+                        validateLoggedAt(args.logged_at, Date.now());
+                    const unit = await resolveWriteWeightUnit(
+                        userId,
+                        args.unit,
+                    );
+                    const weight_g = toGrams(args.weight, unit);
+                    assertPlausibleWeight(weight_g, unit);
+                    const { entry, deduplicated } = await insertWeight(userId, {
+                        weight_g,
+                        logged_at: args.logged_at,
+                        notes: args.notes,
+                        idempotency_key: args.idempotency_key,
+                    });
+                    const prefix = deduplicated
+                        ? "Already logged (idempotent retry)"
+                        : "Weight logged";
+                    return {
+                        content: [
+                            {
+                                type: "text",
+                                text: `${prefix}: ${formatWeight(entry.weight_g, unit)} at ${entry.logged_at}${entry.notes ? ` (${entry.notes})` : ""}. ID: ${entry.id}`,
+                            },
+                        ],
+                    };
+                },
+                { userId },
+            );
+        },
+    );
+
+    server.registerTool(
+        "get_weight_today",
+        {
+            title: "Get Today's Weight",
+            description:
+                "Get today's weight entries, shown in the user's preferred unit.",
+            annotations: {
+                readOnlyHint: true,
+                destructiveHint: false,
+                idempotentHint: true,
+                openWorldHint: false,
+            },
+        },
+        async () => {
+            return withAnalytics(
+                "get_weight_today",
+                async () => {
+                    const [tz, weightPref] = await Promise.all([
+                        getUserTimezone(userId),
+                        getPreferredWeightUnit(userId),
+                    ]);
+                    const unit = weightPref ?? "kg";
+                    const entries = await getWeightByDate(
+                        userId,
+                        todayInTz(tz),
+                        tz,
+                    );
+                    if (entries.length === 0) {
+                        return {
+                            content: [
+                                {
+                                    type: "text",
+                                    text: "No weight logged today.",
+                                },
+                            ],
+                        };
+                    }
+                    const lines = entries.map((e) =>
+                        formatWeightEntry(e, unit),
+                    );
+                    return {
+                        content: [
+                            {
+                                type: "text",
+                                text: `Today (${entries.length} entr${entries.length === 1 ? "y" : "ies"}):\n\n${lines.join("\n")}`,
+                            },
+                        ],
+                    };
+                },
+                { userId },
+            );
+        },
+    );
+
+    server.registerTool(
+        "get_weight_by_date",
+        {
+            title: "Get Weight by Date",
+            description:
+                "Get weight entries for a specific date, in the user's preferred unit.",
+            annotations: {
+                readOnlyHint: true,
+                destructiveHint: false,
+                idempotentHint: true,
+                openWorldHint: false,
+            },
+            inputSchema: {
+                date: z.string().describe("Date in YYYY-MM-DD format"),
+            },
+        },
+        async ({ date }) => {
+            return withAnalytics(
+                "get_weight_by_date",
+                async () => {
+                    const [tz, weightPref] = await Promise.all([
+                        getUserTimezone(userId),
+                        getPreferredWeightUnit(userId),
+                    ]);
+                    const unit = weightPref ?? "kg";
+                    const entries = await getWeightByDate(userId, date, tz);
+                    if (entries.length === 0) {
+                        return {
+                            content: [
+                                {
+                                    type: "text",
+                                    text: `No weight logged on ${date}.`,
+                                },
+                            ],
+                        };
+                    }
+                    const lines = entries.map((e) =>
+                        formatWeightEntry(e, unit),
+                    );
+                    return {
+                        content: [
+                            {
+                                type: "text",
+                                text: `${date} (${entries.length} entr${entries.length === 1 ? "y" : "ies"}):\n\n${lines.join("\n")}`,
+                            },
+                        ],
+                    };
+                },
+                { userId },
+                { date },
+            );
+        },
+    );
+
+    server.registerTool(
+        "get_weight_by_date_range",
+        {
+            title: "Get Weight by Date Range",
+            description:
+                "Get all weight entries between two dates (inclusive), grouped by day with each day's average. Use this instead of multiple get_weight_by_date calls.",
+            annotations: {
+                readOnlyHint: true,
+                destructiveHint: false,
+                idempotentHint: true,
+                openWorldHint: false,
+            },
+            inputSchema: {
+                start_date: z.string().describe("Start date (YYYY-MM-DD)"),
+                end_date: z.string().describe("End date (YYYY-MM-DD)"),
+            },
+        },
+        async ({ start_date, end_date }) => {
+            return withAnalytics(
+                "get_weight_by_date_range",
+                async () => {
+                    const [tz, weightPref] = await Promise.all([
+                        getUserTimezone(userId),
+                        getPreferredWeightUnit(userId),
+                    ]);
+                    const unit = weightPref ?? "kg";
+                    const entries = await getWeightInRange(
+                        userId,
+                        start_date,
+                        end_date,
+                        tz,
+                    );
+                    if (entries.length === 0) {
+                        return {
+                            content: [
+                                {
+                                    type: "text",
+                                    text: `No weight found between ${start_date} and ${end_date}.`,
+                                },
+                            ],
+                        };
+                    }
+
+                    const byDate = new Map<string, WeightEntry[]>();
+                    for (const e of entries) {
+                        const date = dateInTz(e.logged_at, tz);
+                        const existing = byDate.get(date) ?? [];
+                        existing.push(e);
+                        byDate.set(date, existing);
+                    }
+
+                    const sections: string[] = [];
+                    for (const [date, dayEntries] of [
+                        ...byDate.entries(),
+                    ].sort()) {
+                        const avgG =
+                            dayEntries.reduce((s, e) => s + e.weight_g, 0) /
+                            dayEntries.length;
+                        const header =
+                            dayEntries.length === 1
+                                ? `## ${date}`
+                                : `## ${date} (avg ${formatWeight(avgG, unit)}, ${dayEntries.length} entries)`;
+                        const formatted = dayEntries
+                            .map((e) => formatWeightEntry(e, unit))
+                            .join("\n");
+                        sections.push(`${header}\n${formatted}`);
+                    }
+
+                    return {
+                        content: [
+                            {
+                                type: "text",
+                                text: sections.join("\n\n"),
+                            },
+                        ],
+                    };
+                },
+                { userId },
+                { start_date, end_date },
+            );
+        },
+    );
+
+    server.registerTool(
+        "get_weight_trends",
+        {
+            title: "Get Weight Trends",
+            description:
+                "Weight trend over a window: latest reading, overall change, 7/14/30-day moving averages (to smooth day-to-day noise), min/max, and progress toward the target weight if one is set. Aggregates multiple weigh-ins per day by averaging. Defaults to the last 30 days ending today.",
+            annotations: {
+                readOnlyHint: true,
+                destructiveHint: false,
+                idempotentHint: true,
+                openWorldHint: false,
+            },
+            inputSchema: {
+                days: z.coerce
+                    .number()
+                    .int()
+                    .min(2)
+                    .max(365)
+                    .optional()
+                    .describe("Window size in days (default 30, max 365)."),
+                end_date: z
+                    .string()
+                    .optional()
+                    .describe("Window end date YYYY-MM-DD (default today)."),
+            },
+        },
+        async ({ days, end_date }) => {
+            return withAnalytics(
+                "get_weight_trends",
+                async () => {
+                    const [tz, weightPref] = await Promise.all([
+                        getUserTimezone(userId),
+                        getPreferredWeightUnit(userId),
+                    ]);
+                    const unit = weightPref ?? "kg";
+                    const endDate = end_date ?? todayInTz(tz);
+                    const windowDays = days ?? 30;
+                    const startDate = shiftLocalDate(
+                        endDate,
+                        -(windowDays - 1),
+                    );
+                    const [entries, goals] = await Promise.all([
+                        getWeightInRange(userId, startDate, endDate, tz),
+                        getNutritionGoals(userId),
+                    ]);
+                    return {
+                        content: [
+                            {
+                                type: "text",
+                                text: computeWeightTrend(
+                                    entries,
+                                    startDate,
+                                    endDate,
+                                    tz,
+                                    goals?.target_weight_g ?? null,
+                                    unit,
+                                ),
+                            },
+                        ],
+                    };
+                },
+                { userId },
+                { days: days ?? 30 },
+            );
+        },
+    );
+
+    server.registerTool(
+        "update_weight",
+        {
+            title: "Update Weight Entry",
+            description:
+                "Update fields of an existing weight entry. Provide `unit` alongside `weight` (defaults to the user's preferred unit); do NOT convert units yourself.",
+            annotations: {
+                readOnlyHint: false,
+                destructiveHint: false,
+                idempotentHint: true,
+                openWorldHint: false,
+            },
+            inputSchema: {
+                id: z.string().describe("UUID of the weight entry to update"),
+                weight: z.coerce
+                    .number()
+                    .positive()
+                    .optional()
+                    .describe("New weight value, in `unit`."),
+                unit: z
+                    .enum(["kg", "lb"])
+                    .optional()
+                    .describe(
+                        "Unit of the weight value. Defaults to the user's preferred weight unit.",
+                    ),
+                logged_at: z.string().optional().describe("ISO 8601 timestamp"),
+                notes: z.string().optional(),
+            },
+        },
+        async ({ id, weight, unit, logged_at, notes }) => {
+            return withAnalytics(
+                "update_weight",
+                async () => {
+                    if (logged_at !== undefined)
+                        validateLoggedAt(logged_at, Date.now());
+                    const patch: {
+                        weight_g?: number;
+                        logged_at?: string;
+                        notes?: string | null;
+                    } = {};
+                    // Only require a unit when a new weight value is supplied;
+                    // otherwise fall back to kg purely for formatting the result.
+                    let displayUnit: WeightUnit;
+                    if (weight !== undefined) {
+                        displayUnit = await resolveWriteWeightUnit(
+                            userId,
+                            unit,
+                        );
+                        patch.weight_g = toGrams(weight, displayUnit);
+                        assertPlausibleWeight(patch.weight_g, displayUnit);
+                    } else {
+                        displayUnit =
+                            unit ??
+                            (await getPreferredWeightUnit(userId)) ??
+                            "kg";
+                    }
+                    if (logged_at !== undefined) patch.logged_at = logged_at;
+                    if (notes !== undefined) patch.notes = notes;
+                    const entry = await updateWeight(userId, id, patch);
+                    return {
+                        content: [
+                            {
+                                type: "text",
+                                text: `Weight updated:\n${formatWeightEntry(entry, displayUnit)}`,
+                            },
+                        ],
+                    };
+                },
+                { userId },
+            );
+        },
+    );
+
+    server.registerTool(
+        "delete_weight",
+        {
+            title: "Delete Weight Entry",
+            description: "Delete a weight log entry by ID.",
+            annotations: {
+                readOnlyHint: false,
+                destructiveHint: true,
+                idempotentHint: true,
+                openWorldHint: false,
+            },
+            inputSchema: {
+                id: z.string().describe("UUID of the weight entry to delete"),
+            },
+        },
+        async ({ id }) => {
+            return withAnalytics(
+                "delete_weight",
+                async () => {
+                    const deleted = await deleteWeight(userId, id);
+                    return {
+                        content: [
+                            {
+                                type: "text",
+                                text: deleted
+                                    ? `Weight entry ${id} deleted.`
+                                    : `No weight entry found with id ${id}.`,
+                            },
+                        ],
+                    };
+                },
+                { userId },
+            );
+        },
+    );
+
+    server.registerTool(
+        "set_weight_unit",
+        {
+            title: "Set Weight Unit",
+            description:
+                "Set the user's preferred weight unit ('kg' or 'lb'), or pass null to clear it. This controls how weights are shown and how a bare number is interpreted when logging without an explicit unit. Stored weights are unaffected (they are canonical) — only display and default parsing change. While unset, logging requires an explicit unit and weights display in kg.",
+            annotations: {
+                readOnlyHint: false,
+                destructiveHint: false,
+                idempotentHint: true,
+                openWorldHint: false,
+            },
+            inputSchema: {
+                unit: z
+                    .enum(["kg", "lb"])
+                    .nullable()
+                    .describe(
+                        "Preferred weight unit: 'kg' or 'lb'. Pass null to clear the preference.",
+                    ),
+            },
+        },
+        async ({ unit }) => {
+            return withAnalytics(
+                "set_weight_unit",
+                async () => {
+                    if (unit !== null && !isWeightUnit(unit)) {
+                        throw new Error(
+                            `Invalid weight unit: ${unit}. Use 'kg', 'lb', or null to clear.`,
+                        );
+                    }
+                    const profile = await upsertProfile(userId, {
+                        preferred_weight_unit: unit,
+                    });
+                    return {
+                        content: [
+                            {
+                                type: "text",
+                                text: profile.preferred_weight_unit
+                                    ? `Preferred weight unit set to ${profile.preferred_weight_unit}.`
+                                    : "Preferred weight unit cleared. Logging will require an explicit unit until you set one, and weights display in kg.",
+                            },
+                        ],
+                    };
+                },
+                { userId },
+            );
+        },
+    );
+
+    server.registerTool(
+        "get_weight_unit",
+        {
+            title: "Get Weight Unit",
+            description:
+                "Get the user's preferred weight unit. Reports if none is set.",
+            annotations: {
+                readOnlyHint: true,
+                destructiveHint: false,
+                idempotentHint: true,
+                openWorldHint: false,
+            },
+        },
+        async () => {
+            return withAnalytics(
+                "get_weight_unit",
+                async () => {
+                    const unit = await getPreferredWeightUnit(userId);
+                    return {
+                        content: [
+                            {
+                                type: "text",
+                                text: unit
+                                    ? `Preferred weight unit: ${unit}.`
+                                    : "No preferred weight unit set. Weights display in kg by default, and logging requires an explicit unit ('kg' or 'lb').",
+                            },
+                        ],
+                    };
+                },
+                { userId },
+            );
+        },
+    );
+
+    server.registerTool(
         "get_trends",
         {
             title: "Get Trends",
@@ -1237,7 +1895,7 @@ function registerTools(server: McpServer, userId: string) {
                             `Invalid timezone: ${timezone}. Use an IANA identifier like 'America/Los_Angeles' or 'Europe/London'.`,
                         );
                     }
-                    const profile = await upsertProfile(userId, timezone);
+                    const profile = await upsertProfile(userId, { timezone });
                     return {
                         content: [
                             {
@@ -1354,7 +2012,7 @@ function buildMcpServer(c: Context, userId: string): McpServer {
     const server = new McpServer(
         {
             name: "nutrition-mcp",
-            version: "1.13.3",
+            version: "1.14.0",
             icons: [
                 {
                     src: `${baseUrl}/favicon.ico`,

--- a/src/supabase.ts
+++ b/src/supabase.ts
@@ -1,6 +1,7 @@
 import { createClient, type SupabaseClient } from "@supabase/supabase-js";
 import { zonedDayStartUtc, zonedNextDayStartUtc } from "./tz.js";
 import { decodeEscapeSequences } from "./normalize.js";
+import { isWeightUnit, type WeightUnit } from "./units.js";
 
 let supabase: SupabaseClient;
 
@@ -296,6 +297,7 @@ export async function updateMeal(
 export interface Profile {
     user_id: string;
     timezone: string;
+    preferred_weight_unit: WeightUnit | null;
     created_at: string;
     updated_at: string;
 }
@@ -316,20 +318,35 @@ export async function getUserTimezone(userId: string): Promise<string> {
     return profile?.timezone ?? "UTC";
 }
 
+// Returns the user's saved weight-unit preference, or null if they have never
+// chosen one. Write paths use null to refuse guessing; display paths coalesce
+// to "kg".
+export async function getPreferredWeightUnit(
+    userId: string,
+): Promise<WeightUnit | null> {
+    const profile = await getProfile(userId);
+    const unit = profile?.preferred_weight_unit;
+    return isWeightUnit(unit) ? unit : null;
+}
+
+// Upsert the fields provided in `patch`, leaving other columns untouched. On
+// first insert, omitted columns fall back to their DB defaults (UTC / kg).
 export async function upsertProfile(
     userId: string,
-    timezone: string,
+    patch: { timezone?: string; preferred_weight_unit?: WeightUnit | null },
 ): Promise<Profile> {
+    const payload: Record<string, unknown> = {
+        user_id: userId,
+        updated_at: new Date().toISOString(),
+    };
+    if (patch.timezone !== undefined) payload.timezone = patch.timezone;
+    // null is meaningful here (clears the preference), so only skip `undefined`.
+    if (patch.preferred_weight_unit !== undefined)
+        payload.preferred_weight_unit = patch.preferred_weight_unit;
+
     const { data, error } = await getSupabase()
         .from("profiles")
-        .upsert(
-            {
-                user_id: userId,
-                timezone,
-                updated_at: new Date().toISOString(),
-            },
-            { onConflict: "user_id" },
-        )
+        .upsert(payload, { onConflict: "user_id" })
         .select()
         .single();
 
@@ -346,6 +363,7 @@ export interface NutritionGoals {
     daily_carbs_g: number | null;
     daily_fat_g: number | null;
     daily_water_ml: number | null;
+    target_weight_g: number | null;
     updated_at: string;
 }
 
@@ -355,6 +373,7 @@ export interface NutritionGoalsInput {
     daily_carbs_g?: number | null;
     daily_fat_g?: number | null;
     daily_water_ml?: number | null;
+    target_weight_g?: number | null;
 }
 
 export async function upsertNutritionGoals(
@@ -371,6 +390,7 @@ export async function upsertNutritionGoals(
                 daily_carbs_g: input.daily_carbs_g ?? null,
                 daily_fat_g: input.daily_fat_g ?? null,
                 daily_water_ml: input.daily_water_ml ?? null,
+                target_weight_g: input.target_weight_g ?? null,
                 updated_at: new Date().toISOString(),
             },
             { onConflict: "user_id" },
@@ -528,6 +548,187 @@ export async function deleteWater(userId: string, id: string): Promise<void> {
     if (error) throw new Error(`Failed to delete water: ${error.message}`);
 }
 
+// ---------- Weight log ----------
+
+export interface WeightEntry {
+    id: string;
+    user_id: string;
+    weight_g: number;
+    logged_at: string;
+    notes: string | null;
+    created_at: string;
+    idempotency_key: string | null;
+}
+
+export interface WeightInput {
+    weight_g: number;
+    logged_at?: string;
+    notes?: string;
+    idempotency_key?: string;
+}
+
+export interface WeightInsertResult {
+    entry: WeightEntry;
+    deduplicated: boolean;
+}
+
+export async function insertWeight(
+    userId: string,
+    input: WeightInput,
+): Promise<WeightInsertResult> {
+    const sb = getSupabase();
+
+    // Resolve logged_at once so the digest and the persisted row agree.
+    const loggedAt = input.logged_at ?? new Date().toISOString();
+    // Always populate the key: use the client's if given, otherwise derive a
+    // stable one from the request content (see deriveIdempotencyKey).
+    const idempotencyKey =
+        input.idempotency_key ??
+        deriveIdempotencyKey([userId, input.weight_g, input.notes, loggedAt]);
+
+    const { data: existing, error: selErr } = await sb
+        .from("weight_log")
+        .select("*")
+        .eq("user_id", userId)
+        .eq("idempotency_key", idempotencyKey)
+        .maybeSingle();
+    if (selErr) throw new Error(`Failed to look up weight: ${selErr.message}`);
+    if (existing) return { entry: existing as WeightEntry, deduplicated: true };
+
+    const { data, error } = await sb
+        .from("weight_log")
+        .insert({
+            user_id: userId,
+            weight_g: input.weight_g,
+            logged_at: loggedAt,
+            notes: input.notes ?? null,
+            idempotency_key: idempotencyKey,
+        })
+        .select()
+        .single();
+
+    if (error) {
+        if (error.code === "23505") {
+            const { data: existing, error: raceErr } = await sb
+                .from("weight_log")
+                .select("*")
+                .eq("user_id", userId)
+                .eq("idempotency_key", idempotencyKey)
+                .maybeSingle();
+            if (raceErr)
+                throw new Error(
+                    `Failed to resolve idempotent weight: ${raceErr.message}`,
+                );
+            if (existing)
+                return {
+                    entry: existing as WeightEntry,
+                    deduplicated: true,
+                };
+        }
+        throw new Error(`Failed to insert weight: ${error.message}`);
+    }
+    return { entry: data as WeightEntry, deduplicated: false };
+}
+
+export async function getWeightByDate(
+    userId: string,
+    date: string,
+    tz: string = "UTC",
+): Promise<WeightEntry[]> {
+    const startUtc = zonedDayStartUtc(date, tz);
+    const endUtc = zonedNextDayStartUtc(date, tz);
+
+    const { data, error } = await getSupabase()
+        .from("weight_log")
+        .select("*")
+        .eq("user_id", userId)
+        .gte("logged_at", startUtc.toISOString())
+        .lt("logged_at", endUtc.toISOString())
+        .order("logged_at", { ascending: true });
+
+    if (error) throw new Error(`Failed to get weight: ${error.message}`);
+    return (data as WeightEntry[]) ?? [];
+}
+
+export async function getWeightInRange(
+    userId: string,
+    startDate: string,
+    endDate: string,
+    tz: string = "UTC",
+): Promise<WeightEntry[]> {
+    const startUtc = zonedDayStartUtc(startDate, tz);
+    const endUtc = zonedNextDayStartUtc(endDate, tz);
+
+    const { data, error } = await getSupabase()
+        .from("weight_log")
+        .select("*")
+        .eq("user_id", userId)
+        .gte("logged_at", startUtc.toISOString())
+        .lt("logged_at", endUtc.toISOString())
+        .order("logged_at", { ascending: true });
+
+    if (error) throw new Error(`Failed to get weight: ${error.message}`);
+    return (data as WeightEntry[]) ?? [];
+}
+
+/** Most recent weight entry overall, or null if none logged. */
+export async function getLatestWeight(
+    userId: string,
+): Promise<WeightEntry | null> {
+    const { data, error } = await getSupabase()
+        .from("weight_log")
+        .select("*")
+        .eq("user_id", userId)
+        .order("logged_at", { ascending: false })
+        .limit(1)
+        .maybeSingle();
+
+    if (error) throw new Error(`Failed to get latest weight: ${error.message}`);
+    return (data as WeightEntry | null) ?? null;
+}
+
+export async function updateWeight(
+    userId: string,
+    id: string,
+    fields: { weight_g?: number; logged_at?: string; notes?: string | null },
+): Promise<WeightEntry> {
+    const update: Record<string, unknown> = {};
+    if (fields.weight_g !== undefined) update.weight_g = fields.weight_g;
+    if (fields.logged_at !== undefined) update.logged_at = fields.logged_at;
+    if (fields.notes !== undefined)
+        update.notes =
+            fields.notes != null
+                ? decodeEscapeSequences(fields.notes)
+                : fields.notes;
+
+    const { data, error } = await getSupabase()
+        .from("weight_log")
+        .update(update)
+        .eq("id", id)
+        .eq("user_id", userId)
+        .select()
+        .single();
+
+    if (error) throw new Error(`Failed to update weight: ${error.message}`);
+    return data as WeightEntry;
+}
+
+/** Returns true if an entry was deleted, false if no matching row was found. */
+export async function deleteWeight(
+    userId: string,
+    id: string,
+): Promise<boolean> {
+    const { data, error } = await getSupabase()
+        .from("weight_log")
+        .delete()
+        .eq("id", id)
+        .eq("user_id", userId)
+        .select("id");
+
+    if (error) throw new Error(`Failed to delete weight: ${error.message}`);
+    return (data?.length ?? 0) > 0;
+}
+
 // ---------- Delete all user data ----------
 
 export async function deleteAllUserData(userId: string): Promise<void> {
@@ -546,6 +747,13 @@ export async function deleteAllUserData(userId: string): Promise<void> {
         .eq("user_id", userId);
     if (waterErr)
         throw new Error(`Failed to delete water log: ${waterErr.message}`);
+
+    const { error: weightErr } = await sb
+        .from("weight_log")
+        .delete()
+        .eq("user_id", userId);
+    if (weightErr)
+        throw new Error(`Failed to delete weight log: ${weightErr.message}`);
 
     const { error: goalsErr } = await sb
         .from("nutrition_goals")

--- a/src/tz.test.ts
+++ b/src/tz.test.ts
@@ -8,6 +8,7 @@ import {
     zonedDayStartUtc,
     zonedNextDayStartUtc,
     shiftLocalDate,
+    validateLoggedAt,
 } from "./tz.js";
 
 test("dateInTz maps an instant to the local calendar day", () => {
@@ -63,6 +64,24 @@ test("zonedNextDayStartUtc is the exclusive upper bound", () => {
 test("shiftLocalDate does calendar arithmetic across month boundaries", () => {
     expect(shiftLocalDate("2024-02-28", 1)).toBe("2024-02-29"); // leap year
     expect(shiftLocalDate("2024-03-01", -1)).toBe("2024-02-29");
+});
+
+test("validateLoggedAt accepts past/now and rejects future & invalid", () => {
+    const now = Date.parse("2026-07-02T12:00:00Z");
+    // past and present are fine
+    expect(() => validateLoggedAt("2026-07-01T12:00:00Z", now)).not.toThrow();
+    expect(() => validateLoggedAt("2026-07-02T12:00:00Z", now)).not.toThrow();
+    // within the 5-minute skew tolerance
+    expect(() => validateLoggedAt("2026-07-02T12:04:00Z", now)).not.toThrow();
+    // beyond tolerance -> future
+    expect(() => validateLoggedAt("2026-07-02T12:30:00Z", now)).toThrow(
+        /future/,
+    );
+    expect(() => validateLoggedAt("2027-01-01T00:00:00Z", now)).toThrow(
+        /future/,
+    );
+    // unparseable
+    expect(() => validateLoggedAt("not-a-date", now)).toThrow(/Invalid/);
 });
 
 test("validateTz accepts IANA names and rejects junk", () => {

--- a/src/tz.ts
+++ b/src/tz.ts
@@ -132,6 +132,30 @@ export function zonedNextDayStartUtc(date: string, tz: string): Date {
     return zonedDayStartUtc(nextStr, tz);
 }
 
+/**
+ * Validate a client-supplied `logged_at` ISO string: it must parse, and must
+ * not be in the future beyond a small clock-skew tolerance. Prevents a
+ * mis-dated entry from silently becoming the user's "latest" reading. `nowMs`
+ * is injected for testability.
+ */
+export function validateLoggedAt(
+    iso: string,
+    nowMs: number,
+    toleranceMs: number = 5 * 60 * 1000,
+): void {
+    const t = new Date(iso).getTime();
+    if (Number.isNaN(t)) {
+        throw new Error(
+            `Invalid logged_at timestamp: ${iso}. Use an ISO 8601 string.`,
+        );
+    }
+    if (t > nowMs + toleranceMs) {
+        throw new Error(
+            `logged_at is in the future (${iso}). Log the time the measurement was actually taken.`,
+        );
+    }
+}
+
 /** Shift a local YYYY-MM-DD date by N days, returning YYYY-MM-DD. No TZ needed. */
 export function shiftLocalDate(date: string, days: number): string {
     const [y, m, d] = date.split("-").map(Number);

--- a/src/units.test.ts
+++ b/src/units.test.ts
@@ -1,0 +1,98 @@
+import { test, expect } from "bun:test";
+import {
+    toGrams,
+    fromGrams,
+    formatWeight,
+    isWeightUnit,
+    pickWriteUnit,
+    isPlausibleWeightGrams,
+    WEIGHT_UNITS,
+} from "./units.js";
+
+test("toGrams converts kg to integer grams", () => {
+    expect(toGrams(75, "kg")).toBe(75000);
+    expect(toGrams(75.5, "kg")).toBe(75500);
+    expect(toGrams(0.1, "kg")).toBe(100);
+});
+
+test("toGrams converts lb to integer grams using the exact pound", () => {
+    // 1 lb = 453.59237 g -> rounds to 454
+    expect(toGrams(1, "lb")).toBe(454);
+    // 165 lb = 74842.74 g
+    expect(toGrams(165, "lb")).toBe(74843);
+    expect(toGrams(200, "lb")).toBe(90718);
+});
+
+test("fromGrams converts grams back, rounded to 1 decimal", () => {
+    expect(fromGrams(75000, "kg")).toBe(75);
+    expect(fromGrams(75500, "kg")).toBe(75.5);
+    expect(fromGrams(75540, "kg")).toBe(75.5);
+    expect(fromGrams(454, "lb")).toBe(1);
+});
+
+test("kg round-trips through grams exactly at 1-decimal precision", () => {
+    for (const kg of [50, 62.3, 75.5, 90.1, 120.9]) {
+        expect(fromGrams(toGrams(kg, "kg"), "kg")).toBe(kg);
+    }
+});
+
+test("lb round-trips through grams at 1-decimal precision", () => {
+    for (const lb of [110, 154.3, 165, 200.7]) {
+        expect(fromGrams(toGrams(lb, "lb"), "lb")).toBe(lb);
+    }
+});
+
+test("lb->kg reference conversion is correct", () => {
+    // 165 lb -> stored grams -> read as kg ~= 74.8
+    const grams = toGrams(165, "lb");
+    expect(fromGrams(grams, "kg")).toBe(74.8);
+});
+
+test("toGrams rejects non-finite values", () => {
+    expect(() => toGrams(NaN, "kg")).toThrow();
+    expect(() => toGrams(Infinity, "kg")).toThrow();
+});
+
+test("formatWeight renders unit-suffixed string", () => {
+    expect(formatWeight(75500, "kg")).toBe("75.5 kg");
+    expect(formatWeight(74843, "lb")).toBe("165 lb");
+});
+
+test("pickWriteUnit prefers the explicit unit over the saved preference", () => {
+    expect(pickWriteUnit("lb", "kg")).toBe("lb");
+    expect(pickWriteUnit("kg", "lb")).toBe("kg");
+});
+
+test("pickWriteUnit falls back to the saved preference when no explicit unit", () => {
+    expect(pickWriteUnit(undefined, "lb")).toBe("lb");
+    expect(pickWriteUnit(undefined, "kg")).toBe("kg");
+});
+
+test("pickWriteUnit throws when no explicit unit and no preference (never guesses)", () => {
+    expect(() => pickWriteUnit(undefined, null)).toThrow(
+        /No weight unit given and no preference set/,
+    );
+});
+
+test("isPlausibleWeightGrams accepts human weights and rejects magnitude errors", () => {
+    expect(isPlausibleWeightGrams(toGrams(75, "kg"))).toBe(true);
+    expect(isPlausibleWeightGrams(toGrams(165, "lb"))).toBe(true);
+    expect(isPlausibleWeightGrams(toGrams(20, "kg"))).toBe(true); // floor
+    expect(isPlausibleWeightGrams(toGrams(500, "kg"))).toBe(true); // ceiling
+    // value typed in grams (75000 "kg")
+    expect(isPlausibleWeightGrams(toGrams(75000, "kg"))).toBe(false);
+    // extra digit
+    expect(isPlausibleWeightGrams(toGrams(750, "kg"))).toBe(false);
+    // sub-unit typo rounding to 0 g (covers the >0 DB check case)
+    expect(isPlausibleWeightGrams(toGrams(0.0001, "kg"))).toBe(false);
+    expect(isPlausibleWeightGrams(NaN)).toBe(false);
+});
+
+test("isWeightUnit guards kg/lb only", () => {
+    expect(isWeightUnit("kg")).toBe(true);
+    expect(isWeightUnit("lb")).toBe(true);
+    expect(isWeightUnit("st")).toBe(false);
+    expect(isWeightUnit("")).toBe(false);
+    expect(isWeightUnit(undefined)).toBe(false);
+    for (const u of WEIGHT_UNITS) expect(isWeightUnit(u)).toBe(true);
+});

--- a/src/units.ts
+++ b/src/units.ts
@@ -1,0 +1,70 @@
+// Weight unit handling. Weight is stored canonically as integer grams; these
+// pure helpers convert between grams and the user-facing units (kg / lb) so all
+// conversion happens server-side rather than being delegated to the model.
+
+export type WeightUnit = "kg" | "lb";
+
+export const WEIGHT_UNITS: readonly WeightUnit[] = ["kg", "lb"];
+
+const GRAMS_PER_KG = 1000;
+const GRAMS_PER_LB = 453.59237; // international avoirdupois pound (exact)
+
+// Plausible human body-weight range, used to reject gross entry errors (values
+// typed in grams, an extra digit, or a sub-unit typo). Note this cannot catch a
+// kg/lb swap within the human overlap (e.g. 80 kg vs 80 lb are both plausible) —
+// the unit preference / explicit-unit rules guard that; this is the backstop for
+// magnitude mistakes.
+export const MIN_PLAUSIBLE_WEIGHT_G = 20_000; // 20 kg / ~44 lb
+export const MAX_PLAUSIBLE_WEIGHT_G = 500_000; // 500 kg / ~1102 lb
+
+export function isPlausibleWeightGrams(grams: number): boolean {
+    return (
+        Number.isFinite(grams) &&
+        grams >= MIN_PLAUSIBLE_WEIGHT_G &&
+        grams <= MAX_PLAUSIBLE_WEIGHT_G
+    );
+}
+
+export function isWeightUnit(x: unknown): x is WeightUnit {
+    return x === "kg" || x === "lb";
+}
+
+/** Convert a value in the given unit to canonical integer grams (rounded). */
+export function toGrams(value: number, unit: WeightUnit): number {
+    if (!Number.isFinite(value)) {
+        throw new Error(`Invalid weight value: ${value}`);
+    }
+    const grams = unit === "kg" ? value * GRAMS_PER_KG : value * GRAMS_PER_LB;
+    return Math.round(grams);
+}
+
+/** Convert canonical grams to the given unit, rounded to 1 decimal place. */
+export function fromGrams(grams: number, unit: WeightUnit): number {
+    const value = unit === "kg" ? grams / GRAMS_PER_KG : grams / GRAMS_PER_LB;
+    return Math.round(value * 10) / 10;
+}
+
+/** Format canonical grams as a display string in the given unit, e.g. "75.5 kg". */
+export function formatWeight(grams: number, unit: WeightUnit): string {
+    return `${fromGrams(grams, unit)} ${unit}`;
+}
+
+/**
+ * Choose the unit for a WRITE (logging/updating a weight, setting a target):
+ * an explicit unit wins, otherwise the user's saved preference. Throws if
+ * neither exists rather than guessing — silently assuming kg for someone who
+ * meant lb is exactly the mis-log this module exists to prevent. Display paths
+ * should instead coalesce a missing preference to "kg".
+ */
+export function pickWriteUnit(
+    explicit: WeightUnit | undefined,
+    preference: WeightUnit | null,
+): WeightUnit {
+    const unit = explicit ?? preference;
+    if (!unit) {
+        throw new Error(
+            "No weight unit given and no preference set. Pass unit ('kg' or 'lb'), or set a default first with set_weight_unit.",
+        );
+    }
+    return unit;
+}

--- a/supabase/migrations/20260702120000_weight_tracking.sql
+++ b/supabase/migrations/20260702120000_weight_tracking.sql
@@ -1,0 +1,40 @@
+-- Body weight tracking. One row per weigh-in (multiple entries per day are
+-- allowed); trends aggregate by daily average. Weight is stored canonically as
+-- integer grams so kg/lb conversion happens server-side without float drift.
+create table if not exists public.weight_log (
+    id uuid primary key default gen_random_uuid(),
+    user_id uuid not null references auth.users(id) on delete cascade,
+    weight_g integer not null check (weight_g > 0),
+    logged_at timestamptz not null default now(),
+    notes text,
+    created_at timestamptz not null default now(),
+    idempotency_key text
+);
+
+create index if not exists idx_weight_log_user_id on public.weight_log (user_id);
+create index if not exists idx_weight_log_logged_at on public.weight_log (logged_at);
+
+create unique index if not exists uniq_weight_log_user_idem
+    on public.weight_log (user_id, idempotency_key)
+    where idempotency_key is not null;
+
+alter table public.weight_log enable row level security;
+
+create policy "Users manage their own weight_log"
+    on public.weight_log
+    for all
+    using (auth.uid() = user_id)
+    with check (auth.uid() = user_id);
+
+-- Per-user preferred display unit for weight. Storage stays canonical grams;
+-- this only controls how weights are formatted on output and how a bare number
+-- is parsed on input. Deliberately nullable with NO default: NULL means "never
+-- chosen", which lets write paths refuse to guess a unit (and mis-log kg as lb)
+-- instead of silently assuming one. Display paths fall back to kg.
+alter table public.profiles
+    add column if not exists preferred_weight_unit text
+        check (preferred_weight_unit is null or preferred_weight_unit in ('kg', 'lb'));
+
+-- Optional target body weight, stored canonically in grams.
+alter table public.nutrition_goals
+    add column if not exists target_weight_g integer check (target_weight_g > 0);


### PR DESCRIPTION
## Summary

Adds **weight management** to the MCP server: log body weight, read it back, see trends toward a target — and fixes weight-unit handling so kg/lb conversion happens **server-side** instead of being delegated to the model.

## What's included

**New tools (9):** `log_weight`, `get_weight_today`, `get_weight_by_date`, `get_weight_by_date_range`, `get_weight_trends`, `update_weight`, `delete_weight`, `set_weight_unit`, `get_weight_unit`. Existing `set_nutrition_goals` / `get_nutrition_goals` / `get_goal_progress` extended for a target weight with progress.

**Units, done right.** Weight is stored canonically as **integer grams**. A per-user `preferred_weight_unit` (`kg`/`lb`) lives on `profiles`; pure, tested conversion helpers (`src/units.ts`) handle kg/lb ⇄ grams. The `log_weight` description explicitly tells the model **not** to convert.

**Fail-loud on ambiguity.** `preferred_weight_unit` is nullable (NULL = never chosen). If a write gives no explicit unit and no preference exists, the call errors asking for one rather than silently assuming kg — the exact mis-log this feature exists to prevent. Display paths fall back to kg.

**Guards.**
- Plausibility range (20–500 kg equiv.) rejects magnitude mistakes (grams typed as kg, extra digit, sub-unit typo), with a "did you mean lb?" hint.
- `logged_at` is validated — no unparseable or future timestamps (which would otherwise become the permanent "current weight").
- `delete_weight` reports *not found* instead of a false success.

**Trends.** `computeWeightTrend` aggregates weigh-ins by daily average (multiple per day allowed), then reports latest, overall change, 7/14/30-day moving averages, min/max, and goal delta.

**Housekeeping.** `deleteAllUserData` clears `weight_log` (GDPR); version bumped to `1.14.0` in all three places.

## Migration

`supabase/migrations/20260702120000_weight_tracking.sql` — `weight_log` table (RLS + per-user policy, indexes, idempotency), nullable `profiles.preferred_weight_unit`, and `nutrition_goals.target_weight_g`. **Already applied to the production project** and verified (table present with RLS + policy; no new security advisories).

## Testing

- `bun test` — 52 pass / 0 fail (7 files). New pure tests cover unit conversion, fail-loud unit resolution, plausibility bounds, `validateLoggedAt`, and `computeWeightTrend`.
- `src/` typechecks clean.
- Registration smoke test: 30 tools, all 9 weight tools register.

## Deploy notes

Remote MCP server — merging doesn't make it live. Deploy to DigitalOcean to activate the tools, then tag `v1.14.0` to refresh the registry (the migration is already applied, so the tools have their table).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
