### PR TITLE
Reject GET/DELETE on /mcp with 405 (kill the deploy-wedge SSE stream)

### DIFF
--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -2031,10 +2031,34 @@ function buildMcpServer(c: Context, userId: string): McpServer {
 // transport + McpServer and tears it down when the response completes (the SDK
 // forbids reusing a stateless transport). Because nothing is kept in-process, a
 // restart/deploy can never strand a connected client — there is no session to
-// lose, and therefore no reconnect step for a client to wedge on. The trade-off
-// is no server-initiated streaming (standalone GET SSE / notifications), which
-// this server does not use.
+// lose, and therefore no reconnect step for a client to wedge on.
+//
+// Only POST (JSON-RPC request/response) is served. We reject GET and DELETE
+// with 405 instead of delegating to the transport, because a GET would open a
+// long-lived standalone SSE stream — and that stream is the one piece of state
+// a deploy still severs. Since stateless mode never pushes server-initiated
+// messages, that stream carries nothing; the only thing it does is die on every
+// restart and leave some clients (observed: a Claude connector) wedged in a
+// "connected but no tools" state. Refusing the stream (spec-allowed: a server
+// MAY return 405 when it offers no SSE stream at this endpoint) means the client
+// holds nothing that a deploy can break, so updates become truly invisible.
 export const handleMcp = async (c: Context) => {
+    if (c.req.method !== "POST") {
+        return c.json(
+            {
+                jsonrpc: "2.0",
+                id: null,
+                error: {
+                    code: -32000,
+                    message:
+                        "Method Not Allowed: this endpoint serves POST only and offers no SSE stream",
+                },
+            },
+            405,
+            { Allow: "POST" },
+        );
+    }
+
     const userId = c.get("userId") as string;
 
     const transport = new WebStandardStreamableHTTPServerTransport({


### PR DESCRIPTION
## Problem

The stateless change (#29) removed the POST-side deploy wedge — a stale `Mcp-Session-Id` no longer gets a `404`. But a user still wedged across the July 2 deploys **with stateless live**: connector connected, tools silently unavailable, recovered only after re-adding.

Root cause (found in prod logs + SDK source): in stateless mode a `GET /mcp` still opens a **long-lived standalone SSE stream** (`GET /mcp 200` in the logs). That stream carries nothing — stateless mode never pushes server-initiated messages — but it **dies on every server restart**, and its death leaves some clients (observed: a Claude connector) wedged in a "connected but no tools" state.

## Change

Serve **POST only**. Return `405 Allow: POST` for `GET` and `DELETE`, before building a transport, so no standalone SSE stream is ever opened. The MCP spec permits a server to return `405` when it offers no SSE stream at the endpoint. With no stream held, a client keeps nothing a deploy can sever — updates become invisible to it.

## Verification

- In-process: `GET`/`DELETE` → `405 (Allow: POST)`; `POST tools/list` → `200`, 30 tools, no session id.
- `src/` typechecks clean; 52/52 tests pass.
- Verified in MCP Inspector against a real account (the affected user): tools list + execute normally, and the connection **survives a mid-session server restart with no reconnect/wedge**.

## Notes

- Complements #29; does not change the POST request/response path.
- Rollback is a redeploy of the previous commit.
- Remember the version bump (`package.json`, `src/mcp.ts`, `server.json`) when cutting the release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)