### PR TITLE
fix(foods): don't cache Open Food Facts stub products with no macros

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "nutrition-mcp",
-    "version": "1.14.1",
+    "version": "1.14.2",
     "description": "A remote MCP server for personal nutrition tracking. Log meals, track macros, and review nutrition history through Claude.",
     "author": "akutishevsky",
     "license": "MIT",

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
     "name": "io.github.akutishevsky/nutrition-mcp",
     "title": "Nutrition MCP",
     "description": "Personal nutrition tracking — log meals, track macros, and review history through conversation.",
-    "version": "1.14.1",
+    "version": "1.14.2",
     "websiteUrl": "https://nutrition-mcp.com/",
     "repository": {
         "url": "https://github.com/akutishevsky/nutrition-mcp",

--- a/src/foods.test.ts
+++ b/src/foods.test.ts
@@ -126,16 +126,32 @@ describe("fetchProductFromOFF", () => {
         );
     });
 
-    test("missing nutriments yield null macros but keep the name", async () => {
+    test("treats a stub product with no macros as not found (no empty cache)", async () => {
+        // OFF returns status 1 for entries that exist but carry no nutriments.
+        // We must report a miss so the caller can fall back to estimation and
+        // no empty record is cached.
         mockFetch(() =>
             jsonResponse({
                 status: 1,
                 product: { product_name: "Mystery Snack" },
             }),
         );
+        expect(await fetchProductFromOFF("737628064502")).toBeNull();
+    });
+
+    test("keeps a product that has at least one macro even if others are null", async () => {
+        mockFetch(() =>
+            jsonResponse({
+                status: 1,
+                product: {
+                    product_name: "Just Calories",
+                    nutriments: { "energy-kcal_100g": 250 },
+                },
+            }),
+        );
         const food = await fetchProductFromOFF("737628064502");
-        expect(food!.name).toBe("Mystery Snack");
-        expect(food!.calories).toBeNull();
+        expect(food!.name).toBe("Just Calories");
+        expect(food!.calories).toBe(250);
         expect(food!.protein_g).toBeNull();
     });
 

--- a/src/foods.ts
+++ b/src/foods.ts
@@ -113,7 +113,22 @@ export async function fetchProductFromOFF(
         product?: OFFProduct;
     };
     if (!body || body.status === 0 || !body.product) return null;
-    return normalizeOFFProduct(body.product, barcode);
+
+    const food = normalizeOFFProduct(body.product, barcode);
+    // Open Food Facts is full of "stub" products: an entry exists (status 1,
+    // sometimes even a name) but carries no nutriments at all. That is a miss
+    // for our purposes — returning it would report the product as "found" with
+    // every macro n/a (suppressing the caller's estimation fallback) and pin a
+    // useless record in the cache for the full TTL. Treat it as not found.
+    if (
+        food.calories == null &&
+        food.protein_g == null &&
+        food.carbs_g == null &&
+        food.fat_g == null
+    ) {
+        return null;
+    }
+    return food;
 }
 
 // ---------- Cache ----------

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -2012,7 +2012,7 @@ function buildMcpServer(c: Context, userId: string): McpServer {
     const server = new McpServer(
         {
             name: "nutrition-mcp",
-            version: "1.14.1",
+            version: "1.14.2",
             icons: [
                 {
                     src: `${baseUrl}/favicon.ico`,


### PR DESCRIPTION
## Problem

Barcode lookups cache an empty record when Open Food Facts has no real data for a product.

For a genuinely unknown barcode OFF returns `status: 0` and we correctly return `null` (no caching). But OFF is full of **stub products**: entries that exist (`status: 1`, sometimes with a name) yet carry **no `nutriments`**. `normalizeOFFProduct` turned those into a truthy `FoodResult` with a name and **all four macros `null`**, so `lookupBarcode` cached the useless record for the full 7-day TTL.

Two consequences:
1. `lookup_barcode` reported the product as "found" with every macro `n/a`, suppressing the model's fallback to estimation — defeating the point of the lookup.
2. The empty record was pinned in the cache for a week, so a later OFF update wouldn't be picked up.

Production `food_cache` confirmed it: 2 of 41 rows had all-null macros (`Le Choco`, `Miel l'apiculteur Fleurs`). Those rows have been deleted.

## Fix

`fetchProductFromOFF` now treats a product with no usable macros (all of calories/protein/carbs/fat null) as a **miss** and returns `null`. Nothing gets cached and `lookup_barcode` falls back to estimation. Products with at least one macro are unaffected.

- `src/foods.ts` — return null for macro-less stub products
- `src/foods.test.ts` — updated the stub-product test to assert not-found; added a test that a calories-only product is still kept
- Version bumped 1.14.1 → 1.14.2 (`package.json`, `server.json`, `src/mcp.ts`)

All 53 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)