### PR TITLE
feat: rate-limit the OAuth/auth endpoints (v1.15.0)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "nutrition-mcp",
-    "version": "1.14.2",
+    "version": "1.15.0",
     "description": "A remote MCP server for personal nutrition tracking. Log meals, track macros, and review nutrition history through Claude.",
     "author": "akutishevsky",
     "license": "MIT",

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
     "name": "io.github.akutishevsky/nutrition-mcp",
     "title": "Nutrition MCP",
     "description": "Personal nutrition tracking — log meals, track macros, and review history through conversation.",
-    "version": "1.14.2",
+    "version": "1.15.0",
     "websiteUrl": "https://nutrition-mcp.com/",
     "repository": {
         "url": "https://github.com/akutishevsky/nutrition-mcp",

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -2012,7 +2012,7 @@ function buildMcpServer(c: Context, userId: string): McpServer {
     const server = new McpServer(
         {
             name: "nutrition-mcp",
-            version: "1.14.2",
+            version: "1.15.0",
             icons: [
                 {
                     src: `${baseUrl}/favicon.ico`,

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,6 +1,20 @@
 import type { Context, Next } from "hono";
 import { getUserIdByToken } from "./supabase.js";
-import { checkRateLimit } from "./rate-limit.js";
+import { checkRateLimit, checkAuthRateLimit } from "./rate-limit.js";
+
+// Best-effort client IP for rate limiting. Behind DigitalOcean's proxy the real
+// IP is the first entry of x-forwarded-for; fall back to x-real-ip. "unknown"
+// only applies when no proxy header is present (e.g. direct local requests), in
+// which case those callers share a single bucket — acceptable since production
+// always sits behind the proxy.
+function getClientIp(c: Context): string {
+    const forwardedFor = c.req.header("x-forwarded-for");
+    if (forwardedFor) {
+        const first = forwardedFor.split(",")[0]?.trim();
+        if (first) return first;
+    }
+    return c.req.header("x-real-ip")?.trim() || "unknown";
+}
 
 function getBaseUrl(c: Context): string {
     const proto = c.req.header("x-forwarded-proto") || "http";
@@ -49,6 +63,25 @@ export const authenticateBearer = async (c: Context, next: Next) => {
 
     c.set("accessToken", token);
     c.set("userId", userId);
+    await next();
+};
+
+// Per-IP rate limiter for the unauthenticated OAuth endpoints, where there is
+// no user id yet. Guards against bulk signups and credential stuffing.
+export const rateLimitAuth = async (c: Context, next: Next) => {
+    const result = checkAuthRateLimit(getClientIp(c));
+    c.header("X-RateLimit-Limit", String(result.limit));
+    c.header("X-RateLimit-Remaining", String(result.remaining));
+    if (!result.allowed) {
+        c.header("Retry-After", String(result.retryAfterSeconds ?? 60));
+        return c.json(
+            {
+                error: "rate_limited",
+                error_description: `Rate limit exceeded (${result.limit} requests per minute). Retry after ${result.retryAfterSeconds}s.`,
+            },
+            429,
+        );
+    }
     await next();
 };
 

--- a/src/oauth.ts
+++ b/src/oauth.ts
@@ -12,6 +12,7 @@ import {
     registerClient,
 } from "./supabase.js";
 import { getBaseUrl } from "./url.js";
+import { rateLimitAuth } from "./middleware.js";
 
 const SESSION_TTL_MS = 10 * 60 * 1000;
 
@@ -97,6 +98,11 @@ async function finishAuthorization(
 
 export function createOAuthRouter() {
     const oauth = new Hono();
+
+    // Per-IP rate limit across all OAuth endpoints — these are unauthenticated,
+    // so this is the only throttle standing between the internet and signup /
+    // sign-in / token issuance.
+    oauth.use("*", rateLimitAuth);
 
     const clientId = process.env.OAUTH_CLIENT_ID;
     const clientSecret = process.env.OAUTH_CLIENT_SECRET;

--- a/src/rate-limit.ts
+++ b/src/rate-limit.ts
@@ -1,21 +1,30 @@
-// In-memory sliding-window rate limiter, keyed by user id. Fine for the
-// current single-instance deployment; swap for a shared store if we ever
-// scale horizontally.
+// In-memory sliding-window rate limiter. Fine for the current single-instance
+// deployment; swap for a shared store if we ever scale horizontally.
 
 const WINDOW_MS = 60_000;
+// Per-user limit for authenticated MCP traffic, keyed by user id.
 const LIMIT_PER_WINDOW = 60;
+// Tighter per-IP limit for the unauthenticated OAuth endpoints. Users have no
+// user id yet at this stage, so we key on client IP. A full login flow is only
+// a handful of requests (authorize → approve → token), so this leaves ample
+// headroom for legitimate use — even shared NAT'd IPs — while blocking bulk
+// signup/credential-stuffing abuse.
+const AUTH_LIMIT_PER_WINDOW = 30;
 const SWEEP_INTERVAL_MS = 5 * 60_000;
 
 const buckets = new Map<string, number[]>();
+const authBuckets = new Map<string, number[]>();
 
 // Periodically drop buckets whose newest entry is older than the window, so
-// a user who stops making requests doesn't keep a slot in the Map forever.
+// a caller who stops making requests doesn't keep a slot in the Map forever.
 setInterval(() => {
     const cutoff = Date.now() - WINDOW_MS;
-    for (const [key, timestamps] of buckets) {
-        const last = timestamps[timestamps.length - 1];
-        if (last == null || last < cutoff) {
-            buckets.delete(key);
+    for (const map of [buckets, authBuckets]) {
+        for (const [key, timestamps] of map) {
+            const last = timestamps[timestamps.length - 1];
+            if (last == null || last < cutoff) {
+                map.delete(key);
+            }
         }
     }
 }, SWEEP_INTERVAL_MS);
@@ -27,10 +36,15 @@ export interface RateLimitResult {
     limit: number;
 }
 
-export function checkRateLimit(userId: string): RateLimitResult {
+// Shared sliding-window check against a given bucket store and limit.
+function slidingWindow(
+    store: Map<string, number[]>,
+    key: string,
+    limit: number,
+): RateLimitResult {
     const now = Date.now();
     const cutoff = now - WINDOW_MS;
-    const existing = buckets.get(userId) ?? [];
+    const existing = store.get(key) ?? [];
 
     // Trim in place: keep only entries within the window.
     let keepFrom = 0;
@@ -39,31 +53,41 @@ export function checkRateLimit(userId: string): RateLimitResult {
     }
     const trimmed = keepFrom === 0 ? existing : existing.slice(keepFrom);
 
-    if (trimmed.length >= LIMIT_PER_WINDOW) {
+    if (trimmed.length >= limit) {
         const oldest = trimmed[0]!;
         const retryAfterSeconds = Math.max(
             1,
             Math.ceil((oldest + WINDOW_MS - now) / 1000),
         );
-        buckets.set(userId, trimmed);
+        store.set(key, trimmed);
         return {
             allowed: false,
             retryAfterSeconds,
             remaining: 0,
-            limit: LIMIT_PER_WINDOW,
+            limit,
         };
     }
 
     trimmed.push(now);
-    buckets.set(userId, trimmed);
+    store.set(key, trimmed);
     return {
         allowed: true,
-        remaining: LIMIT_PER_WINDOW - trimmed.length,
-        limit: LIMIT_PER_WINDOW,
+        remaining: limit - trimmed.length,
+        limit,
     };
+}
+
+export function checkRateLimit(userId: string): RateLimitResult {
+    return slidingWindow(buckets, userId, LIMIT_PER_WINDOW);
+}
+
+// Per-IP limiter for the unauthenticated OAuth endpoints.
+export function checkAuthRateLimit(ip: string): RateLimitResult {
+    return slidingWindow(authBuckets, ip, AUTH_LIMIT_PER_WINDOW);
 }
 
 // Exposed for tests.
 export function _resetBuckets(): void {
     buckets.clear();
+    authBuckets.clear();
 }


### PR DESCRIPTION
## Summary

Adds per-IP rate limiting to the unauthenticated OAuth endpoints. Previously only `/mcp` was throttled (keyed by user id); the auth surface — including signup and token issuance — had no limit, leaving the door open to bulk signups and credential stuffing.

## Changes

- **`src/rate-limit.ts`** — Refactor the sliding-window core into a shared `slidingWindow()` helper and add `checkAuthRateLimit(ip)`, a second limiter keyed by client IP at **30 req/min**. The periodic sweep and `_resetBuckets()` now cover both bucket maps.
- **`src/middleware.ts`** — Add `getClientIp()` (`x-forwarded-for` first entry → `x-real-ip` fallback, matching DigitalOcean's proxy) and a `rateLimitAuth` middleware returning `429` with `Retry-After` / `X-RateLimit-*` headers, mirroring the existing `rateLimit`.
- **`src/oauth.ts`** — Apply `rateLimitAuth` across the whole OAuth router: `/register`, `/authorize`, `/approve`, `/authorize/google`, `/auth/google/callback`, `/token`.
- **Version** — Bump to `1.15.0` in `package.json`, `server.json`, and `src/mcp.ts`.

## Rationale

- **30/min per IP**: a full login flow is only ~3 requests (`authorize → approve → token`), so this leaves generous headroom for legitimate use — even NAT'd/shared IPs — while blocking bulk abuse. Tunable via `AUTH_LIMIT_PER_WINDOW`.
- **Router-wide** rather than just `/approve`: `/token` and the Google paths are also unauthenticated attack surface.

## Verification

- `bun test` → 53 pass, 0 fail
- `tsc --noEmit` → clean for all touched files (pre-existing `scripts/gen-map-data.ts` errors unrelated)
- Runtime check: 31st request from one IP is blocked; a second IP has an independent bucket.

## Notes

Like the existing user-id limiter, this is in-memory and single-instance — consistent with the current DigitalOcean deployment. If we ever scale horizontally, both limiters would need a shared store (e.g. `Bun.redis`).

Post-merge: push a matching `v1.15.0` tag to refresh the MCP Registry listing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)