### PR TITLE
feat(tools): search_meals + guided photo-based meal logging

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "nutrition-mcp",
-    "version": "1.17.0",
+    "version": "1.18.0",
     "description": "A remote MCP server for personal nutrition tracking. Log meals, track macros, and review nutrition history through Claude.",
     "author": "akutishevsky",
     "license": "MIT",

--- a/public/tools.html
+++ b/public/tools.html
@@ -458,7 +458,7 @@
                     </p>
                     <span class="count-pill"
                         ><i class="fa-solid fa-wrench" aria-hidden="true"></i
-                        ><b>30 tools</b> across 7 areas</span
+                        ><b>31 tools</b> across 7 areas</span
                     >
                 </div>
             </section>
@@ -618,7 +618,11 @@
                                             aria-hidden="true"
                                         ></i>
                                         …or just snap a photo of your plate —
-                                        the AI reads it and logs it.
+                                        the AI names each dish, sizes portions
+                                        in everyday measures (a glass, a
+                                        handful), checks how you've logged it
+                                        before, and confirms with you before
+                                        logging.
                                     </p>
                                 </div>
                             </article>
@@ -784,6 +788,58 @@
                             </div>
                         </div>
                         <div class="tool-grid">
+                            <article class="tool-card" id="search_meals">
+                                <div class="tool-head">
+                                    <code class="tool-name">search_meals</code>
+                                    <span class="chip chip-view">View</span>
+                                </div>
+                                <p class="tool-desc">
+                                    Search your past meals by keyword and see
+                                    them grouped into your recurring variations
+                                    — how often each was logged, when last, and
+                                    its typical calories. This is how the AI
+                                    checks a photo of your plate against how
+                                    you've actually logged that meal before, and
+                                    how "log my usual breakfast" works.
+                                </p>
+                                <div class="tool-params">
+                                    <span class="tool-params-label"
+                                        >Parameters</span
+                                    >
+                                    <ul>
+                                        <li>
+                                            <code>queries</code>
+                                            <span class="param-req"
+                                                >required</span
+                                            >
+                                            — Food keyword alternatives, in any
+                                            language you've logged in
+                                        </li>
+                                        <li>
+                                            <code>days</code>
+                                            <span class="param-opt"
+                                                >optional</span
+                                            >
+                                            — How far back to look (default a
+                                            year)
+                                        </li>
+                                        <li>
+                                            <code>limit</code>
+                                            <span class="param-opt"
+                                                >optional</span
+                                            >
+                                            — Max entries to analyze
+                                        </li>
+                                    </ul>
+                                </div>
+                                <div class="tool-ex">
+                                    <span class="tool-ex-label"
+                                        >Try saying</span
+                                    >
+                                    <p>Log my usual breakfast</p>
+                                </div>
+                            </article>
+
                             <article class="tool-card" id="get_meals_today">
                                 <div class="tool-head">
                                     <code class="tool-name"

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
     "name": "io.github.akutishevsky/nutrition-mcp",
     "title": "Nutrition MCP",
     "description": "Personal nutrition tracking — log meals, track macros, and review history through conversation.",
-    "version": "1.17.0",
+    "version": "1.18.0",
     "websiteUrl": "https://nutrition-mcp.com/",
     "repository": {
         "url": "https://github.com/akutishevsky/nutrition-mcp",

--- a/src/analytics.ts
+++ b/src/analytics.ts
@@ -37,7 +37,8 @@ function categorizeError(error: unknown): string {
         msg.includes("failed to insert") ||
         msg.includes("failed to get") ||
         msg.includes("failed to delete") ||
-        msg.includes("failed to update")
+        msg.includes("failed to update") ||
+        msg.includes("failed to search")
     )
         return "supabase_error";
     if (

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -6,6 +6,7 @@ import {
     insertMeal,
     getMealsByDate,
     getMealsInRange,
+    searchMeals,
     deleteMeal,
     updateMeal,
     deleteAllUserData,
@@ -56,6 +57,7 @@ import {
 } from "./units.js";
 import { exportMeals } from "./export.js";
 import { normalizeBarcode, lookupBarcode, formatFoodResult } from "./foods.js";
+import { formatMealSearchResults } from "./search.js";
 import { getWidgetHtml } from "./widgets.js";
 
 // MCP Apps UI (https://blog.modelcontextprotocol.io/posts/2026-01-26-mcp-apps/):
@@ -72,6 +74,22 @@ const GOAL_PROGRESS_WIDGET_URI = "ui://widget/goal-progress.html";
 const MEAL_LOGGED_WIDGET_URI = "ui://widget/meal-logged.html";
 const TRENDS_WIDGET_URI = "ui://widget/trends.html";
 const WEIGHT_TRENDS_WIDGET_URI = "ui://widget/weight-trends.html";
+
+// Sent to clients in the initialize response (SDK ServerOptions.instructions).
+// Advisory — not every client surfaces it, so the enforcement rule ("never log
+// from a photo until the user confirms") is repeated in log_meal's own
+// description. Keep both in sync.
+const SERVER_INSTRUCTIONS = `Nutrition tracking: meals, water, weight, goals, and trends, per-user with timezone support.
+
+Photo-based meal logging — when the user sends a photo of food, follow these steps in order:
+1. Pick the flow. A packaged product with a visible barcode: transcribe the digits printed under the barcode and call lookup_barcode. A plate, bowl, or prepared meal: continue below.
+2. Identify each distinct dish or food item in the photo.
+3. Estimate portions in household measures the user can verify at a glance — "a glass of", "a handful of", "a tablespoon of", "half the plate" — never grams or ounces (nobody can weigh food from a photo).
+4. Call search_meals with a short keyword per dish, passing alternatives in both the conversation language and English (past logs may be in either). Past variations reveal ingredients invisible in the photo (raisins vs banana, milk vs water, added honey or oil). Offer them as options: "Is this the oatmeal with raisins like Monday, or with banana, or something else?"
+5. Present the identified dishes, your portion assumptions, and the past-variation options, then WAIT for the user to confirm or correct before calling log_meal. Never log straight from a photo.
+6. When logging, write the confirmed household-measure portions into the meal description itself (e.g. "Oatmeal (1 glass raw oats, 2 glasses milk) with banana and honey (1 tbsp)") so future search_meals results are self-describing.
+
+For "log my usual X" requests, use search_meals the same way: search, confirm the variation, then log.`;
 
 interface DailyTotals {
     calories: number;
@@ -352,7 +370,7 @@ function registerTools(server: McpServer, userId: string) {
         {
             title: "Log Meal",
             description:
-                "Log a meal entry with nutritional information. If the user doesn't specify the quantity or portion size, ask how much they ate before estimating calories and macros. When the user gives a barcode — typed, or read from a photo of the package (transcribe the digits printed under the barcode) — call lookup_barcode first to get verified nutritional data, then scale it to the amount eaten. Fall back to web search or estimation only when no product is found. Use web search for branded products when no barcode is available.",
+                "Log a meal entry with nutritional information. If the user doesn't specify the quantity or portion size, ask how much they ate before estimating calories and macros. When the user gives a barcode — typed, or read from a photo of the package (transcribe the digits printed under the barcode) — call lookup_barcode first to get verified nutritional data, then scale it to the amount eaten. Fall back to web search or estimation only when no product is found. Use web search for branded products when no barcode is available. When logging from a photo of a plated or prepared meal (no package/barcode): first identify each dish, estimate portions in household measures the user can eyeball (a glass of, a handful of, a tablespoon of — NOT grams), call search_meals to see how similar meals were logged before and to surface ingredients that may be invisible in the photo, then present your assumptions and the past variations as options — do NOT call this tool until the user confirms. Write the confirmed household-measure portions into the description itself (e.g. 'Oatmeal (1 glass raw oats, 2 glasses milk) with banana') so future searches are self-describing.",
             annotations: {
                 readOnlyHint: false,
                 destructiveHint: false,
@@ -656,6 +674,88 @@ function registerTools(server: McpServer, userId: string) {
                 },
                 { userId },
                 { start_date, end_date },
+            );
+        },
+    );
+
+    server.registerTool(
+        "search_meals",
+        {
+            title: "Search Past Meals",
+            description:
+                "Search the user's past logged meals by keyword (case-insensitive match on description and notes), newest first, grouped into recurring variations with counts, last-logged date, and typical macros. Use this BEFORE logging a meal from a photo: past variations reveal ingredients that aren't visible in the picture (raisins vs banana, milk vs water, added honey or oil) — present them to the user as options rather than picking one silently. Also use it for requests like 'log my usual breakfast': search, confirm the variation with the user, then log_meal. Pass short food keywords, not full sentences, and include the food name in every language the user may have logged in — always add an English alternative alongside the conversation language, e.g. [\"вівсянка\", \"oatmeal\"].",
+            annotations: {
+                readOnlyHint: true,
+                destructiveHint: false,
+                idempotentHint: true,
+                openWorldHint: false,
+            },
+            inputSchema: {
+                queries: z
+                    .array(z.string().min(1))
+                    .min(1)
+                    .max(5)
+                    .describe(
+                        "Keyword alternatives, each a short food name like 'oatmeal' or 'chicken salad' (all words of one alternative must match; alternatives are OR'd). Include the food name in every language the user may have logged in — typically the conversation language plus English.",
+                    ),
+                days: z.coerce
+                    .number()
+                    .int()
+                    .min(1)
+                    .max(3650)
+                    .optional()
+                    .describe("How far back to search, in days (default 365)."),
+                limit: z.coerce
+                    .number()
+                    .int()
+                    .min(1)
+                    .max(100)
+                    .optional()
+                    .describe("Max matching entries to analyze (default 50)."),
+            },
+        },
+        async ({ queries, days, limit }) => {
+            return withAnalytics(
+                "search_meals",
+                async () => {
+                    const tz = await getUserTimezone(userId);
+                    const windowDays = days ?? 365;
+                    // A fuzzy lookback window needs no calendar-day precision,
+                    // so a plain UTC offset from now is enough (tz is still
+                    // used to render dates in the results).
+                    const sinceIso = new Date(
+                        Date.now() - windowDays * 24 * 60 * 60 * 1000,
+                    ).toISOString();
+                    const meals = await searchMeals(userId, queries, {
+                        limit: limit ?? 50,
+                        sinceIso,
+                    });
+                    if (meals.length === 0) {
+                        const label = queries.map((q) => `"${q}"`).join(" / ");
+                        return {
+                            content: [
+                                {
+                                    type: "text",
+                                    text: `No past meals matching ${label} in the last ${windowDays} days. If logging from a photo, proceed with your own portion assumptions — but still confirm them with the user before calling log_meal.`,
+                                },
+                            ],
+                        };
+                    }
+                    return {
+                        content: [
+                            {
+                                type: "text",
+                                text: formatMealSearchResults(
+                                    meals,
+                                    queries,
+                                    tz,
+                                ),
+                            },
+                        ],
+                    };
+                },
+                { userId },
+                { days: days ?? 365 },
             );
         },
     );
@@ -2595,7 +2695,7 @@ function buildMcpServer(c: Context, userId: string): McpServer {
     const server = new McpServer(
         {
             name: "nutrition-mcp",
-            version: "1.17.0",
+            version: "1.18.0",
             icons: [
                 {
                     src: `${baseUrl}/favicon.ico`,
@@ -2603,7 +2703,10 @@ function buildMcpServer(c: Context, userId: string): McpServer {
                 },
             ],
         },
-        { capabilities: { tools: {}, resources: {} } },
+        {
+            capabilities: { tools: {}, resources: {} },
+            instructions: SERVER_INSTRUCTIONS,
+        },
     );
 
     registerTools(server, userId);

--- a/src/search.test.ts
+++ b/src/search.test.ts
@@ -1,0 +1,234 @@
+import { test, expect } from "bun:test";
+import {
+    escapeLikePattern,
+    tokenizeQuery,
+    groupMealVariations,
+    formatMealSearchResults,
+} from "./search.js";
+import type { Meal } from "./supabase.js";
+
+function meal(overrides: Partial<Meal> = {}): Meal {
+    return {
+        id: "11111111-1111-1111-1111-111111111111",
+        user_id: "user-1",
+        logged_at: "2026-06-20T14:30:00.000Z",
+        meal_type: "lunch",
+        description: "Grilled chicken",
+        calories: 500,
+        protein_g: 40,
+        carbs_g: 10,
+        fat_g: 20,
+        notes: null,
+        idempotency_key: null,
+        ...overrides,
+    };
+}
+
+// --- escapeLikePattern ---
+
+test("escapes LIKE metacharacters", () => {
+    expect(escapeLikePattern("50%_off\\")).toBe("50\\%\\_off\\\\");
+});
+
+test("leaves plain text untouched", () => {
+    expect(escapeLikePattern("oatmeal with banana")).toBe(
+        "oatmeal with banana",
+    );
+});
+
+// --- tokenizeQuery ---
+
+test("splits on whitespace, lowercases, drops empties", () => {
+    expect(tokenizeQuery("  Chicken   SALAD ")).toEqual(["chicken", "salad"]);
+});
+
+test("caps at 5 tokens", () => {
+    expect(tokenizeQuery("a b c d e f g")).toEqual(["a", "b", "c", "d", "e"]);
+});
+
+test("returns empty array for blank query", () => {
+    expect(tokenizeQuery("   ")).toEqual([]);
+});
+
+// --- groupMealVariations ---
+
+test("merges case, whitespace, and trailing-punctuation variants", () => {
+    const variations = groupMealVariations([
+        meal({ id: "a", description: "Oatmeal with raisins" }),
+        meal({ id: "b", description: "oatmeal  with raisins." }),
+        meal({ id: "c", description: " OATMEAL WITH RAISINS " }),
+    ]);
+    expect(variations).toHaveLength(1);
+    expect(variations[0]!.count).toBe(3);
+});
+
+test("keeps distinct descriptions as distinct groups", () => {
+    const variations = groupMealVariations([
+        meal({ id: "a", description: "Oatmeal with raisins" }),
+        meal({ id: "b", description: "Oatmeal with banana" }),
+    ]);
+    expect(variations).toHaveLength(2);
+});
+
+test("sorts by count desc, ties broken by recency", () => {
+    const variations = groupMealVariations([
+        meal({
+            id: "a",
+            description: "Oatmeal with banana",
+            logged_at: "2026-06-01T08:00:00.000Z",
+        }),
+        meal({
+            id: "b",
+            description: "Oatmeal with raisins",
+            logged_at: "2026-06-02T08:00:00.000Z",
+        }),
+        meal({
+            id: "c",
+            description: "Oatmeal with raisins",
+            logged_at: "2026-06-03T08:00:00.000Z",
+        }),
+        meal({
+            id: "d",
+            description: "Oatmeal with honey",
+            logged_at: "2026-06-04T08:00:00.000Z",
+        }),
+    ]);
+    expect(variations.map((v) => v.label)).toEqual([
+        "Oatmeal with raisins",
+        "Oatmeal with honey",
+        "Oatmeal with banana",
+    ]);
+});
+
+test("label and lastLoggedAt come from the newest entry in the group", () => {
+    const variations = groupMealVariations([
+        meal({
+            id: "a",
+            description: "oatmeal with raisins",
+            logged_at: "2026-06-01T08:00:00.000Z",
+        }),
+        meal({
+            id: "b",
+            description: "Oatmeal with raisins",
+            logged_at: "2026-06-05T08:00:00.000Z",
+        }),
+    ]);
+    expect(variations[0]!.label).toBe("Oatmeal with raisins");
+    expect(variations[0]!.lastLoggedAt).toBe("2026-06-05T08:00:00.000Z");
+});
+
+test("typical macros are medians of non-null values", () => {
+    const variations = groupMealVariations([
+        meal({ id: "a", calories: 300, protein_g: 10 }),
+        meal({ id: "b", calories: 350, protein_g: 12.4 }),
+        meal({ id: "c", calories: 900, protein_g: null }),
+    ]);
+    // odd count → middle value
+    expect(variations[0]!.typicalCalories).toBe(350);
+    // nulls excluded, even count → average, rounded to 1 decimal
+    expect(variations[0]!.typicalProteinG).toBe(11.2);
+});
+
+test("all-null macros yield null", () => {
+    const variations = groupMealVariations([
+        meal({ id: "a", calories: null, protein_g: null }),
+        meal({ id: "b", calories: null, protein_g: null }),
+    ]);
+    expect(variations[0]!.typicalCalories).toBeNull();
+    expect(variations[0]!.typicalProteinG).toBeNull();
+});
+
+// --- formatMealSearchResults ---
+
+test("renders counts, typical macros, and last-logged date", () => {
+    const text = formatMealSearchResults(
+        [
+            meal({
+                id: "b",
+                description: "Oatmeal with raisins",
+                logged_at: "2026-06-05T08:00:00.000Z",
+                calories: 350,
+            }),
+            meal({
+                id: "a",
+                description: "Oatmeal with raisins",
+                logged_at: "2026-06-01T08:00:00.000Z",
+                calories: 350,
+            }),
+        ],
+        ["oatmeal"],
+        "UTC",
+    );
+    expect(text).toContain('Found 2 past meals matching "oatmeal".');
+    expect(text).toContain("logged 2×, last on 2026-06-05");
+    expect(text).toContain("~350 kcal");
+});
+
+test("renders header with all query alternatives", () => {
+    const text = formatMealSearchResults(
+        [meal({ description: "Вівсянка з бананом" })],
+        ["oatmeal", "вівсянка"],
+        "UTC",
+    );
+    expect(text).toContain('matching "oatmeal" / "вівсянка".');
+});
+
+test("renders last-logged date in the user's timezone", () => {
+    // 23:30 UTC on the 20th is already the 21st in Berlin (CEST, summer).
+    const text = formatMealSearchResults(
+        [meal({ logged_at: "2026-06-20T23:30:00.000Z" })],
+        ["chicken"],
+        "Europe/Berlin",
+    );
+    expect(text).toContain("last on 2026-06-21");
+    expect(text).toContain("- 2026-06-21 lunch:");
+});
+
+test("caps variations and reports the hidden count", () => {
+    const meals = Array.from({ length: 4 }, (_, i) =>
+        meal({
+            id: `id-${i}`,
+            description: `Dish ${i}`,
+            logged_at: `2026-06-0${i + 1}T08:00:00.000Z`,
+        }),
+    ).reverse();
+    const text = formatMealSearchResults(meals, ["dish"], "UTC", {
+        maxVariations: 2,
+        recentCount: 5,
+    });
+    expect(text).toContain("(…and 2 more variations)");
+    expect(text).not.toContain("3. ");
+});
+
+test("caps recent entries and includes ids", () => {
+    const meals = Array.from({ length: 4 }, (_, i) =>
+        meal({
+            id: `id-${i}`,
+            description: "Same dish",
+            logged_at: `2026-06-0${i + 1}T08:00:00.000Z`,
+        }),
+    ).reverse();
+    const text = formatMealSearchResults(meals, ["dish"], "UTC", {
+        recentCount: 2,
+    });
+    expect(text).toContain("[id: id-3]");
+    expect(text).toContain("[id: id-2]");
+    expect(text).not.toContain("[id: id-1]");
+});
+
+test("renders '(no macros logged)' when every entry lacks macros", () => {
+    const text = formatMealSearchResults(
+        [
+            meal({
+                calories: null,
+                protein_g: null,
+                carbs_g: null,
+                fat_g: null,
+            }),
+        ],
+        ["soup"],
+        "UTC",
+    );
+    expect(text).toContain("(no macros logged)");
+    expect(text).not.toContain("~null");
+});

--- a/src/search.ts
+++ b/src/search.ts
@@ -1,0 +1,168 @@
+import type { Meal } from "./supabase.js";
+import { dateInTz } from "./tz.js";
+
+/**
+ * Escape LIKE/ILIKE metacharacters so user input matches literally.
+ * Backslash must be escaped first, then % and _.
+ */
+export function escapeLikePattern(s: string): string {
+    return s.replace(/[\\%_]/g, (c) => `\\${c}`);
+}
+
+/**
+ * Split a search query into lowercase word tokens (whitespace-separated,
+ * empties removed), capped at 5 tokens to bound the query chain length.
+ */
+export function tokenizeQuery(query: string): string[] {
+    return query
+        .toLowerCase()
+        .split(/\s+/)
+        .filter((t) => t.length > 0)
+        .slice(0, 5);
+}
+
+export interface MealVariation {
+    /** Normalized description used as the grouping key. */
+    key: string;
+    /** Description of the most recent meal in the group (original casing). */
+    label: string;
+    count: number;
+    /** ISO timestamp of the newest entry in the group. */
+    lastLoggedAt: string;
+    /** Median of non-null values; null when every entry lacks the field. */
+    typicalCalories: number | null;
+    typicalProteinG: number | null;
+    typicalCarbsG: number | null;
+    typicalFatG: number | null;
+}
+
+/**
+ * Grouping is by exact normalized description, deliberately not fuzzy:
+ * fuzzy matching would merge exactly the variations this feature exists to
+ * distinguish ("oatmeal with raisins" vs "oatmeal with banana").
+ */
+function normalizeDescription(description: string): string {
+    return description
+        .toLowerCase()
+        .trim()
+        .replace(/\s+/g, " ")
+        .replace(/[.,!]+$/, "");
+}
+
+function median(values: number[]): number | null {
+    if (values.length === 0) return null;
+    const sorted = [...values].sort((a, b) => a - b);
+    const mid = Math.floor(sorted.length / 2);
+    return sorted.length % 2 === 1
+        ? sorted[mid]!
+        : (sorted[mid - 1]! + sorted[mid]!) / 2;
+}
+
+function medianOf(
+    meals: Meal[],
+    pick: (m: Meal) => number | null,
+    round: (n: number) => number,
+): number | null {
+    const values = meals
+        .map(pick)
+        .filter((v): v is number => v !== null && v !== undefined);
+    const m = median(values);
+    return m === null ? null : round(m);
+}
+
+const round1 = (n: number) => Math.round(n * 10) / 10;
+
+/** Group meals into recurring variations, most frequent first. */
+export function groupMealVariations(meals: Meal[]): MealVariation[] {
+    const groups = new Map<string, Meal[]>();
+    for (const meal of meals) {
+        const key = normalizeDescription(meal.description);
+        const group = groups.get(key);
+        if (group) group.push(meal);
+        else groups.set(key, [meal]);
+    }
+    const variations: MealVariation[] = [];
+    for (const [key, group] of groups) {
+        const newest = group.reduce((a, b) =>
+            b.logged_at.localeCompare(a.logged_at) > 0 ? b : a,
+        );
+        variations.push({
+            key,
+            label: newest.description,
+            count: group.length,
+            lastLoggedAt: newest.logged_at,
+            typicalCalories: medianOf(group, (m) => m.calories, Math.round),
+            typicalProteinG: medianOf(group, (m) => m.protein_g, round1),
+            typicalCarbsG: medianOf(group, (m) => m.carbs_g, round1),
+            typicalFatG: medianOf(group, (m) => m.fat_g, round1),
+        });
+    }
+    variations.sort(
+        (a, b) =>
+            b.count - a.count || b.lastLoggedAt.localeCompare(a.lastLoggedAt),
+    );
+    return variations;
+}
+
+function formatVariation(v: MealVariation, index: number, tz: string): string {
+    const parts: string[] = [
+        `${index + 1}. ${v.label} — logged ${v.count}×, last on ${dateInTz(v.lastLoggedAt, tz)}`,
+    ];
+    if (v.typicalCalories !== null) {
+        const macros = [
+            v.typicalProteinG !== null ? `${v.typicalProteinG}g protein` : null,
+            v.typicalCarbsG !== null ? `${v.typicalCarbsG}g carbs` : null,
+            v.typicalFatG !== null ? `${v.typicalFatG}g fat` : null,
+        ].filter(Boolean);
+        parts.push(
+            `typically ~${v.typicalCalories} kcal${macros.length > 0 ? ` (${macros.join(", ")})` : ""}`,
+        );
+    } else {
+        parts.push("(no macros logged)");
+    }
+    return parts.join(", ");
+}
+
+function formatRecentEntry(meal: Meal, tz: string): string {
+    const date = dateInTz(meal.logged_at, tz);
+    const type = meal.meal_type ? ` ${meal.meal_type}` : "";
+    const kcal = meal.calories !== null ? ` — ${meal.calories} kcal` : "";
+    return `- ${date}${type}: ${meal.description}${kcal} [id: ${meal.id}]`;
+}
+
+/**
+ * Render search results as grouped variations plus the most recent raw
+ * entries. Assumes meals is non-empty and pre-sorted newest first (the
+ * tool handler handles the empty case, per repo convention).
+ */
+export function formatMealSearchResults(
+    meals: Meal[],
+    queries: string[],
+    tz: string,
+    opts: { maxVariations?: number; recentCount?: number } = {},
+): string {
+    const maxVariations = opts.maxVariations ?? 10;
+    const recentCount = opts.recentCount ?? 5;
+
+    const label = queries.map((q) => `"${q}"`).join(" / ");
+    const variations = groupMealVariations(meals);
+    const shown = variations.slice(0, maxVariations);
+    const hidden = variations.length - shown.length;
+
+    const sections = [
+        `Found ${meals.length} past meal${meals.length === 1 ? "" : "s"} matching ${label}.`,
+        [
+            "Variations (by frequency):",
+            ...shown.map((v, i) => formatVariation(v, i, tz)),
+            ...(hidden > 0
+                ? [`(…and ${hidden} more variation${hidden === 1 ? "" : "s"})`]
+                : []),
+        ].join("\n"),
+        [
+            "Most recent matching entries:",
+            ...meals.slice(0, recentCount).map((m) => formatRecentEntry(m, tz)),
+        ].join("\n"),
+        "When logging from a photo, present these variations to the user as options before logging.",
+    ];
+    return sections.join("\n\n");
+}

--- a/src/supabase.ts
+++ b/src/supabase.ts
@@ -2,6 +2,7 @@ import { createClient, type SupabaseClient } from "@supabase/supabase-js";
 import { zonedDayStartUtc, zonedNextDayStartUtc } from "./tz.js";
 import { decodeEscapeSequences } from "./normalize.js";
 import { isWeightUnit, type WeightUnit } from "./units.js";
+import { escapeLikePattern, tokenizeQuery } from "./search.js";
 
 let supabase: SupabaseClient;
 
@@ -248,6 +249,56 @@ export async function getAllMeals(userId: string): Promise<Meal[]> {
 
     if (error) throw new Error(`Failed to get meals: ${error.message}`);
     return (data as Meal[]) ?? [];
+}
+
+// Keyword search over past meals. Each query string is an alternative (OR'd
+// across, e.g. the same food in two languages); within one alternative every
+// word token must match the column (AND'd via chained .ilike). We deliberately
+// avoid PostgREST's .or() — its logic-tree grammar treats commas/parens inside
+// values as structure and supabase-js does not quote them — and instead run
+// one cheap per-user query per (alternative × column) and merge in code.
+export async function searchMeals(
+    userId: string,
+    queries: string[],
+    opts: { limit?: number; sinceIso?: string } = {},
+): Promise<Meal[]> {
+    const limit = opts.limit ?? 50;
+    const tokenized = queries
+        .map(tokenizeQuery)
+        .filter((tokens) => tokens.length > 0);
+    if (tokenized.length === 0) return [];
+
+    const buildQuery = (tokens: string[], column: "description" | "notes") => {
+        let q = getSupabase().from("meals").select("*").eq("user_id", userId);
+        if (opts.sinceIso) q = q.gte("logged_at", opts.sinceIso);
+        for (const token of tokens) {
+            q = q.ilike(column, `%${escapeLikePattern(token)}%`);
+        }
+        return q.order("logged_at", { ascending: false }).limit(limit);
+    };
+
+    const results = await Promise.all(
+        tokenized.flatMap((tokens) => [
+            buildQuery(tokens, "description"),
+            buildQuery(tokens, "notes"),
+        ]),
+    );
+
+    const seen = new Set<string>();
+    const merged: Meal[] = [];
+    for (const { data, error } of results) {
+        if (error) {
+            throw new Error(`Failed to search meals: ${error.message}`);
+        }
+        for (const meal of (data as Meal[]) ?? []) {
+            if (!seen.has(meal.id)) {
+                seen.add(meal.id);
+                merged.push(meal);
+            }
+        }
+    }
+    merged.sort((a, b) => b.logged_at.localeCompare(a.logged_at));
+    return merged.slice(0, limit);
 }
 
 export async function deleteMeal(userId: string, id: string): Promise<void> {


### PR DESCRIPTION
## What

Photo-based meal logging now follows a confirm-first workflow, backed by a new `search_meals` tool.

When the user sends a photo of a plated/prepared meal, the model is instructed to:
1. Identify each dish in the photo
2. Estimate portions in **household measures** ("a glass of", "a handful of", "a tablespoon of" — never grams)
3. Call `search_meals` to surface past variations of the same meal — catching ingredients invisible in the photo ("oatmeal with raisins like Monday, or with banana?")
4. Present assumptions + past-variation options and **wait for user confirmation before logging**
5. Write the confirmed portions into the meal description (e.g. "Oatmeal (1 glass raw oats, 2 glasses milk) with banana") so history becomes self-describing

## How

- **`search_meals` tool** — keyword search over past meals (description + notes), newest first, grouped into recurring variations with counts, last-logged date, and median macros. Accepts up to 5 query alternatives (OR'd) so the model searches in both the conversation language and English (past logs may be in either).
- **`src/search.ts`** — pure helpers (escaping, tokenizing, grouping, formatting) with 17 tests in the export.test.ts fixture style. Grouping is exact-normalized on purpose: fuzzy matching would merge exactly the variations this feature must distinguish.
- **`searchMeals` in `src/supabase.ts`** — one query per (alternative × column) with chained `.ilike` per token, merged by id. Deliberately avoids PostgREST `.or()`, whose logic-tree grammar mis-parses commas/parens inside values; LIKE metacharacters are escaped.
- **Prompt surfaces** — the plate-photo flow is appended to `log_meal`'s description (disambiguated from the existing barcode-photo flow by trigger: "photo of the package" vs "plated meal, no barcode"), and the full 6-step workflow ships as server-level `instructions` (previously unused `McpServer` field). Redundant on purpose: not all clients surface instructions.
- **Misc** — "failed to search" added to the `supabase_error` analytics bucket; `tools.html` gets a `search_meals` card + updated log_meal photo copy (31 tools); version 1.18.0 in all three places.

## Verification

- `bun test`: 84/84 pass (17 new)
- `src/` typechecks clean (pre-existing `scripts/gen-map-data.ts` errors untouched)
- Server boots cleanly; `/mcp` 401s without a token as before
- Live read-only run against the real DB: Cyrillic keyword matched case-insensitively and grouped into variations as designed; a metacharacter query (`100% (test), _x_`) returned 0 rows instead of matching everything

🤖 Generated with [Claude Code](https://claude.com/claude-code)