### PR TITLE
feat(widgets): add per-user widget display toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,8 @@ Read the story behind it: [How I Replaced MyFitnessPal and Other Apps with a Sin
 | `export_meals`             | Export all meals as a CSV and return a 60-minute download link                                           |
 | `set_timezone`             | Set the user's IANA timezone (e.g. `America/Los_Angeles`)                                                |
 | `get_timezone`             | Get the user's configured timezone                                                                       |
+| `set_widget_display`       | Enable or disable the in-chat visual widgets (dashboards, rings, charts); enabled by default             |
+| `get_widget_display`       | Get whether the in-chat visual widgets are enabled                                                       |
 | `delete_account`           | Permanently delete account and all associated data                                                       |
 
 ## MCP Resources

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "nutrition-mcp",
-    "version": "1.18.0",
+    "version": "1.19.0",
     "description": "A remote MCP server for personal nutrition tracking. Log meals, track macros, and review nutrition history through Claude.",
     "author": "akutishevsky",
     "license": "MIT",

--- a/public/index.html
+++ b/public/index.html
@@ -863,7 +863,7 @@
                         ></span>
                         <span class="tools-cta-text">
                             <strong>Curious what it can actually do?</strong>
-                            Browse all 30 tools — logging, barcodes, water,
+                            Browse all 33 tools — logging, barcodes, water,
                             weight, goals, and trends — with a description and
                             an example prompt for each.
                         </span>

--- a/public/tools.html
+++ b/public/tools.html
@@ -458,7 +458,7 @@
                     </p>
                     <span class="count-pill"
                         ><i class="fa-solid fa-wrench" aria-hidden="true"></i
-                        ><b>31 tools</b> across 7 areas</span
+                        ><b>33 tools</b> across 7 areas</span
                     >
                 </div>
             </section>
@@ -1752,6 +1752,64 @@
                                         >Try saying</span
                                     >
                                     <p>What timezone am I set to?</p>
+                                </div>
+                            </article>
+
+                            <article class="tool-card" id="set_widget_display">
+                                <div class="tool-head">
+                                    <code class="tool-name"
+                                        >set_widget_display</code
+                                    >
+                                    <span class="chip chip-setting"
+                                        >Setting</span
+                                    >
+                                </div>
+                                <p class="tool-desc">
+                                    Turn the in-chat visual widgets on or off —
+                                    the dashboards, goal rings, and trend charts.
+                                    When off, the same tools reply with text and
+                                    data only. Enabled by default; the change
+                                    applies to new conversations.
+                                </p>
+                                <div class="tool-params">
+                                    <span class="tool-params-label"
+                                        >Parameters</span
+                                    >
+                                    <ul>
+                                        <li>
+                                            <code>enabled</code>
+                                            <span class="param-req"
+                                                >required</span
+                                            >
+                                            — true to show widgets, false for
+                                            text-only responses
+                                        </li>
+                                    </ul>
+                                </div>
+                                <div class="tool-ex">
+                                    <span class="tool-ex-label"
+                                        >Try saying</span
+                                    >
+                                    <p>Turn off the widgets</p>
+                                </div>
+                            </article>
+
+                            <article class="tool-card" id="get_widget_display">
+                                <div class="tool-head">
+                                    <code class="tool-name"
+                                        >get_widget_display</code
+                                    >
+                                    <span class="chip chip-view">View</span>
+                                </div>
+                                <p class="tool-desc">
+                                    Check whether the in-chat visual widgets are
+                                    currently enabled.
+                                </p>
+                                <div class="tool-ex">
+                                    <span class="tool-ex-label"
+                                        >Try saying</span
+                                    >
+                                    <p>Are the widgets turned on?</p>
                                 </div>
                             </article>
 

--- a/public/widgets/src/shared/bridge.js
+++ b/public/widgets/src/shared/bridge.js
@@ -47,10 +47,28 @@ function initWidget(config) {
             null
         );
     }
+    // Render, then append a small persistent note at the bottom explaining that
+    // widget display is a user setting. render() replaces #root wholesale, so
+    // the footer is re-appended after every paint. Skipped when a widget
+    // deliberately renders nothing (e.g. meal-logged with no goals) so an empty
+    // widget stays empty and the host collapses it.
+    function paint(data) {
+        config.render(data);
+        const el = root();
+        if (!el || el.innerHTML.trim() === "") return;
+        const foot = document.createElement("div");
+        foot.textContent =
+            "You can enable or disable these widgets anytime — just ask to update your settings.";
+        foot.style.cssText =
+            "margin-top:14px;padding-top:10px;" +
+            "border-top:1px solid var(--panel-border);" +
+            "font-size:11px;line-height:1.4;color:var(--text-dim);text-align:center;";
+        el.appendChild(foot);
+    }
     function show(payload) {
         const data = config.coerce(payload);
         if (!data) return false;
-        config.render(data);
+        paint(data);
         return true;
     }
 
@@ -177,6 +195,6 @@ function initWidget(config) {
     } else {
         // Opened directly in a browser (no host) — render the sample so the
         // file is previewable on its own.
-        config.render(window.__WIDGET_DATA__ || config.sample);
+        paint(window.__WIDGET_DATA__ || config.sample);
     }
 }

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
     "name": "io.github.akutishevsky/nutrition-mcp",
     "title": "Nutrition MCP",
     "description": "Personal nutrition tracking — log meals, track macros, and review history through conversation.",
-    "version": "1.18.0",
+    "version": "1.19.0",
     "websiteUrl": "https://nutrition-mcp.com/",
     "repository": {
         "url": "https://github.com/akutishevsky/nutrition-mcp",

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -24,6 +24,7 @@ import {
     deleteWeight,
     getUserTimezone,
     getPreferredWeightUnit,
+    getWidgetsEnabled,
     upsertProfile,
     getProfile,
     type Meal,
@@ -364,7 +365,18 @@ function formatMeal(meal: Meal): string {
     return parts.filter(Boolean).join("\n");
 }
 
-function registerTools(server: McpServer, userId: string) {
+function registerTools(
+    server: McpServer,
+    userId: string,
+    widgetsEnabled: boolean,
+) {
+    // Link a tool to its widget only when this user has widgets enabled. Because
+    // buildMcpServer registers tools per request, this makes widget display a
+    // per-user setting: with widgets off, tools/list advertises no UI link, so
+    // hosts render no widget. Spreads to nothing when disabled.
+    const uiMeta = (resourceUri: string) =>
+        widgetsEnabled ? { _meta: { ui: { resourceUri } } } : {};
+
     server.registerTool(
         "log_meal",
         {
@@ -417,7 +429,7 @@ function registerTools(server: McpServer, userId: string) {
             // Link the tool to its progress UI (MCP Apps). update_meal reuses
             // the SAME widget; see buildMealProgress / meal-logged.html. The
             // widget renders nothing when no goals are set.
-            _meta: { ui: { resourceUri: MEAL_LOGGED_WIDGET_URI } },
+            ...uiMeta(MEAL_LOGGED_WIDGET_URI),
         },
         async (args) => {
             return withAnalytics(
@@ -938,7 +950,7 @@ function registerTools(server: McpServer, userId: string) {
                 meals: z.array(MEAL_BREAKDOWN_ITEM),
             },
             // Link the tool to its dashboard UI (MCP Apps).
-            _meta: { ui: { resourceUri: SUMMARY_WIDGET_URI } },
+            ...uiMeta(SUMMARY_WIDGET_URI),
         },
         async ({ start_date, end_date }) => {
             return withAnalytics(
@@ -1289,7 +1301,7 @@ function registerTools(server: McpServer, userId: string) {
                 meals: z.array(MEAL_BREAKDOWN_ITEM),
             },
             // Link the tool to its progress UI (MCP Apps).
-            _meta: { ui: { resourceUri: GOAL_PROGRESS_WIDGET_URI } },
+            ...uiMeta(GOAL_PROGRESS_WIDGET_URI),
         },
         async ({ date }) => {
             return withAnalytics(
@@ -1458,7 +1470,7 @@ function registerTools(server: McpServer, userId: string) {
             // Reuses the SAME meal-logged widget as log_meal (see
             // buildMealProgress / meal-logged.html); `action: "updated"` just
             // changes its header. Renders nothing when no goals are set.
-            _meta: { ui: { resourceUri: MEAL_LOGGED_WIDGET_URI } },
+            ...uiMeta(MEAL_LOGGED_WIDGET_URI),
         },
         async ({ id, ...fields }) => {
             return withAnalytics(
@@ -1993,7 +2005,7 @@ function registerTools(server: McpServer, userId: string) {
                 ),
             },
             // Link the tool to its interactive weight-trends UI (MCP Apps).
-            _meta: { ui: { resourceUri: WEIGHT_TRENDS_WIDGET_URI } },
+            ...uiMeta(WEIGHT_TRENDS_WIDGET_URI),
         },
         async ({ days, end_date }) => {
             return withAnalytics(
@@ -2282,6 +2294,83 @@ function registerTools(server: McpServer, userId: string) {
     );
 
     server.registerTool(
+        "set_widget_display",
+        {
+            title: "Set Widget Display",
+            description:
+                "Enable or disable the in-chat visual widgets (nutrition dashboard, goal progress, meal-logged rings, trends, weight charts). When disabled, the same tools still return their full text and data — just no rendered widget. Widgets are enabled by default. Note: hosts read the widget list when a session connects, so the change takes effect in new conversations; an already-open chat may keep showing widgets until it reconnects.",
+            annotations: {
+                readOnlyHint: false,
+                destructiveHint: false,
+                idempotentHint: true,
+                openWorldHint: false,
+            },
+            inputSchema: {
+                enabled: z
+                    .boolean()
+                    .describe(
+                        "true to show widgets (default), false for text-only responses with no widget.",
+                    ),
+            },
+        },
+        async ({ enabled }) => {
+            return withAnalytics(
+                "set_widget_display",
+                async () => {
+                    const profile = await upsertProfile(userId, {
+                        widgets_enabled: enabled,
+                    });
+                    return {
+                        content: [
+                            {
+                                type: "text",
+                                text: profile.widgets_enabled
+                                    ? "Widgets enabled. Supported tools will show a visual widget alongside their text in new conversations."
+                                    : "Widgets disabled. Supported tools will return text and data only, with no widget, in new conversations.",
+                            },
+                        ],
+                    };
+                },
+                { userId },
+            );
+        },
+    );
+
+    server.registerTool(
+        "get_widget_display",
+        {
+            title: "Get Widget Display",
+            description:
+                "Get whether the in-chat visual widgets are currently enabled for the user. Enabled by default.",
+            annotations: {
+                readOnlyHint: true,
+                destructiveHint: false,
+                idempotentHint: true,
+                openWorldHint: false,
+            },
+        },
+        async () => {
+            return withAnalytics(
+                "get_widget_display",
+                async () => {
+                    const enabled = await getWidgetsEnabled(userId);
+                    return {
+                        content: [
+                            {
+                                type: "text",
+                                text: enabled
+                                    ? "Widgets are enabled. Supported tools show a visual widget alongside their text."
+                                    : "Widgets are disabled. Supported tools return text and data only.",
+                            },
+                        ],
+                    };
+                },
+                { userId },
+            );
+        },
+    );
+
+    server.registerTool(
         "get_trends",
         {
             title: "Get Trends",
@@ -2332,7 +2421,7 @@ function registerTools(server: McpServer, userId: string) {
                 ),
             },
             // Link the tool to its interactive trends UI (MCP Apps).
-            _meta: { ui: { resourceUri: TRENDS_WIDGET_URI } },
+            ...uiMeta(TRENDS_WIDGET_URI),
         },
         async ({ days, end_date }) => {
             return withAnalytics(
@@ -2686,7 +2775,7 @@ function registerTools(server: McpServer, userId: string) {
 }
 
 // Build a fresh McpServer with this user's tools registered.
-function buildMcpServer(c: Context, userId: string): McpServer {
+async function buildMcpServer(c: Context, userId: string): Promise<McpServer> {
     const proto = c.req.header("x-forwarded-proto") || "http";
     const host =
         c.req.header("x-forwarded-host") || c.req.header("host") || "localhost";
@@ -2695,7 +2784,7 @@ function buildMcpServer(c: Context, userId: string): McpServer {
     const server = new McpServer(
         {
             name: "nutrition-mcp",
-            version: "1.18.0",
+            version: "1.19.0",
             icons: [
                 {
                     src: `${baseUrl}/favicon.ico`,
@@ -2709,7 +2798,7 @@ function buildMcpServer(c: Context, userId: string): McpServer {
         },
     );
 
-    registerTools(server, userId);
+    registerTools(server, userId, await getWidgetsEnabled(userId));
     return server;
 }
 
@@ -2750,7 +2839,7 @@ export const handleMcp = async (c: Context) => {
     const transport = new WebStandardStreamableHTTPServerTransport({
         sessionIdGenerator: undefined,
     });
-    const server = buildMcpServer(c, userId);
+    const server = await buildMcpServer(c, userId);
     await server.connect(transport);
 
     return transport.handleRequest(c.req.raw);

--- a/src/supabase.ts
+++ b/src/supabase.ts
@@ -349,6 +349,7 @@ export interface Profile {
     user_id: string;
     timezone: string;
     preferred_weight_unit: WeightUnit | null;
+    widgets_enabled: boolean;
     created_at: string;
     updated_at: string;
 }
@@ -380,11 +381,23 @@ export async function getPreferredWeightUnit(
     return isWeightUnit(unit) ? unit : null;
 }
 
+// Whether in-chat widgets should be shown for this user. Defaults to true when
+// no profile exists yet, or (for backward compatibility) when the column is
+// absent — widgets are on for everyone until a user explicitly opts out.
+export async function getWidgetsEnabled(userId: string): Promise<boolean> {
+    const profile = await getProfile(userId);
+    return profile?.widgets_enabled ?? true;
+}
+
 // Upsert the fields provided in `patch`, leaving other columns untouched. On
 // first insert, omitted columns fall back to their DB defaults (UTC / kg).
 export async function upsertProfile(
     userId: string,
-    patch: { timezone?: string; preferred_weight_unit?: WeightUnit | null },
+    patch: {
+        timezone?: string;
+        preferred_weight_unit?: WeightUnit | null;
+        widgets_enabled?: boolean;
+    },
 ): Promise<Profile> {
     const payload: Record<string, unknown> = {
         user_id: userId,
@@ -394,6 +407,8 @@ export async function upsertProfile(
     // null is meaningful here (clears the preference), so only skip `undefined`.
     if (patch.preferred_weight_unit !== undefined)
         payload.preferred_weight_unit = patch.preferred_weight_unit;
+    if (patch.widgets_enabled !== undefined)
+        payload.widgets_enabled = patch.widgets_enabled;
 
     const { data, error } = await getSupabase()
         .from("profiles")

--- a/supabase/migrations/20260717120000_widget_display_setting.sql
+++ b/supabase/migrations/20260717120000_widget_display_setting.sql
@@ -1,0 +1,7 @@
+-- Per-user toggle for whether in-chat MCP Apps widgets are shown. Default TRUE
+-- keeps widgets enabled for everyone, including every existing profile row. A
+-- user opts out via the set_widget_display tool; when disabled, the server omits
+-- the tool→widget UI link for that user's session so hosts render no widget.
+-- Covered by the existing "Users manage their own profile" RLS policy.
+alter table public.profiles
+    add column if not exists widgets_enabled boolean not null default true;


### PR DESCRIPTION
## What

Adds a per-user setting to turn the in-chat MCP Apps widgets on or off. Widgets stay **enabled by default** for everyone (including all existing profiles).

- New `profiles.widgets_enabled` column (`boolean not null default true`).
- Two new tools: **`set_widget_display`** (`enabled: boolean`) and **`get_widget_display`**.
- A footer note on every widget explaining that display is a user setting.

## How it works

`buildMcpServer` already registers tools **per request** with the user in scope, so the tool→widget UI link (`_meta.ui.resourceUri`) is gated on the setting **at registration time**. When a user has widgets off, `tools/list` advertises no UI link, so hosts render no widget — while the tools still return their full model-facing `content` and `structuredContent`. This is the reliable lever (the tool listing is what hosts read; per-call result `_meta` is host-dependent).

The footer is centralized in `shared/bridge.js` (`paint()` wrapper) using existing theme tokens, so it needed no per-template edits and preserves the widget-assembly test invariants. It's skipped when a widget deliberately renders empty (e.g. `meal-logged` with no goals).

## Behaviour note

Because gating happens at `tools/list` time, toggling takes effect in **new conversations** — hosts cache the tool list per connection, so an already-open chat may keep showing widgets until it reconnects. The tool descriptions and confirmation text say this.

## Changes

- `src/supabase.ts` — `Profile.widgets_enabled`, `upsertProfile` patch, `getWidgetsEnabled()` (defaults to `true` when no profile or column absent → safe to deploy before/after the migration).
- `src/mcp.ts` — `uiMeta()` gating on all 6 widget-backed tools, the two new tools, async `buildMcpServer`, version → 1.19.0.
- `public/widgets/src/shared/bridge.js` — footer.
- Docs: `README.md` tools table, `public/tools.html` (+ count → 33), `public/index.html` count.
- `supabase/migrations/20260717120000_widget_display_setting.sql` — **already applied to the production project** (`qcwuhidewndfxzjskmhe`).
- Version bump in `package.json`, `server.json`, `src/mcp.ts`.

## Testing

- `bun test` → 84 pass; `bun test src/widgets.test.ts` → 11 pass.
- Touched TS files typecheck clean.
- Verified footer + `paint()` inline into assembled widgets with no unresolved markers and invariants intact.

## Deploy note

This is a remote MCP server — the feature (and the static `public/` pages) go live on the next DigitalOcean deploy. No `v1.19.0` tag pushed; tag later to refresh the MCP Registry listing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)