### PR TITLE
feat: add Glama connector-ownership route

### DIFF
--- a/scripts/depersonalize.ts
+++ b/scripts/depersonalize.ts
@@ -8,6 +8,7 @@
  *
  * What it removes / neutralizes:
  *   - Google Analytics (gtag) from every public HTML page + the CSP allow-list
+ *   - The Glama connector-ownership route (embeds the maintainer's email)
  *   - Patreon "Support" section and hero button
  *   - GitHub repo links (nav, footer, "Star on GitHub" CTA) and the live
  *     star-count fetch
@@ -133,6 +134,17 @@ const LANDING_RULES: Rule[] = [
     },
 ];
 
+/**
+ * The Glama connector-ownership route (`/.well-known/glama.json`) exists only to
+ * claim the maintainer's Glama listing and hard-codes their email, so drop the
+ * whole handler. Matches the comment through the route's closing `});` and the
+ * trailing blank line, leaving the surrounding routes intact.
+ */
+const GLAMA_RULE: Rule = {
+    name: "Glama connector-ownership route",
+    find: /[ \t]*\/\/ Glama connector ownership verification\.[\s\S]*?app\.get\("\/\.well-known\/glama\.json"[\s\S]*?\n\}\);\n\n/,
+};
+
 /** Tighten the Content-Security-Policy: drop GA + GitHub API hosts. */
 const CSP_RULES: Rule[] = [
     {
@@ -204,7 +216,7 @@ const JOBS: { path: string; rules: Rule[] }[] = [
     // SITE constant, GA tag, GitHub/contact links by hand (see its header).
     { path: "public/sitemap.xml", rules: [DOMAIN_RULE] },
     { path: "public/robots.txt", rules: [DOMAIN_RULE] },
-    { path: "src/index.ts", rules: CSP_RULES },
+    { path: "src/index.ts", rules: [GLAMA_RULE, ...CSP_RULES] },
 ];
 
 let hadWarning = false;

--- a/src/index.ts
+++ b/src/index.ts
@@ -114,6 +114,15 @@ app.get("/.well-known/oauth-authorization-server", (c) => {
     });
 });
 
+// Glama connector ownership verification. Glama polls this file and matches the
+// maintainer email against the Glama account email to claim the listing.
+app.get("/.well-known/glama.json", (c) => {
+    return c.json({
+        $schema: "https://glama.ai/mcp/schemas/connector.json",
+        maintainers: [{ email: "akutishevsky@gmail.com" }],
+    });
+});
+
 // OAuth routes
 app.route("/", createOAuthRouter());
 


### PR DESCRIPTION
## Summary
- Serve `/.well-known/glama.json` with the maintainer email so [Glama](https://glama.ai) can verify and claim the connector listing.
- Add a `depersonalize.ts` rule (`GLAMA_RULE`) that strips the route (and its embedded email) so self-hosters stay clean.

## Notes
- Verified locally: `GET /.well-known/glama.json` → `200 application/json` with the expected payload.
- Depersonalize dry-run reports `✓ 1× Glama connector-ownership route` and removes it cleanly, leaving surrounding routes intact.
- No version bump / registry republish needed — this isn't discovery metadata. Glama auto-detects the file once deployed to DigitalOcean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)