### PR TITLE
docs: clarify that merging to main auto-deploys to DigitalOcean

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,9 +6,13 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 nutrition-mcp is a Model Context Protocol (MCP) server for nutrition-related functionality, built with Bun and TypeScript. Entry point is `src/index.ts`. Server version must be updated in three places: `package.json`, `src/mcp.ts` (McpServer constructor), and `server.json`. The server icon is at `public/favicon.ico`. Tool call analytics (duration, success/failure, error category) are tracked via `src/analytics.ts` and persisted to a `tool_analytics` Supabase table.
 
-## Releasing
+## Deploying
 
-This is a remote MCP server: deploying to DigitalOcean makes code changes live for clients immediately (the MCP Registry is only discovery metadata pointing at `https://nutrition-mcp.com/mcp`, so republishing is not required for a fix to take effect). To refresh the registry listing on a release, bump the version in all three places above, merge to `main`, then push a matching `v*` tag:
+This is a remote MCP server, and DigitalOcean auto-deploys `main`. **Merging to `main` ships to production** — there is no separate deploy step to run and no version bump or tag needed for a change to reach clients. Every client hitting `https://nutrition-mcp.com/mcp` picks it up as soon as the deploy finishes, so treat a merge as a release: prompt and tool-description edits go live exactly like code does.
+
+## Publishing to the registry
+
+Separate from deploying, and rarely required. The MCP Registry is only discovery metadata pointing at `https://nutrition-mcp.com/mcp`, so a fix takes effect without republishing. To refresh the registry listing on a release, bump the version in all three places above, merge to `main`, then push a matching `v*` tag:
 
 ```
 git tag v1.13.3 && git push origin v1.13.3


### PR DESCRIPTION
## Problem

The `Releasing` section conflated two unrelated things — deploying the server and publishing to the MCP Registry — and never stated that DigitalOcean auto-deploys `main`.

It said *"deploying to DigitalOcean makes code changes live"* without saying what triggers a deploy, then immediately described the bump-and-tag flow. Read top to bottom, it implies deploying is a manual step gated behind a version bump and a `v*` tag.

That's not academic: it caused a wrong call in this repo earlier today. After #43 merged I told the author the change wasn't live yet and needed a deploy — it had already shipped.

## Change

Split the section in two:

- **Deploying** — merging to `main` ships to production. No separate deploy step, no version bump, no tag. Notes that prompt and tool-description edits go live exactly like code, so a merge is a release.
- **Publishing to the registry** — separate and rarely required, since the registry is only discovery metadata pointing at `https://nutrition-mcp.com/mcp`. The tag-driven `mcp-publisher` flow is unchanged.

## Notes

Docs only — no code, no behavior change. The `mcp-publisher` / OIDC paragraph is untouched.

Worth knowing given the above: the photo-interview change from #43 is already in production, so verifying it against a real food photo is a now-ish task rather than a pre-release one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
