### PR TITLE
feat(site): add Terms of Service page, correct privacy disclosures

### DIFF
--- a/public/alternatives/cronometer.html
+++ b/public/alternatives/cronometer.html
@@ -654,7 +654,8 @@
                         >GitHub</a
                     >
                     <a href="mailto:anton@nutrition-mcp.com">Contact</a>
-                    <a href="/privacy">Privacy &amp; Terms</a>
+                    <a href="/privacy">Privacy Policy</a>
+                    <a href="/terms">Terms of Service</a>
                 </nav>
             </div>
         </footer>

--- a/public/alternatives/index.html
+++ b/public/alternatives/index.html
@@ -310,7 +310,8 @@
                         >GitHub</a
                     >
                     <a href="mailto:anton@nutrition-mcp.com">Contact</a>
-                    <a href="/privacy">Privacy &amp; Terms</a>
+                    <a href="/privacy">Privacy Policy</a>
+                    <a href="/terms">Terms of Service</a>
                 </nav>
             </div>
         </footer>

--- a/public/alternatives/lifesum.html
+++ b/public/alternatives/lifesum.html
@@ -648,7 +648,8 @@
                         >GitHub</a
                     >
                     <a href="mailto:anton@nutrition-mcp.com">Contact</a>
-                    <a href="/privacy">Privacy &amp; Terms</a>
+                    <a href="/privacy">Privacy Policy</a>
+                    <a href="/terms">Terms of Service</a>
                 </nav>
             </div>
         </footer>

--- a/public/alternatives/lose-it.html
+++ b/public/alternatives/lose-it.html
@@ -650,7 +650,8 @@
                         >GitHub</a
                     >
                     <a href="mailto:anton@nutrition-mcp.com">Contact</a>
-                    <a href="/privacy">Privacy &amp; Terms</a>
+                    <a href="/privacy">Privacy Policy</a>
+                    <a href="/terms">Terms of Service</a>
                 </nav>
             </div>
         </footer>

--- a/public/alternatives/macrofactor.html
+++ b/public/alternatives/macrofactor.html
@@ -660,7 +660,8 @@
                         >GitHub</a
                     >
                     <a href="mailto:anton@nutrition-mcp.com">Contact</a>
-                    <a href="/privacy">Privacy &amp; Terms</a>
+                    <a href="/privacy">Privacy Policy</a>
+                    <a href="/terms">Terms of Service</a>
                 </nav>
             </div>
         </footer>

--- a/public/alternatives/myfitnesspal.html
+++ b/public/alternatives/myfitnesspal.html
@@ -665,7 +665,8 @@
                         >GitHub</a
                     >
                     <a href="mailto:anton@nutrition-mcp.com">Contact</a>
-                    <a href="/privacy">Privacy &amp; Terms</a>
+                    <a href="/privacy">Privacy Policy</a>
+                    <a href="/terms">Terms of Service</a>
                 </nav>
             </div>
         </footer>

--- a/public/alternatives/yazio.html
+++ b/public/alternatives/yazio.html
@@ -641,7 +641,8 @@
                         >GitHub</a
                     >
                     <a href="mailto:anton@nutrition-mcp.com">Contact</a>
-                    <a href="/privacy">Privacy &amp; Terms</a>
+                    <a href="/privacy">Privacy Policy</a>
+                    <a href="/terms">Terms of Service</a>
                 </nav>
             </div>
         </footer>

--- a/public/index.html
+++ b/public/index.html
@@ -2834,7 +2834,8 @@
                         >GitHub</a
                     >
                     <a href="mailto:anton@nutrition-mcp.com">Contact</a>
-                    <a href="/privacy">Privacy &amp; Terms</a>
+                    <a href="/privacy">Privacy Policy</a>
+                    <a href="/terms">Terms of Service</a>
                 </nav>
             </div>
         </footer>

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -24,4 +24,5 @@ Most nutrition apps (MyFitnessPal, Cronometer, Lose It!, MacroFactor, Yazio, Lif
 ## Optional
 
 - [GitHub repository](https://github.com/akutishevsky/nutrition-mcp): Source code, self-hosting instructions, and tech stack (Bun, Hono, Supabase).
-- [Privacy & Terms](https://nutrition-mcp.com/privacy): Data handling, export, and account deletion.
+- [Privacy Policy](https://nutrition-mcp.com/privacy): Data handling, export, and account deletion.
+- [Terms of Service](https://nutrition-mcp.com/terms): Acceptable use, not-medical-advice notice, no warranty, and termination.

--- a/public/login.html
+++ b/public/login.html
@@ -110,6 +110,17 @@
                         Continue
                     </button>
                     <p class="auth-note">
+                        By continuing you confirm you're at least 16 and agree
+                        to the
+                        <a href="/terms" target="_blank" rel="noopener"
+                            >Terms of Service</a
+                        >
+                        and
+                        <a href="/privacy" target="_blank" rel="noopener"
+                            >Privacy Policy</a
+                        >.
+                    </p>
+                    <p class="auth-note">
                         New here? Just enter your email and password — an
                         account will be created automatically.
                     </p>

--- a/public/privacy.html
+++ b/public/privacy.html
@@ -1,9 +1,31 @@
 <!doctype html>
 <html lang="en">
     <head>
-        <title>Privacy & Terms — Nutrition MCP</title>
+        <title>Privacy Policy — Nutrition MCP</title>
         <meta name="viewport" content="width=device-width, initial-scale=1" />
         <meta charset="utf-8" />
+        <meta
+            name="description"
+            content="How Nutrition MCP handles your data: what we store, how it is used, where it lives, and how to delete your account and everything in it at any time."
+        />
+        <meta property="og:title" content="Privacy Policy — Nutrition MCP" />
+        <meta
+            property="og:description"
+            content="How Nutrition MCP handles your data: what we store, how it is used, where it lives, and how to delete your account and everything in it at any time."
+        />
+        <meta property="og:type" content="website" />
+        <meta property="og:url" content="https://nutrition-mcp.com/privacy" />
+        <meta property="og:image" content="https://nutrition-mcp.com/og.png" />
+        <meta property="og:image:width" content="1200" />
+        <meta property="og:image:height" content="630" />
+        <meta name="twitter:card" content="summary_large_image" />
+        <meta name="twitter:image" content="https://nutrition-mcp.com/og.png" />
+        <meta name="twitter:title" content="Privacy Policy — Nutrition MCP" />
+        <meta
+            name="twitter:description"
+            content="How Nutrition MCP handles your data: what we store, how it is used, where it lives, and how to delete your account and everything in it at any time."
+        />
+        <link rel="canonical" href="https://nutrition-mcp.com/privacy" />
         <link rel="icon" href="/favicon.ico" />
         <meta name="theme-color" content="#4a7c59" />
         <link rel="preconnect" href="https://fonts.googleapis.com" />
@@ -51,27 +73,107 @@
             <div class="auth-card">
                 <div class="auth-head">
                     <span class="auth-mark" aria-hidden="true">🍏</span>
-                    <h1 class="auth-title">Privacy &amp; Terms</h1>
+                    <h1 class="auth-title">Privacy Policy</h1>
                 </div>
+
+                <p class="legal-updated">Last updated: July 23, 2026</p>
 
                 <div class="legal-section">
                     <h2 class="legal-heading">What we collect</h2>
                     <p>
                         When you register, we store your
                         <strong>email address</strong> and a securely hashed
-                        password via Supabase Auth. When you use the service, we
-                        store your <strong>meal logs</strong> (description, meal
-                        type, calories, macros, notes, and timestamps).
+                        password via Supabase Auth. If you sign in with Google
+                        instead, we receive your email address from Google and
+                        never see a password at all.
+                    </p>
+                    <p>When you use the service, we store:</p>
+                    <ul>
+                        <li>
+                            <strong>Meal logs</strong> — description, meal type,
+                            calories, macros, notes, and timestamps. Food photos
+                            are interpreted by your AI assistant and are never
+                            uploaded to or stored by us.
+                        </li>
+                        <li>
+                            <strong>Water logs</strong> — amount, notes, and
+                            timestamps.
+                        </li>
+                        <li>
+                            <strong>Body weight logs</strong> — weight, notes,
+                            and timestamps. This is health data, and it is
+                            treated exactly like the rest of your logs.
+                        </li>
+                        <li>
+                            <strong>Goals</strong> — your daily calorie,
+                            protein, carb, fat, and water targets, and your
+                            target weight.
+                        </li>
+                        <li>
+                            <strong>Profile settings</strong> — your IANA
+                            timezone, preferred weight unit, and whether in-chat
+                            widgets are enabled.
+                        </li>
+                        <li>
+                            <strong>Tool-usage telemetry</strong> — for each MCP
+                            tool call, which tool ran, whether it succeeded, how
+                            long it took, a coarse error category when it
+                            failed, the span in days of any date range you asked
+                            for, and the MCP session id. It is linked to your
+                            account id. It never includes the content of your
+                            logs.
+                        </li>
+                    </ul>
+                    <p>
+                        We also keep the OAuth access and refresh tokens and
+                        authorization codes that let your AI assistant stay
+                        connected to your account.
                     </p>
                 </div>
 
                 <div class="legal-section">
                     <h2 class="legal-heading">How we use it</h2>
                     <p>
-                        Your data is used solely to provide the nutrition
-                        tracking service. We do not sell, share, or distribute
-                        your data to third parties. We do not use your data for
-                        advertising or analytics.
+                        Your meal, water, weight, and goal data is used solely
+                        to provide the nutrition tracking service. We
+                        <strong
+                            >never sell it, never share it with third parties,
+                            and never use it for advertising</strong
+                        >
+                        or feed it into any ad or profiling system.
+                    </p>
+                    <p>
+                        Two kinds of analytics do exist, and neither touches the
+                        content of your logs:
+                    </p>
+                    <ul>
+                        <li>
+                            <strong>Website analytics.</strong> These pages load
+                            Google Analytics, which gives us aggregate traffic
+                            statistics — page views, referrers, rough geography,
+                            device type. It runs on every page, including this
+                            one, and there is currently no consent banner and no
+                            IP anonymization, so Google receives your IP address
+                            as part of the standard measurement. If you would
+                            rather not be measured, a tracker blocker or your
+                            browser's &ldquo;do not track&rdquo;-style
+                            protections will stop it.
+                        </li>
+                        <li>
+                            <strong>Server telemetry.</strong> Every MCP tool
+                            call writes one row of usage telemetry — which tool
+                            ran, whether it succeeded, how long it took — linked
+                            to your account id but not to what you logged. We
+                            use it to find slow and broken tools. It is not
+                            shared with anyone, and it is deleted along with
+                            everything else when you delete your account.
+                        </li>
+                    </ul>
+                    <p>
+                        Because the site loads fonts and icons from Google Fonts
+                        and jsDelivr, and the home page fetches the project's
+                        star count from the GitHub API, visiting these pages
+                        exposes your IP address to those providers.
                     </p>
                 </div>
 
@@ -94,24 +196,32 @@
                     <h2 class="legal-heading">Data deletion</h2>
                     <p>
                         You can delete your account and all associated data at
-                        any time by asking Claude to
+                        any time by asking your AI assistant to
                         <strong>delete your account</strong> while connected to
                         the Nutrition MCP server. This action is immediate and
-                        irreversible.
+                        irreversible. It removes your meals, water and weight
+                        logs, goals, profile settings, any stored CSV export,
+                        your tool-usage telemetry, your access tokens, and the
+                        account itself.
                     </p>
                 </div>
 
                 <div class="legal-section">
-                    <h2 class="legal-heading">No warranty</h2>
+                    <h2 class="legal-heading">Terms of Service</h2>
                     <p>
-                        This service is provided as-is, free of charge, with no
-                        guarantees of availability, accuracy, or fitness for any
-                        purpose. Use at your own risk.
+                        Use of the service is also governed by our
+                        <a href="/terms">Terms of Service</a>, which cover
+                        acceptable use, the fact that nothing here is medical
+                        advice, and the absence of any warranty — the service is
+                        provided as-is, free of charge, with no guarantees of
+                        availability, accuracy, or fitness for any purpose.
                     </p>
                 </div>
 
                 <div class="legal-foot">
                     <a href="/" class="legal-back">&larr; Back to home</a>
+                    <span class="legal-sep" aria-hidden="true">·</span>
+                    <a href="/terms" class="legal-back">Terms of Service</a>
                 </div>
             </div>
         </main>

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -53,6 +53,13 @@
     </url>
     <url>
         <loc>https://nutrition-mcp.com/privacy</loc>
+        <lastmod>2026-07-23</lastmod>
+        <changefreq>yearly</changefreq>
+        <priority>0.3</priority>
+    </url>
+    <url>
+        <loc>https://nutrition-mcp.com/terms</loc>
+        <lastmod>2026-07-23</lastmod>
         <changefreq>yearly</changefreq>
         <priority>0.3</priority>
     </url>

--- a/public/styles.css
+++ b/public/styles.css
@@ -222,49 +222,8 @@ pre.code-block {
     padding-top: 1.25rem;
 }
 
-/* legal page */
-.legal-section {
-    margin-bottom: 1.25rem;
-}
-
-.legal-section:last-of-type {
-    margin-bottom: 0;
-}
-
-.legal-heading {
-    font-family: "DM Serif Display", serif;
-    font-size: 1rem;
-    font-weight: 400;
-    color: #2c2416;
-    margin-bottom: 0.35rem;
-}
-
-.legal-section p {
-    font-size: 0.875rem;
-    line-height: 1.6;
-    color: #5a5247;
-}
-
-.legal-section a {
-    color: var(--accent);
-    text-decoration: underline;
-    text-underline-offset: 2px;
-}
-
-.legal-section a:hover {
-    color: var(--accent-hover);
-}
-
-.back-link {
-    font-size: 0.85rem;
-    color: #8a7e6b;
-    text-decoration: none;
-    transition: color 0.2s ease;
-}
-
-.back-link:hover {
-    color: #2c2416;
-}
+/* Legal pages (/privacy, /terms) are styled under `body.auth` further down
+   this file — see the "Privacy / legal page" section. */
 
 .icon-wrap-small {
     width: 56px;
@@ -2404,6 +2363,14 @@ body.auth[data-theme="dark"] {
     text-align: center;
     color: var(--auth-ink-2);
 }
+/* Links inside the fine print (Terms / Privacy consent line). Accent + an
+   underline so they are distinguishable from the muted note text without
+   relying on colour alone. */
+body.auth .auth-note a {
+    color: var(--accent);
+    text-decoration: underline;
+    text-underline-offset: 2px;
+}
 
 /* error banner (rendered into {{ERROR}} as .error-banner) */
 body.auth .error-banner {
@@ -2470,9 +2437,6 @@ body.auth .error-banner {
 body.auth .auth-card .legal-section {
     margin-bottom: 1.5rem;
 }
-body.auth .auth-card .legal-section:last-of-type {
-    margin-bottom: 0;
-}
 body.auth .legal-heading {
     font-family: var(--font-display);
     font-weight: 700;
@@ -2506,11 +2470,42 @@ body.auth .legal-section a:hover {
 .legal-back {
     font-size: 0.9rem;
     color: var(--auth-ink-2);
-    text-decoration: none;
+    text-decoration: underline;
+    text-underline-offset: 2px;
     transition: color 0.2s ease;
 }
 .legal-back:hover {
     color: var(--auth-ink);
+}
+/* Terms page extras: sections there run to several paragraphs and a bullet
+   list, where the privacy page is one paragraph per section. */
+body.auth .legal-section p + p,
+body.auth .legal-section ul + p {
+    margin-top: 0.7rem;
+}
+body.auth .legal-section ul {
+    margin: 0.55rem 0 0;
+    padding-left: 1.15rem;
+    font-size: 0.95rem;
+    line-height: 1.6;
+    color: var(--auth-ink-2);
+}
+body.auth .legal-section li {
+    margin-bottom: 0.35rem;
+}
+body.auth .legal-section li:last-child {
+    margin-bottom: 0;
+}
+body.auth .legal-updated {
+    font-size: 0.82rem;
+    color: var(--auth-ink-2);
+    margin: -0.4rem 0 1.5rem;
+}
+.legal-sep {
+    color: var(--auth-ink-2);
+    opacity: 0.45;
+    margin: 0 0.55rem;
+    font-size: 0.9rem;
 }
 
 /* ---------- SEO comparison / "alternative" landing pages ---------- */

--- a/public/terms.html
+++ b/public/terms.html
@@ -1,0 +1,420 @@
+<!doctype html>
+<html lang="en">
+    <head>
+        <title>Terms of Service — Nutrition MCP</title>
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <meta charset="utf-8" />
+        <meta
+            name="description"
+            content="The terms that govern use of Nutrition MCP — the free, open-source nutrition tracker and remote MCP server for Claude and ChatGPT. Plain-language terms covering accounts, acceptable use, your data, and liability."
+        />
+        <meta property="og:title" content="Terms of Service — Nutrition MCP" />
+        <meta
+            property="og:description"
+            content="The terms that govern use of Nutrition MCP — the free, open-source nutrition tracker and remote MCP server for Claude and ChatGPT."
+        />
+        <meta property="og:type" content="website" />
+        <meta property="og:url" content="https://nutrition-mcp.com/terms" />
+        <meta property="og:image" content="https://nutrition-mcp.com/og.png" />
+        <meta property="og:image:width" content="1200" />
+        <meta property="og:image:height" content="630" />
+        <meta name="twitter:card" content="summary_large_image" />
+        <meta name="twitter:image" content="https://nutrition-mcp.com/og.png" />
+        <meta name="twitter:title" content="Terms of Service — Nutrition MCP" />
+        <meta
+            name="twitter:description"
+            content="The terms that govern use of Nutrition MCP — the free, open-source nutrition tracker and remote MCP server for Claude and ChatGPT."
+        />
+        <link rel="canonical" href="https://nutrition-mcp.com/terms" />
+        <link rel="icon" href="/favicon.ico" />
+        <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
+        <meta name="theme-color" content="#4a7c59" />
+        <link rel="preconnect" href="https://fonts.googleapis.com" />
+        <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+        <link
+            href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=Inter+Tight:wght@700;800&display=swap"
+            rel="stylesheet"
+        />
+        <link rel="stylesheet" href="/styles.css" />
+        <script
+            async
+            src="https://www.googletagmanager.com/gtag/js?id=G-1K4HRB2R8X"
+        ></script>
+        <script>
+            window.dataLayer = window.dataLayer || [];
+            function gtag() {
+                dataLayer.push(arguments);
+            }
+            gtag("js", new Date());
+            gtag("config", "G-1K4HRB2R8X");
+        </script>
+    </head>
+    <body class="auth">
+        <script>
+            // Apply a saved theme override before paint to avoid a flash.
+            // With no saved preference, the OS setting drives it via CSS.
+            (function () {
+                try {
+                    var t = localStorage.getItem("theme");
+                    if (t === "dark" || t === "light")
+                        document.body.setAttribute("data-theme", t);
+                } catch (e) {}
+            })();
+        </script>
+
+        <button
+            class="auth-toggle"
+            type="button"
+            id="theme-toggle"
+            aria-label="Toggle dark mode"
+            title="Toggle dark mode"
+        ></button>
+
+        <main class="auth-wrap legal">
+            <div class="auth-card">
+                <div class="auth-head">
+                    <span class="auth-mark" aria-hidden="true">🍏</span>
+                    <h1 class="auth-title">Terms of Service</h1>
+                </div>
+
+                <p class="legal-updated">Last updated: July 23, 2026</p>
+
+                <div class="legal-section">
+                    <h2 class="legal-heading">Agreement</h2>
+                    <p>
+                        These terms govern your use of Nutrition MCP (the
+                        &ldquo;service&rdquo;) — the website at
+                        nutrition-mcp.com and the remote MCP server at
+                        <strong>https://nutrition-mcp.com/mcp</strong>. By
+                        creating an account or connecting an AI assistant to the
+                        server, you agree to these terms. If you do not agree,
+                        please do not use the service.
+                    </p>
+                </div>
+
+                <div class="legal-section">
+                    <h2 class="legal-heading">The service</h2>
+                    <p>
+                        Nutrition MCP is a free, open-source nutrition tracker
+                        that runs as an MCP server, letting AI assistants such
+                        as Claude and ChatGPT log meals, water, and body weight
+                        on your behalf. There is no paid tier, no advertising,
+                        and no charge for using the service. We accept voluntary
+                        donations on Patreon to help cover hosting and database
+                        costs; they are a gift, not a purchase, and they buy no
+                        features, no tier, and no priority of any kind. The
+                        source code is published under the MIT license on
+                        <a
+                            href="https://github.com/akutishevsky/nutrition-mcp"
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            >GitHub</a
+                        >
+                        and you are free to self-host it.
+                    </p>
+                </div>
+
+                <div class="legal-section">
+                    <h2 class="legal-heading">Your account</h2>
+                    <p>
+                        You must be at least 16 years old to use the service. We
+                        do not verify age, so by creating an account you confirm
+                        you meet that requirement. You are responsible for
+                        keeping your login credentials confidential and for all
+                        activity that happens under your account. Please provide
+                        an email address you actually control — it is the only
+                        way to recover access.
+                    </p>
+                </div>
+
+                <div class="legal-section">
+                    <h2 class="legal-heading">Not medical advice</h2>
+                    <p>
+                        Nutrition MCP is a logging and reporting tool, not a
+                        healthcare service. Nothing it produces — calorie and
+                        macro figures, goals, trends, or any commentary your AI
+                        assistant adds — is medical, nutritional, or dietary
+                        advice, and none of it is a substitute for a qualified
+                        professional. Consult a doctor or dietitian before
+                        making decisions about your health, especially if you
+                        have a medical condition or a history of disordered
+                        eating.
+                    </p>
+                    <p>
+                        The service is not designed for clinical use and should
+                        not be used by anyone with an active eating disorder, or
+                        by anyone who is pregnant or under clinical supervision
+                        for a nutrition-related condition, without their
+                        clinician's involvement. Calorie and macro tracking can
+                        be harmful in those situations. If that describes you,
+                        talk to your clinician before using it.
+                    </p>
+                    <p>
+                        Nutrition figures are <strong>estimates</strong>. They
+                        come from AI models interpreting your descriptions and
+                        photos, from third-party databases such as Open Food
+                        Facts, and from whatever you enter yourself. They can be
+                        wrong. Verify anything that matters.
+                    </p>
+                    <p>
+                        Food photos are never sent to our server. Your AI
+                        assistant interprets the picture on its own side and
+                        sends us only the resulting text and numbers — a
+                        description, a meal type, calories, macros, notes, a
+                        barcode.
+                    </p>
+                </div>
+
+                <div class="legal-section">
+                    <h2 class="legal-heading">Acceptable use</h2>
+                    <p>When using the service, you agree not to:</p>
+                    <ul>
+                        <li>
+                            use it for any unlawful purpose, or in breach of any
+                            applicable law or regulation;
+                        </li>
+                        <li>
+                            attempt to access another user's account or data, or
+                            to bypass authentication, rate limits, or any other
+                            technical control;
+                        </li>
+                        <li>
+                            probe, scan, overload, or disrupt the service or the
+                            infrastructure it runs on, including through
+                            automated bulk requests;
+                        </li>
+                        <li>
+                            upload content that is illegal, or that you have no
+                            right to share;
+                        </li>
+                        <li>
+                            resell the hosted service or present it as your own;
+                        </li>
+                        <li>
+                            use it to pursue extreme calorie restriction, or to
+                            promote, coach, or encourage that in anyone else.
+                        </li>
+                    </ul>
+                    <p>
+                        The service is rate-limited to keep it available for
+                        everyone. If you need higher volume, self-host it — that
+                        is what the MIT license is for.
+                    </p>
+                </div>
+
+                <div class="legal-section">
+                    <h2 class="legal-heading">Your data</h2>
+                    <p>
+                        Your logs remain yours. We store and process them to
+                        operate the service for you, as described in our
+                        <a href="/privacy">Privacy Policy</a>. You are
+                        responsible for the content you log.
+                    </p>
+                    <p>
+                        You can export your <strong>meal log</strong> to CSV at
+                        any time by asking your AI assistant to export your
+                        meals. The export covers meals only — one row per meal
+                        with its time, timezone, meal type, description,
+                        calories, protein, carbs, fat, and notes. Water, weight,
+                        goals, and settings are not included in the export
+                        today. The download link we hand back is private and
+                        expires after 60 minutes.
+                    </p>
+                    <p>
+                        We also record basic operational telemetry about how the
+                        service is used: for every tool call, the tool's name,
+                        whether it succeeded, how long it took, a coarse error
+                        category when it fails, the length of any date range you
+                        asked for, and the session id. These rows are linked to
+                        your account id. They do not contain what you logged —
+                        no food descriptions, no calories, no weights. We use
+                        them to keep the service working and to see which tools
+                        are worth improving, and they are deleted along with
+                        everything else when you delete your account.
+                    </p>
+                    <p>
+                        You can delete your account and all associated data at
+                        any time by asking your AI assistant to
+                        <strong>delete your account</strong> while connected —
+                        that action is immediate and irreversible.
+                    </p>
+                </div>
+
+                <div class="legal-section">
+                    <h2 class="legal-heading">Availability and changes</h2>
+                    <p>
+                        The service is offered free of charge with no uptime
+                        commitment and no service-level agreement. We may
+                        change, suspend, or discontinue any part of it —
+                        including tools, features, and the hosted server itself
+                        — at any time and without notice. We may also modify or
+                        remove content that breaches these terms.
+                    </p>
+                </div>
+
+                <div class="legal-section">
+                    <h2 class="legal-heading">Third-party services</h2>
+                    <p>
+                        The service depends on third parties: Supabase for
+                        database, authentication, and export storage,
+                        DigitalOcean for hosting, Open Food Facts for barcode
+                        data, and whichever AI assistant you connect from.
+                    </p>
+                    <p>
+                        The website itself also uses Google Analytics to measure
+                        traffic, Google Fonts and the jsDelivr CDN to load fonts
+                        and icons, Google Sign-In if you choose that way of
+                        logging in, and the GitHub API to show the project's
+                        star count. Loading a page therefore makes requests to
+                        those services, which can see your IP address and
+                        browser.
+                    </p>
+                    <p>
+                        Their terms and their availability are their own, and we
+                        are not responsible for them.
+                    </p>
+                </div>
+
+                <div class="legal-section">
+                    <h2 class="legal-heading">No warranty</h2>
+                    <p>
+                        The service is provided
+                        <strong
+                            >&ldquo;as is&rdquo; and &ldquo;as
+                            available&rdquo;</strong
+                        >, without warranties of any kind, express or implied,
+                        including any implied warranties of merchantability,
+                        fitness for a particular purpose, accuracy, or
+                        non-infringement. We do not warrant that the service
+                        will be uninterrupted, secure, error-free, or that any
+                        data or nutrition figure it produces is accurate. You
+                        use it at your own risk.
+                    </p>
+                </div>
+
+                <div class="legal-section">
+                    <h2 class="legal-heading">Limitation of liability</h2>
+                    <p>
+                        To the fullest extent permitted by law, we are not
+                        liable for any indirect, incidental, special,
+                        consequential, or exemplary damages, nor for any loss of
+                        data or profits, arising out of or in connection with
+                        your use of the service.
+                    </p>
+                </div>
+
+                <div class="legal-section">
+                    <h2 class="legal-heading">Your legal rights</h2>
+                    <p>
+                        Some liability can never be excluded, and we do not try
+                        to. We remain fully liable for death or personal injury
+                        caused by our negligence, and for fraud or fraudulent
+                        misrepresentation.
+                    </p>
+                    <p>
+                        You also keep every right the law gives you as a
+                        consumer. These terms sit alongside those rights and do
+                        not reduce them. Where a section above conflicts with a
+                        right you cannot sign away, your legal right wins.
+                    </p>
+                </div>
+
+                <div class="legal-section">
+                    <h2 class="legal-heading">Termination</h2>
+                    <p>
+                        You may stop using the service at any time and delete
+                        your account as described above. We may suspend or
+                        terminate access that breaches these terms or that
+                        threatens the stability or security of the service. The
+                        &ldquo;No warranty&rdquo;, &ldquo;Limitation of
+                        liability&rdquo;, and &ldquo;Your legal rights&rdquo;
+                        sections survive termination.
+                    </p>
+                </div>
+
+                <div class="legal-section">
+                    <h2 class="legal-heading">Changes to these terms</h2>
+                    <p>
+                        We may update these terms from time to time. The current
+                        version always lives at this page, with the date at the
+                        top showing when it last changed. Continuing to use the
+                        service after an update means you accept the revised
+                        terms.
+                    </p>
+                </div>
+
+                <div class="legal-section">
+                    <h2 class="legal-heading">Severability</h2>
+                    <p>
+                        If any part of these terms is found to be unenforceable,
+                        that part is removed and the rest stays in force.
+                    </p>
+                </div>
+
+                <div class="legal-section">
+                    <h2 class="legal-heading">Contact</h2>
+                    <p>
+                        Questions about these terms? Email
+                        <a href="mailto:anton@nutrition-mcp.com"
+                            >anton@nutrition-mcp.com</a
+                        >.
+                    </p>
+                </div>
+
+                <div class="legal-foot">
+                    <a href="/" class="legal-back">&larr; Back to home</a>
+                    <span class="legal-sep" aria-hidden="true">·</span>
+                    <a href="/privacy" class="legal-back">Privacy Policy</a>
+                </div>
+            </div>
+        </main>
+
+        <script>
+            (function () {
+                var btn = document.getElementById("theme-toggle");
+                if (!btn) return;
+                var meta = document.querySelector('meta[name="theme-color"]');
+                var darkQuery = window.matchMedia(
+                    "(prefers-color-scheme: dark)",
+                );
+                var MOON =
+                    '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 12.8A9 9 0 1 1 11.2 3a7 7 0 0 0 9.8 9.8z"/></svg>';
+                var SUN =
+                    '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M2 12h2M20 12h2M4.9 4.9l1.4 1.4M17.7 17.7l1.4 1.4M19.1 4.9l-1.4 1.4M6.3 17.7l-1.4 1.4"/></svg>';
+                // Effective theme = explicit override, else the OS setting.
+                function effectiveTheme() {
+                    var override = document.body.getAttribute("data-theme");
+                    if (override) return override;
+                    return darkQuery.matches ? "dark" : "light";
+                }
+                function syncUI() {
+                    var dark = effectiveTheme() === "dark";
+                    btn.innerHTML = dark ? SUN : MOON;
+                    var label = dark
+                        ? "Switch to light mode"
+                        : "Switch to dark mode";
+                    btn.setAttribute("aria-label", label);
+                    btn.setAttribute("title", label);
+                    if (meta)
+                        meta.setAttribute(
+                            "content",
+                            dark ? "#161617" : "#4a7c59",
+                        );
+                }
+                btn.addEventListener("click", function () {
+                    var next = effectiveTheme() === "dark" ? "light" : "dark";
+                    document.body.setAttribute("data-theme", next);
+                    try {
+                        localStorage.setItem("theme", next);
+                    } catch (e) {}
+                    syncUI();
+                });
+                // While following the OS (no override), track system changes.
+                darkQuery.addEventListener("change", function () {
+                    if (!document.body.getAttribute("data-theme")) syncUI();
+                });
+                syncUI();
+            })();
+        </script>
+    </body>
+</html>

--- a/public/tools.html
+++ b/public/tools.html
@@ -1854,7 +1854,8 @@
                         >GitHub</a
                     >
                     <a href="mailto:anton@nutrition-mcp.com">Contact</a>
-                    <a href="/privacy">Privacy &amp; Terms</a>
+                    <a href="/privacy">Privacy Policy</a>
+                    <a href="/terms">Terms of Service</a>
                 </nav>
             </div>
         </footer>

--- a/scripts/depersonalize.ts
+++ b/scripts/depersonalize.ts
@@ -198,6 +198,27 @@ const JOBS: { path: string; rules: Rule[] }[] = [
     },
     { path: "public/login.html", rules: [...ANALYTICS_RULES, DOMAIN_RULE] },
     { path: "public/privacy.html", rules: [...ANALYTICS_RULES, DOMAIN_RULE] },
+    // Terms page. Its GitHub link and contact mailto sit mid-sentence, so the
+    // generic GITHUB_LINKS_RULE / MAILTO_RULE (which delete the whole anchor
+    // line) would leave dangling prose — unwrap them to text instead. Both run
+    // before DOMAIN_RULE so the email goes before the domain sweep sees it.
+    {
+        path: "public/terms.html",
+        rules: [
+            ...ANALYTICS_RULES,
+            {
+                name: "terms: 'GitHub' prose link -> plain text",
+                find: /<a\b[^>]*href="https:\/\/github\.com\/akutishevsky\/nutrition-mcp"[^>]*>GitHub<\/a\s*>/,
+                replace: "GitHub",
+            },
+            {
+                name: "terms: contact mailto -> placeholder address",
+                find: /<a\b[^>]*?href="mailto:anton@nutrition-mcp\.com"[^>]*>[^<]*<\/a\s*>/,
+                replace: "your@email.com",
+            },
+            DOMAIN_RULE,
+        ],
+    },
     // Tools reference page: GA + the nav/footer GitHub link, the footer contact
     // mailto, and the canonical/OG domain.
     {

--- a/scripts/gen-alternatives.ts
+++ b/scripts/gen-alternatives.ts
@@ -339,7 +339,8 @@ const FOOTER = `        <footer class="footer">
                         >GitHub</a
                     >
                     <a href="mailto:anton@nutrition-mcp.com">Contact</a>
-                    <a href="/privacy">Privacy &amp; Terms</a>
+                    <a href="/privacy">Privacy Policy</a>
+                    <a href="/terms">Terms of Service</a>
                 </nav>
             </div>
         </footer>`;

--- a/src/index.ts
+++ b/src/index.ts
@@ -204,10 +204,17 @@ app.get("/", async (c) => {
     return c.html(await Bun.file("./public/index.html").text());
 });
 
-// Privacy & Terms
+// Privacy Policy
 app.get("/privacy", async (c) => {
     return c.html(await Bun.file("./public/privacy.html").text());
 });
+app.get("/privacy/", (c) => c.redirect("/privacy", 301));
+
+// Terms of Service
+app.get("/terms", async (c) => {
+    return c.html(await Bun.file("./public/terms.html").text());
+});
+app.get("/terms/", (c) => c.redirect("/terms", 301));
 
 // Tools reference — the full list of MCP tools with descriptions and examples.
 app.get("/tools", async (c) => {

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -84,6 +84,8 @@ const WEIGHT_TRENDS_WIDGET_URI = "ui://widget/weight-trends.html";
 // follow it, so the loop cannot be strictly enforced from here.
 const SERVER_INSTRUCTIONS = `Nutrition tracking: meals, water, weight, goals, and trends, per-user with timezone support.
 
+All nutrition figures are estimates and this server does not provide medical or dietary advice.
+
 Photo-based meal logging — when the user sends a photo of food, follow these steps in order:
 1. Pick the flow. A packaged product with a visible barcode: transcribe the digits printed under the barcode and call lookup_barcode. A plate, bowl, or prepared meal: continue below.
 2. Identify each distinct dish or food item in the photo.
@@ -917,7 +919,7 @@ function registerTools(
         {
             title: "Get Nutrition Summary",
             description:
-                "Get daily nutrition totals for a date range. Renders an interactive dashboard (macro tiles vs. goals and a per-day breakdown) in clients that support MCP Apps UI, and returns the same data as text elsewhere.",
+                "Get daily nutrition totals for a date range. Renders an interactive dashboard (macro tiles vs. goals and a per-day breakdown) in clients that support MCP Apps UI, and returns the same data as text elsewhere. Figures are estimates, not medical or dietary advice.",
             annotations: {
                 readOnlyHint: true,
                 destructiveHint: false,
@@ -1114,7 +1116,7 @@ function registerTools(
         {
             title: "Set Nutrition Goals",
             description:
-                "Set the user's daily calorie and macro targets, and optionally a target body weight. Pass only the fields you want to update — omitted fields keep their previous value. Pass null explicitly to clear a target.",
+                "Set the user's daily calorie and macro targets, and optionally a target body weight. Pass only the fields you want to update — omitted fields keep their previous value. Pass null explicitly to clear a target. Targets are the user's own choice; this server does not provide medical or dietary advice.",
             annotations: {
                 readOnlyHint: false,
                 destructiveHint: false,
@@ -1269,7 +1271,7 @@ function registerTools(
         {
             title: "Get Goal Progress",
             description:
-                "Get progress against daily nutrition goals for a specific date (defaults to today). Renders intake-vs-goal rings plus body-weight progress in clients that support MCP Apps UI, and returns the same data as text elsewhere.",
+                "Get progress against daily nutrition goals for a specific date (defaults to today). Renders intake-vs-goal rings plus body-weight progress in clients that support MCP Apps UI, and returns the same data as text elsewhere. Figures are estimates, not medical or dietary advice.",
             annotations: {
                 readOnlyHint: true,
                 destructiveHint: false,
@@ -2387,7 +2389,7 @@ function registerTools(
         {
             title: "Get Trends",
             description:
-                "Rolling 7/14/30-day averages, standard deviation, coefficient of variation, logging streaks, day-of-week breakdowns, and best/worst day for calories and each macro. Pre-aggregated so you can narrate findings to the user without doing arithmetic. Defaults to the last 30 days ending today.",
+                "Rolling 7/14/30-day averages, standard deviation, coefficient of variation, logging streaks, day-of-week breakdowns, and best/worst day for calories and each macro. Pre-aggregated so you can narrate findings to the user without doing arithmetic. Defaults to the last 30 days ending today. Figures are estimates, not medical or dietary advice.",
             annotations: {
                 readOnlyHint: true,
                 destructiveHint: false,
@@ -2511,7 +2513,7 @@ function registerTools(
         {
             title: "Get Meal Patterns",
             description:
-                "Pre-aggregated behavioural patterns across the logged window: meal-type presence rates, breakfast effect (days with vs without), high-calorie-lunch effect, late-dinner effect, weekday vs weekend, and outlier days. Narrate findings conversationally to the user. Defaults to the last 30 days.",
+                "Pre-aggregated behavioural patterns across the logged window: meal-type presence rates, breakfast effect (days with vs without), high-calorie-lunch effect, late-dinner effect, weekday vs weekend, and outlier days. Narrate findings conversationally to the user. Defaults to the last 30 days. Patterns are descriptive estimates, not medical or dietary advice.",
             annotations: {
                 readOnlyHint: true,
                 destructiveHint: false,


### PR DESCRIPTION
TAAFT rejected the listing because the site has no Terms of Service. This adds one — and fixes the factual problems a review of it turned up in the existing legal pages.

## What's new

- **`/terms`** — `public/terms.html`, route + trailing-slash redirect, linked as "Terms of Service" in every footer, plus sitemap and `llms.txt` entries.
- The old combined **"Privacy & Terms"** page is now **"Privacy Policy"**; the two cross-link.

## Accuracy fixes

Each was verified against the code, not assumed:

| Claim | Reality | Fix |
|---|---|---|
| "export everything to CSV" | `src/export.ts` exports 10 meal columns; `getAllMeals()` reads `meals` only | Terms now promise the meal log only |
| "no charge of any kind" | landing page sells a Patreon "pay what you want" tier | donations carved out explicitly |
| privacy: "we do not use your data for advertising or **analytics**" | GA loads on every page incl. that one; `src/analytics.ts` writes a `user_id`-keyed `tool_analytics` row per tool call | replaced with an accurate description of both; states telemetry is deleted with the account (verified against `deleteAllUserData`) |
| third-party list | CSP in `src/index.ts` allows seven hosts the page never mentioned | list now matches the CSP |
| "what we collect" | omitted water, weight, goals, settings, tokens | all covered |

## Signup consent

`login.html` linked to neither legal page and had no assent text — so the terms were browsewrap and the "16+" term was never shown to anyone. Adds a consent line under the Continue button, visible without scrolling on both sign-in paths. Links open in a new tab so they can't kill the in-flight OAuth session. No form or JS behaviour changed.

## ⚠️ Ships to connected clients on merge

`src/mcp.ts` gains one sentence in the server instructions and a short "estimates, not medical advice" clause on five tools (`set_nutrition_goals`, `get_goal_progress`, `get_nutrition_summary`, `get_trends`, `get_meal_patterns`). Most users reach this product through Claude and never load the website, so the disclaimer needs to live here too. The other ~29 tools were deliberately left alone to avoid diluting routing signal. Descriptions only — no schema, `_meta`, or handler changes.

## Also

- Dropped "or health outcomes" from the liability exclusion (void for UK/EU consumers anyway) and moved the consumer-rights savings language into its own plain-English section
- Added severability, an eating-disorder scope limit, and an age-not-verified representation
- `canonical` + meta/og tags on both legal pages (kept indexed — a `noindex` would contradict the sitemap)
- Fixed `.legal-updated` failing WCAG AA (3.09:1 → 5.07:1 light) and removed a dead legacy `.legal-*` CSS block

## Verification

- `bun test` — 84 pass, 0 fail
- `scripts/depersonalize.ts --dry` — no unmatched rules (terms-specific unwrap rules added, since its links sit mid-sentence and the generic sweeps would leave dangling prose)
- Rendered `/terms`, `/privacy`, and the login card in a browser, light and dark

## Open items, deliberately not in this PR

1. **Operator identity** — the terms say only "we"; EU e-commerce rules expect a legal name and country. Needs @akutishevsky to supply it.
2. **The GA consent gap itself** — the privacy page now honestly documents that GA runs on every page with no consent banner and no IP anonymization. Documenting it beats lying about it, but for EU visitors the underlying setup is still the gap.
3. **Age gate stays at 16** — 18 is arguably more defensible for a calorie tracker; left as a product call.
4. **`export_meals` still covers meals only** — the terms are now accurate about it, but extending the export is the better long-term fix.

Not a lawyer; this is plain-language boilerplate for a free tool, not legal advice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)