### PR TITLE
fix(auth): scope OAuth rate limiter, shed repeat auth failures

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,11 @@ import { Hono } from "hono";
 import { cors } from "hono/cors";
 import { bodyLimit } from "hono/body-limit";
 import { createOAuthRouter } from "./oauth.js";
-import { authenticateBearer, rateLimit } from "./middleware.js";
+import {
+    authenticateBearer,
+    rateLimit,
+    banRepeatAuthFailures,
+} from "./middleware.js";
 import { handleMcp } from "./mcp.js";
 import { startExportCleanup } from "./export.js";
 import { getLandingStats, type LandingStats } from "./supabase.js";
@@ -19,11 +23,14 @@ const app = new Hono();
 // OAuth discovery crawls, vuln scanners. Registered first so it runs outermost
 // and observes the final response status. /health is skipped to keep the
 // platform's frequent health checks from evicting real traffic from the buffer.
+// Requests from IPs banned for repeated auth failures are skipped too — they are
+// announced once by a [ban] line and would otherwise dominate the log.
 app.use("*", async (c, next) => {
     const path = new URL(c.req.url).pathname;
     if (path === "/health") return next();
     const start = performance.now();
     await next();
+    if (c.get("suppressAccessLog")) return;
     const ms = Math.round(performance.now() - start);
     const ip = maskIp(c.req.header("x-forwarded-for"));
     console.log(
@@ -126,8 +133,15 @@ app.get("/.well-known/glama.json", (c) => {
 // OAuth routes
 app.route("/", createOAuthRouter());
 
-// MCP endpoint (protected)
-app.all("/mcp", authenticateBearer, rateLimit, handleMcp);
+// MCP endpoint (protected). banRepeatAuthFailures runs first so a client stuck
+// in a failed-auth retry loop is rejected before any token verification.
+app.all(
+    "/mcp",
+    banRepeatAuthFailures,
+    authenticateBearer,
+    rateLimit,
+    handleMcp,
+);
 
 // Aggregate landing-page stats, cached in-memory so page views don't each hit
 // the DB. The numbers move slowly, so a stale value for a few minutes is fine.

--- a/src/middleware.test.ts
+++ b/src/middleware.test.ts
@@ -1,0 +1,173 @@
+import {
+    test,
+    expect,
+    mock,
+    beforeEach,
+    afterEach,
+    afterAll,
+    spyOn,
+} from "bun:test";
+import { Hono } from "hono";
+import * as actualSupabase from "./supabase.js";
+
+// middleware.ts only reaches Supabase to resolve a bearer token, so stubbing
+// that one export is enough to exercise the whole auth path offline. Counting
+// the calls also lets us prove a banned IP is shed *before* any token lookup.
+//
+// mock.module swaps the module for the whole test *process*, not just this
+// file, so the real exports must be spread back in — replacing the module
+// wholesale breaks every other suite that imports getSupabase/signInUser — and
+// restored afterwards so no later file sees the stub.
+let tokenLookups = 0;
+let supabaseAvailable = true;
+mock.module("./supabase.js", () => ({
+    ...actualSupabase,
+    getUserIdByToken: async (token: string) => {
+        tokenLookups++;
+        if (!supabaseAvailable) return { status: "unavailable" };
+        return token === "valid-token"
+            ? { status: "valid", userId: "user-1" }
+            : { status: "invalid" };
+    },
+}));
+afterAll(() => {
+    mock.module("./supabase.js", () => actualSupabase);
+});
+
+const { authenticateBearer, banRepeatAuthFailures, rateLimit } =
+    await import("./middleware.js");
+const { _resetBuckets } = await import("./rate-limit.js");
+
+// Mirrors the /mcp wiring in index.ts: the ban guard runs ahead of the bearer
+// check, and the outermost access log honours the suppression flag. Replicated
+// rather than importing index.ts, which boots a server and warms widgets on
+// import; the ordering asserted here is the thing that matters.
+function buildApp() {
+    const app = new Hono();
+    const logs: string[] = [];
+    app.use("*", async (c, next) => {
+        await next();
+        if (c.get("suppressAccessLog")) return;
+        logs.push(`[req] ${c.req.method} ${c.req.path} ${c.res.status}`);
+    });
+    app.all("/mcp", banRepeatAuthFailures, authenticateBearer, rateLimit, (c) =>
+        c.json({ ok: true }),
+    );
+    return { app, logs };
+}
+
+const from = (ip: string, token?: string) =>
+    new Request("http://localhost/mcp", {
+        method: "POST",
+        headers: {
+            "x-forwarded-for": ip,
+            ...(token ? { Authorization: `Bearer ${token}` } : {}),
+        },
+    });
+
+beforeEach(() => {
+    _resetBuckets();
+    tokenLookups = 0;
+    supabaseAvailable = true;
+});
+afterEach(() => _resetBuckets());
+
+test("unauthenticated /mcp is shed with 429 after the strike threshold", async () => {
+    const { app } = buildApp();
+
+    // The 20th failure trips the ban, but that request is already past the
+    // guard, so it still answers 401. Only the next one is shed.
+    for (let i = 0; i < 20; i++) {
+        expect((await app.fetch(from("1.2.3.4"))).status).toBe(401);
+    }
+
+    const shed = await app.fetch(from("1.2.3.4"));
+    expect(shed.status).toBe(429);
+    expect(Number(shed.headers.get("Retry-After"))).toBeGreaterThan(0);
+});
+
+test("shed requests are kept out of the access log", async () => {
+    const { app, logs } = buildApp();
+    for (let i = 0; i < 20; i++) await app.fetch(from("5.6.7.8"));
+    const beforeShedding = logs.length;
+
+    for (let i = 0; i < 50; i++) await app.fetch(from("5.6.7.8"));
+
+    // All 20 pre-ban 401s are logged; none of the 50 shed requests are. This is
+    // the whole point of the change — one stuck client must not drown the log.
+    expect(beforeShedding).toBe(20);
+    expect(logs.length).toBe(20);
+});
+
+test("a newly tripped ban is announced exactly once", async () => {
+    const { app } = buildApp();
+    const logSpy = spyOn(console, "log").mockImplementation(() => {});
+    try {
+        for (let i = 0; i < 60; i++) await app.fetch(from("9.9.9.9"));
+        const banLines = logSpy.mock.calls
+            .map((args) => String(args[0]))
+            .filter((line) => line.startsWith("[ban]"));
+        expect(banLines).toHaveLength(1);
+        // Masked to the same subnet granularity as the [req] access log.
+        expect(banLines[0]).toContain("9.9.9.x");
+    } finally {
+        logSpy.mockRestore();
+    }
+});
+
+test("a banned IP is shed without a token lookup", async () => {
+    const { app } = buildApp();
+    for (let i = 0; i < 20; i++) await app.fetch(from("4.4.4.4", "bad-token"));
+    const lookupsBeforeBan = tokenLookups;
+
+    for (let i = 0; i < 25; i++) await app.fetch(from("4.4.4.4", "bad-token"));
+
+    // Shedding happens ahead of authenticateBearer, so the Supabase round trip
+    // the ban is meant to save is genuinely never made.
+    expect(lookupsBeforeBan).toBe(20);
+    expect(tokenLookups).toBe(20);
+});
+
+test("a success resets strikes, so a shared IP is never banned", async () => {
+    const { app } = buildApp();
+
+    // The NAT case end-to-end: one broken client failing repeatedly alongside a
+    // working one. Total failures far exceed the threshold, but never 20 in a
+    // row, so the healthy users behind that egress IP keep working.
+    for (let round = 0; round < 5; round++) {
+        for (let i = 0; i < 19; i++) {
+            expect((await app.fetch(from("7.7.7.7"))).status).toBe(401);
+        }
+        expect((await app.fetch(from("7.7.7.7", "valid-token"))).status).toBe(
+            200,
+        );
+    }
+
+    expect((await app.fetch(from("7.7.7.7"))).status).toBe(401);
+});
+
+test("a token lookup outage never bans anyone", async () => {
+    const { app } = buildApp();
+    supabaseAvailable = false;
+
+    // Every token looks unverifiable while the database is down. If those
+    // counted as strikes, the outage would ban the entire active user base and
+    // keep them shed for 5-60 minutes after recovery.
+    for (let i = 0; i < 100; i++) {
+        expect((await app.fetch(from("3.3.3.3", "valid-token"))).status).toBe(
+            401,
+        );
+    }
+
+    supabaseAvailable = true;
+    expect((await app.fetch(from("3.3.3.3", "valid-token"))).status).toBe(200);
+});
+
+test("bans are per-IP and do not affect other clients", async () => {
+    const { app } = buildApp();
+    for (let i = 0; i < 21; i++) await app.fetch(from("8.8.8.8"));
+
+    expect((await app.fetch(from("8.8.8.8"))).status).toBe(429);
+    expect((await app.fetch(from("8.8.4.4"))).status).toBe(401);
+    expect((await app.fetch(from("8.8.4.4", "valid-token"))).status).toBe(200);
+});

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,6 +1,24 @@
 import type { Context, Next } from "hono";
 import { getUserIdByToken } from "./supabase.js";
-import { checkRateLimit, checkAuthRateLimit } from "./rate-limit.js";
+import { maskIp } from "./net.js";
+
+// Declare the context variables this middleware sets. Without it, c.get/c.set on
+// an untyped `new Hono()` app types its keys as `never`, so index.ts cannot read
+// suppressAccessLog.
+declare module "hono" {
+    interface ContextVariableMap {
+        userId: string;
+        accessToken: string;
+        suppressAccessLog: boolean;
+    }
+}
+import {
+    checkRateLimit,
+    checkAuthRateLimit,
+    noteAuthFailure,
+    clearAuthFailures,
+    getBanState,
+} from "./rate-limit.js";
 
 // Best-effort client IP for rate limiting. Behind DigitalOcean's proxy the real
 // IP is the first entry of x-forwarded-for; fall back to x-real-ip. "unknown"
@@ -23,46 +41,100 @@ function getBaseUrl(c: Context): string {
     return new URL(c.req.url).origin;
 }
 
+// Shared 401 path. Every rejection also counts a strike against the client IP so
+// a client that never recovers eventually gets shed by banRepeatAuthFailures.
+function rejectUnauthenticated(
+    c: Context,
+    error: "unauthorized" | "invalid_token",
+    description: string,
+) {
+    const ip = getClientIp(c);
+    const ban = noteAuthFailure(ip);
+    // Reaching here means the ban guard let the request through, so a banned
+    // result is necessarily a *newly* tripped ban — log the transition once
+    // rather than on every suppressed request that follows.
+    if (ban.banned) {
+        console.log(
+            `[ban] ${maskIp(c.req.header("x-forwarded-for"))} repeated auth failures on ${c.req.path} — shedding for ${ban.retryAfterSeconds}s`,
+        );
+    }
+
+    const resourceMetadataUrl = `${getBaseUrl(c)}/.well-known/oauth-protected-resource`;
+    c.header(
+        "WWW-Authenticate",
+        `Bearer resource_metadata="${resourceMetadataUrl}"`,
+    );
+    return c.json({ error, error_description: description }, 401);
+}
+
 export const authenticateBearer = async (c: Context, next: Next) => {
     const authHeader = c.req.header("Authorization");
 
     if (!authHeader || !authHeader.startsWith("Bearer ")) {
-        const baseUrl = getBaseUrl(c);
-        const resourceMetadataUrl = `${baseUrl}/.well-known/oauth-protected-resource`;
-        c.header(
-            "WWW-Authenticate",
-            `Bearer resource_metadata="${resourceMetadataUrl}"`,
-        );
-        return c.json(
-            {
-                error: "unauthorized",
-                error_description: "Bearer token required",
-            },
-            401,
+        return rejectUnauthenticated(
+            c,
+            "unauthorized",
+            "Bearer token required",
         );
     }
 
     const token = authHeader.substring(7);
-    const userId = await getUserIdByToken(token);
+    const lookup = await getUserIdByToken(token);
 
-    if (!userId) {
-        const baseUrl = getBaseUrl(c);
-        const resourceMetadataUrl = `${baseUrl}/.well-known/oauth-protected-resource`;
+    if (lookup.status === "unavailable") {
+        // We could not verify the token, so this is not the client's fault:
+        // answer 401 as before, but record no strike. Otherwise a Supabase
+        // outage would ban every active user and outlast the outage itself.
         c.header(
             "WWW-Authenticate",
-            `Bearer resource_metadata="${resourceMetadataUrl}"`,
+            `Bearer resource_metadata="${getBaseUrl(c)}/.well-known/oauth-protected-resource"`,
         );
         return c.json(
             {
                 error: "invalid_token",
-                error_description: "Token is invalid or expired",
+                error_description: "Unable to verify token, try again",
             },
             401,
         );
     }
 
+    if (lookup.status === "invalid") {
+        return rejectUnauthenticated(
+            c,
+            "invalid_token",
+            "Token is invalid or expired",
+        );
+    }
+
+    // A success clears the IP's strike count. This is what keeps a shared egress
+    // IP — one broken client alongside working ones — from ever accumulating the
+    // consecutive failures a ban requires.
+    clearAuthFailures(getClientIp(c));
+
     c.set("accessToken", token);
-    c.set("userId", userId);
+    c.set("userId", lookup.userId);
+    await next();
+};
+
+// Sheds clients that have failed authentication many times in a row — in
+// practice an abandoned MCP client retrying a dead token indefinitely. Runs
+// ahead of authenticateBearer so a banned IP costs one Map lookup instead of a
+// token verification, and marks the request so the access log skips it: a single
+// stuck client can otherwise outnumber real traffic in the logs by an order of
+// magnitude and hide everything worth seeing.
+export const banRepeatAuthFailures = async (c: Context, next: Next) => {
+    const ban = getBanState(getClientIp(c));
+    if (ban.banned) {
+        c.set("suppressAccessLog", true);
+        c.header("Retry-After", String(ban.retryAfterSeconds ?? 60));
+        return c.json(
+            {
+                error: "rate_limited",
+                error_description: `Too many failed authentication attempts. Retry after ${ban.retryAfterSeconds}s.`,
+            },
+            429,
+        );
+    }
     await next();
 };
 

--- a/src/oauth.test.ts
+++ b/src/oauth.test.ts
@@ -1,6 +1,13 @@
 import { test, expect } from "bun:test";
 import crypto from "node:crypto";
-import { renderLoginPage } from "./oauth.js";
+import { Hono } from "hono";
+import { OAUTH_PATHS, createOAuthRouter, renderLoginPage } from "./oauth.js";
+import { _resetBuckets } from "./rate-limit.js";
+
+// createOAuthRouter() refuses to build without these; the values are never
+// exercised by the rate-limit tests below.
+process.env.OAUTH_CLIENT_ID ||= "test-client-id";
+process.env.OAUTH_CLIENT_SECRET ||= "test-client-secret";
 
 // Guards the nonce representation: Supabase expects the SHA-256 *hex* digest sent
 // to Google (not base64url). A regression to base64URLEncode would break sign-in.
@@ -34,4 +41,114 @@ test("renderLoginPage renders the error banner only when given an error", async 
     expect(withError).toContain("error-banner");
     // Error text is HTML-escaped.
     expect(withError).toContain("Bad &lt;stuff&gt; &amp; things");
+});
+
+// ---------- OAuth rate-limit scoping ----------
+
+// The HTTP method each OAuth path is registered with, so the table-driven test
+// drives the route the router actually serves rather than a 404.
+const OAUTH_METHODS: Record<(typeof OAUTH_PATHS)[number], string> = {
+    "/register": "POST",
+    "/authorize": "GET",
+    "/approve": "POST",
+    "/authorize/google": "GET",
+    "/auth/google/callback": "GET",
+    "/token": "POST",
+};
+
+// Mirrors how src/index.ts wires things up: the OAuth router is mounted at the
+// root (the OAuth paths are spec-fixed there) with /mcp as a sibling route.
+function buildTestApp() {
+    let mcpHits = 0;
+    const app = new Hono();
+    app.route("/", createOAuthRouter());
+    app.all("/mcp", (c) => {
+        mcpHits++;
+        return c.text("ok");
+    });
+    // These tests send deliberately malformed bodies so handlers bail out before
+    // touching Supabase; swallow the resulting throws instead of logging 30 of
+    // them per path. Status codes are what the assertions look at.
+    app.onError((_err, c) => c.text("handler error", 500));
+    return { app, mcpHits: () => mcpHits };
+}
+
+function fire(app: Hono, method: string, path: string, ip: string) {
+    return app.request(`http://localhost${path}`, {
+        method,
+        headers: { "x-forwarded-for": ip },
+    });
+}
+
+// The bug this guards: `oauth.use("*", rateLimitAuth)` inside the router. Hono
+// applies a sub-app's wildcard middleware to every path of the parent app, so
+// the 30/min per-IP OAuth limiter also governed /mcp — capping all authenticated
+// MCP traffic behind a shared egress IP well below the intended 60/min per-user
+// limit. A structural assertion on OAUTH_PATHS would not have caught this;
+// only actually driving /mcp past the auth limit does.
+test("the OAuth rate limiter does not leak onto /mcp", async () => {
+    _resetBuckets();
+    const { app, mcpHits } = buildTestApp();
+
+    // Read the per-IP auth limit off a real OAuth response instead of hardcoding
+    // it, so this stays correct if the limit is retuned.
+    const probe = await fire(app, "GET", "/authorize", "203.0.113.9");
+    const authLimit = Number(probe.headers.get("X-RateLimit-Limit"));
+    expect(authLimit).toBeGreaterThan(0);
+    _resetBuckets();
+
+    const total = authLimit * 3;
+    for (let i = 0; i < total; i++) {
+        const res = await fire(app, "POST", "/mcp", "198.51.100.7");
+        expect(res.status).not.toBe(429);
+        // rateLimitAuth always stamps these; their absence proves it never ran.
+        expect(res.headers.get("X-RateLimit-Limit")).toBeNull();
+    }
+    // Every request reached the handler — none were short-circuited.
+    expect(mcpHits()).toBe(total);
+});
+
+// Table-driven so a route added to the router but left out of OAUTH_PATHS fails
+// here: dropping the limiter from an unauthenticated endpoint is a security
+// regression, and it is the main risk of scoping the middleware by path.
+test("every OAuth endpoint is still rate-limited", async () => {
+    for (const [i, path] of OAUTH_PATHS.entries()) {
+        _resetBuckets();
+        const { app } = buildTestApp();
+        const method = OAUTH_METHODS[path]!;
+        // Distinct IP per path so the buckets can't bleed into each other.
+        const ip = `192.0.2.${i + 1}`;
+
+        let limit = 0;
+        let saw429 = false;
+        for (let n = 0; n <= 200; n++) {
+            const res = await fire(app, method, path, ip);
+            if (n === 0) {
+                limit = Number(res.headers.get("X-RateLimit-Limit"));
+                expect(limit).toBeGreaterThan(0);
+            }
+            if (n < limit) {
+                // Within the window: whatever the handler does, it isn't a 429.
+                expect(res.status).not.toBe(429);
+                continue;
+            }
+            expect(res.status).toBe(429);
+            expect(res.headers.get("Retry-After")).toBeTruthy();
+            saw429 = true;
+            break;
+        }
+        expect(saw429).toBe(true);
+    }
+});
+
+// OAUTH_PATHS is now the list the limiter is attached to, so it must stay in
+// sync with the routes the router registers, including their methods.
+test("OAUTH_PATHS covers exactly the router's registered routes", () => {
+    const registered = new Set(
+        createOAuthRouter()
+            .routes.filter((r) => r.method !== "ALL")
+            .map((r) => r.path),
+    );
+    expect([...registered].sort()).toEqual([...OAUTH_PATHS].sort());
+    expect(Object.keys(OAUTH_METHODS).sort()).toEqual([...OAUTH_PATHS].sort());
 });

--- a/src/oauth.ts
+++ b/src/oauth.ts
@@ -96,13 +96,33 @@ async function finishAuthorization(
     return c.redirect(redirectUrl.toString());
 }
 
+// Every path this router serves. Kept in sync with the oauth.get/oauth.post
+// registrations below — a route added there but missing here is unthrottled.
+export const OAUTH_PATHS = [
+    "/register",
+    "/authorize",
+    "/approve",
+    "/authorize/google",
+    "/auth/google/callback",
+    "/token",
+] as const;
+
 export function createOAuthRouter() {
     const oauth = new Hono();
 
     // Per-IP rate limit across all OAuth endpoints — these are unauthenticated,
     // so this is the only throttle standing between the internet and signup /
     // sign-in / token issuance.
-    oauth.use("*", rateLimitAuth);
+    //
+    // Deliberately NOT `oauth.use("*", ...)`: this router is mounted at the root
+    // (`app.route("/", createOAuthRouter())`) because the OAuth paths are
+    // spec-fixed there, and Hono applies a sub-app's wildcard middleware to
+    // *every* path of the parent app — a wildcard here rate-limited /mcp too,
+    // capping authenticated MCP traffic at the 30/min per-IP auth limit. Listing
+    // the endpoints explicitly keeps the limiter from leaking beyond OAuth again.
+    for (const path of OAUTH_PATHS) {
+        oauth.use(path, rateLimitAuth);
+    }
 
     const clientId = process.env.OAUTH_CLIENT_ID;
     const clientSecret = process.env.OAUTH_CLIENT_SECRET;

--- a/src/rate-limit.test.ts
+++ b/src/rate-limit.test.ts
@@ -1,0 +1,250 @@
+import { test, expect, beforeEach, afterEach, setSystemTime } from "bun:test";
+import {
+    checkRateLimit,
+    checkAuthRateLimit,
+    noteAuthFailure,
+    clearAuthFailures,
+    getBanState,
+    _resetBuckets,
+} from "./rate-limit.js";
+
+const T0 = new Date("2026-01-01T00:00:00Z").getTime();
+const MINUTE = 60_000;
+
+// Every test drives the clock explicitly so nothing depends on wall time.
+let now = T0;
+function at(ms: number): void {
+    now = ms;
+    setSystemTime(new Date(now));
+}
+function advance(ms: number): void {
+    at(now + ms);
+}
+
+function fail(ip: string, times: number) {
+    let last = { banned: false } as ReturnType<typeof noteAuthFailure>;
+    for (let i = 0; i < times; i++) {
+        last = noteAuthFailure(ip);
+    }
+    return last;
+}
+
+beforeEach(() => {
+    _resetBuckets();
+    at(T0);
+});
+
+afterEach(() => {
+    _resetBuckets();
+    setSystemTime();
+});
+
+test("19 consecutive failures do not ban, the 20th does", () => {
+    const ip = "203.0.113.7";
+    for (let i = 0; i < 19; i++) {
+        expect(noteAuthFailure(ip).banned).toBe(false);
+    }
+    expect(getBanState(ip).banned).toBe(false);
+
+    const twentieth = noteAuthFailure(ip);
+    expect(twentieth.banned).toBe(true);
+    expect(twentieth.retryAfterSeconds).toBe(5 * 60);
+    expect(getBanState(ip).banned).toBe(true);
+});
+
+test("a success resets the run, so a shared NAT IP never accumulates a ban", () => {
+    // One broken client on the IP fails forever while real users behind the
+    // same NAT keep authenticating successfully. 190 total failures, never 20
+    // in a row, so the IP must never be banned.
+    const ip = "198.51.100.42";
+    for (let round = 0; round < 10; round++) {
+        expect(fail(ip, 19).banned).toBe(false);
+        clearAuthFailures(ip);
+        expect(getBanState(ip).banned).toBe(false);
+    }
+    expect(getBanState(ip).banned).toBe(false);
+
+    // And the counter really is back at zero: 19 more still isn't enough.
+    expect(fail(ip, 19).banned).toBe(false);
+});
+
+test("clearAuthFailures lifts an active ban", () => {
+    const ip = "198.51.100.9";
+    expect(fail(ip, 20).banned).toBe(true);
+
+    clearAuthFailures(ip);
+    expect(getBanState(ip).banned).toBe(false);
+    expect(fail(ip, 19).banned).toBe(false);
+});
+
+test("ban durations escalate 5, 10, 20, 40, 60, then cap at 60 minutes", () => {
+    const ip = "203.0.113.99";
+    const expectedMinutes = [5, 10, 20, 40, 60, 60];
+
+    for (const minutes of expectedMinutes) {
+        const result = fail(ip, 20);
+        expect(result.banned).toBe(true);
+        expect(result.retryAfterSeconds).toBe(minutes * 60);
+
+        // Sit out the ban before earning the next one.
+        advance(minutes * MINUTE + 1000);
+        expect(getBanState(ip).banned).toBe(false);
+    }
+});
+
+test("the ban lifts once its duration elapses", () => {
+    const ip = "203.0.113.11";
+    expect(fail(ip, 20).banned).toBe(true);
+
+    advance(5 * MINUTE - 1000);
+    expect(getBanState(ip).banned).toBe(true);
+
+    advance(1000);
+    expect(getBanState(ip).banned).toBe(false);
+    // Post-ban the strike counter starts fresh rather than re-tripping.
+    expect(noteAuthFailure(ip).banned).toBe(false);
+});
+
+test("hammering while banned does not extend the ban", () => {
+    const ip = "203.0.113.12";
+    expect(fail(ip, 20).banned).toBe(true);
+
+    // 500 more attempts spread across the ban window must not push it out.
+    for (let i = 0; i < 5; i++) {
+        advance(30_000);
+        const result = fail(ip, 100);
+        expect(result.banned).toBe(true);
+        expect(result.retryAfterSeconds).toBe(5 * 60 - (i + 1) * 30);
+    }
+
+    advance(2.5 * MINUTE + 1000);
+    expect(getBanState(ip).banned).toBe(false);
+});
+
+test("strikes decay after 10 idle minutes", () => {
+    const ip = "203.0.113.13";
+    expect(fail(ip, 19).banned).toBe(false);
+
+    advance(10 * MINUTE);
+    // The run restarted, so another 19 still isn't a ban — 38 total failures.
+    expect(fail(ip, 19).banned).toBe(false);
+    // ...but 20 in a row within the window is.
+    expect(noteAuthFailure(ip).banned).toBe(true);
+});
+
+test("a slow trickle of failures never trips a ban", () => {
+    const ip = "203.0.113.14";
+    for (let i = 0; i < 100; i++) {
+        expect(noteAuthFailure(ip).banned).toBe(false);
+        advance(11 * MINUTE);
+    }
+});
+
+test("retryAfterSeconds counts down accurately and never drops below 1", () => {
+    const ip = "203.0.113.15";
+    expect(fail(ip, 20).retryAfterSeconds).toBe(5 * 60);
+
+    advance(60_000);
+    expect(getBanState(ip).retryAfterSeconds).toBe(4 * 60);
+
+    advance(3 * MINUTE + 59_500);
+    // 500ms left rounds up rather than reporting 0.
+    expect(getBanState(ip).retryAfterSeconds).toBe(1);
+
+    advance(499);
+    expect(getBanState(ip).retryAfterSeconds).toBe(1);
+
+    advance(1);
+    expect(getBanState(ip).banned).toBe(false);
+    expect(getBanState(ip).retryAfterSeconds).toBeUndefined();
+});
+
+test("getBanState is read-only and does not count as an attempt", () => {
+    const ip = "203.0.113.16";
+    fail(ip, 19);
+    for (let i = 0; i < 50; i++) {
+        expect(getBanState(ip).banned).toBe(false);
+    }
+    // The 20th *failure* is what bans, not the reads in between.
+    expect(noteAuthFailure(ip).banned).toBe(true);
+});
+
+test("bans are per-IP and independent", () => {
+    const banned = "203.0.113.20";
+    const innocent = "203.0.113.21";
+
+    fail(innocent, 15);
+    expect(fail(banned, 20).banned).toBe(true);
+
+    expect(getBanState(innocent).banned).toBe(false);
+    expect(fail(innocent, 4).banned).toBe(false);
+    expect(getBanState(banned).banned).toBe(true);
+
+    // The innocent IP's own 20th still bans it, at its own base duration.
+    expect(noteAuthFailure(innocent).retryAfterSeconds).toBe(5 * 60);
+});
+
+test("escalation decays after 6 quiet hours", () => {
+    const ip = "203.0.113.22";
+    expect(fail(ip, 20).retryAfterSeconds).toBe(5 * 60);
+    advance(5 * MINUTE + 1000);
+    expect(fail(ip, 20).retryAfterSeconds).toBe(10 * 60);
+
+    advance(6 * 60 * MINUTE);
+    // Back to a clean record: the next ban starts at the 5-minute tier again.
+    expect(fail(ip, 20).retryAfterSeconds).toBe(5 * 60);
+});
+
+test("unknown IPs report no ban", () => {
+    expect(getBanState("203.0.113.30")).toEqual({ banned: false });
+    // Clearing an IP we've never seen is a no-op, not a crash.
+    clearAuthFailures("203.0.113.30");
+    expect(getBanState("203.0.113.30").banned).toBe(false);
+});
+
+// --- Regression coverage for the pre-existing sliding windows ---
+
+test("checkRateLimit allows 60 requests per user per minute, then blocks", () => {
+    const user = "user-abc";
+    for (let i = 0; i < 60; i++) {
+        const result = checkRateLimit(user);
+        expect(result.allowed).toBe(true);
+        expect(result.limit).toBe(60);
+        expect(result.remaining).toBe(59 - i);
+    }
+
+    const blocked = checkRateLimit(user);
+    expect(blocked.allowed).toBe(false);
+    expect(blocked.remaining).toBe(0);
+    expect(blocked.retryAfterSeconds).toBe(60);
+
+    // The window slides: once the oldest entry ages out, traffic resumes.
+    advance(60_000);
+    expect(checkRateLimit(user).allowed).toBe(true);
+});
+
+test("checkAuthRateLimit allows 30 requests per IP per minute, then blocks", () => {
+    const ip = "203.0.113.40";
+    for (let i = 0; i < 30; i++) {
+        const result = checkAuthRateLimit(ip);
+        expect(result.allowed).toBe(true);
+        expect(result.limit).toBe(30);
+    }
+    expect(checkAuthRateLimit(ip).allowed).toBe(false);
+
+    // Independent per IP, and independent of the per-user store.
+    expect(checkAuthRateLimit("203.0.113.41").allowed).toBe(true);
+    expect(checkRateLimit(ip).allowed).toBe(true);
+});
+
+test("_resetBuckets clears rate-limit windows and ban state together", () => {
+    const ip = "203.0.113.50";
+    for (let i = 0; i < 30; i++) checkAuthRateLimit(ip);
+    expect(checkAuthRateLimit(ip).allowed).toBe(false);
+    expect(fail(ip, 20).banned).toBe(true);
+
+    _resetBuckets();
+
+    expect(checkAuthRateLimit(ip).allowed).toBe(true);
+    expect(getBanState(ip).banned).toBe(false);
+});

--- a/src/rate-limit.ts
+++ b/src/rate-limit.ts
@@ -12,19 +12,59 @@ const LIMIT_PER_WINDOW = 60;
 const AUTH_LIMIT_PER_WINDOW = 30;
 const SWEEP_INTERVAL_MS = 5 * 60_000;
 
+// Strike-based banning for IPs that keep failing authentication. A sliding
+// window alone can't distinguish "client with a stale token retrying" from
+// "attacker enumerating credentials", so we count *consecutive* failures: any
+// successful auth from the IP wipes the slate. That's what keeps a corporate
+// NAT — one broken client sharing an egress IP with real users — off the ban
+// list, since its successes keep interrupting the run of failures.
+const BAN_STRIKE_THRESHOLD = 20;
+// Escalating ban lengths for repeat offenders, capped at the last entry so a
+// persistent attacker plateaus rather than being locked out permanently.
+const BAN_DURATIONS_MS = [5, 10, 20, 40, 60].map((m) => m * 60_000);
+// Strikes are only "consecutive" if they're close together — an IP that
+// trickles a stray 401 every so often should never accumulate its way to a ban.
+const STRIKE_DECAY_MS = 10 * 60_000;
+// Forgive the escalation level too, eventually, so a one-off bad afternoon
+// doesn't make an IP a permanent repeat offender.
+const ESCALATION_DECAY_MS = 6 * 60 * 60_000;
+
+interface AuthFailureEntry {
+    // Consecutive failures since the last success, ban, or decay.
+    strikes: number;
+    lastFailureAt: number;
+    // Epoch ms the current ban ends; 0 when not banned.
+    bannedUntil: number;
+    // Index into BAN_DURATIONS_MS for the *next* ban this IP earns.
+    escalation: number;
+}
+
 const buckets = new Map<string, number[]>();
 const authBuckets = new Map<string, number[]>();
+const authFailures = new Map<string, AuthFailureEntry>();
 
 // Periodically drop buckets whose newest entry is older than the window, so
 // a caller who stops making requests doesn't keep a slot in the Map forever.
 setInterval(() => {
-    const cutoff = Date.now() - WINDOW_MS;
+    const now = Date.now();
+    const cutoff = now - WINDOW_MS;
     for (const map of [buckets, authBuckets]) {
         for (const [key, timestamps] of map) {
             const last = timestamps[timestamps.length - 1];
             if (last == null || last < cutoff) {
                 map.delete(key);
             }
+        }
+    }
+    // A failure entry is only droppable once it holds nothing we'd act on:
+    // no live ban, and idle long enough that both the strikes and the
+    // escalation level would have decayed to zero anyway.
+    for (const [ip, entry] of authFailures) {
+        if (
+            entry.bannedUntil <= now &&
+            now - entry.lastFailureAt >= ESCALATION_DECAY_MS
+        ) {
+            authFailures.delete(ip);
         }
     }
 }, SWEEP_INTERVAL_MS);
@@ -86,8 +126,95 @@ export function checkAuthRateLimit(ip: string): RateLimitResult {
     return slidingWindow(authBuckets, ip, AUTH_LIMIT_PER_WINDOW);
 }
 
+export interface BanState {
+    banned: boolean;
+    retryAfterSeconds?: number;
+}
+
+const NOT_BANNED: BanState = { banned: false };
+
+function bannedState(bannedUntil: number, now: number): BanState {
+    // Round up and floor at 1: a Retry-After of 0 invites an instant retry.
+    return {
+        banned: true,
+        retryAfterSeconds: Math.max(1, Math.ceil((bannedUntil - now) / 1000)),
+    };
+}
+
+// Record one failed (401) unauthenticated attempt from this IP and report the
+// resulting ban state.
+export function noteAuthFailure(ip: string): BanState {
+    const now = Date.now();
+    const entry = authFailures.get(ip) ?? {
+        strikes: 0,
+        lastFailureAt: now,
+        bannedUntil: 0,
+        escalation: 0,
+    };
+
+    const idle = now - entry.lastFailureAt;
+    if (idle >= ESCALATION_DECAY_MS) {
+        entry.escalation = 0;
+        entry.strikes = 0;
+    } else if (idle >= STRIKE_DECAY_MS) {
+        entry.strikes = 0;
+    }
+    entry.lastFailureAt = now;
+
+    if (entry.bannedUntil > now) {
+        // Deliberately no strike, no extension: a client hammering through its
+        // ban would otherwise renew it forever and never get a chance to come
+        // back with a fixed token. Escalation is earned by tripping a *new*
+        // ban after this one expires, not by keeping this one alive.
+        authFailures.set(ip, entry);
+        return bannedState(entry.bannedUntil, now);
+    }
+
+    entry.strikes++;
+    if (entry.strikes >= BAN_STRIKE_THRESHOLD) {
+        const duration =
+            BAN_DURATIONS_MS[
+                Math.min(entry.escalation, BAN_DURATIONS_MS.length - 1)
+            ]!;
+        entry.bannedUntil = now + duration;
+        entry.escalation++;
+        // Start the next run from scratch; the ban itself is the punishment
+        // for the strikes just spent.
+        entry.strikes = 0;
+        authFailures.set(ip, entry);
+        return bannedState(entry.bannedUntil, now);
+    }
+
+    authFailures.set(ip, entry);
+    return NOT_BANNED;
+}
+
+// Clear strikes and any active ban for this IP, called whenever auth succeeds.
+// The escalation level survives, so an attacker can't launder a repeat-offender
+// record with a single valid request between rounds.
+export function clearAuthFailures(ip: string): void {
+    const entry = authFailures.get(ip);
+    if (!entry) return;
+    entry.strikes = 0;
+    entry.bannedUntil = 0;
+    if (entry.escalation === 0) {
+        // Nothing left worth remembering — don't hold the slot.
+        authFailures.delete(ip);
+    }
+}
+
+// Read-only view of the ban state; does not count as an attempt.
+export function getBanState(ip: string): BanState {
+    const entry = authFailures.get(ip);
+    if (!entry) return NOT_BANNED;
+    const now = Date.now();
+    if (entry.bannedUntil <= now) return NOT_BANNED;
+    return bannedState(entry.bannedUntil, now);
+}
+
 // Exposed for tests.
 export function _resetBuckets(): void {
     buckets.clear();
     authBuckets.clear();
+    authFailures.clear();
 }

--- a/src/supabase.ts
+++ b/src/supabase.ts
@@ -896,16 +896,40 @@ export async function storeToken(token: string, userId: string): Promise<void> {
     if (error) throw new Error(`Failed to store token: ${error.message}`);
 }
 
-export async function getUserIdByToken(token: string): Promise<string | null> {
-    const { data, error } = await getSupabase()
-        .from("oauth_tokens")
-        .select("user_id")
-        .eq("token", token)
-        .gt("expires_at", new Date().toISOString())
-        .single();
+// "invalid" means the token definitively isn't valid; "unavailable" means we
+// could not find out. Callers must not treat the two alike: counting an
+// unavailable lookup as a failed auth attempt would let a brief Supabase outage
+// — during which *every* token looks invalid — trip the repeat-failure bans in
+// rate-limit.ts and keep clients shed long after the database recovered.
+export type TokenLookup =
+    | { status: "valid"; userId: string }
+    | { status: "invalid" }
+    | { status: "unavailable" };
 
-    if (error || !data) return null;
-    return data.user_id as string;
+// PostgREST's code for "no rows returned" from .single() — a real answer (this
+// token does not exist), not a transport or availability failure.
+const PGRST_NO_ROWS = "PGRST116";
+
+export async function getUserIdByToken(token: string): Promise<TokenLookup> {
+    try {
+        const { data, error } = await getSupabase()
+            .from("oauth_tokens")
+            .select("user_id")
+            .eq("token", token)
+            .gt("expires_at", new Date().toISOString())
+            .single();
+
+        if (error) {
+            return error.code === PGRST_NO_ROWS
+                ? { status: "invalid" }
+                : { status: "unavailable" };
+        }
+        if (!data) return { status: "invalid" };
+        return { status: "valid", userId: data.user_id as string };
+    } catch {
+        // Network-level failure never reaches the `error` field.
+        return { status: "unavailable" };
+    }
 }
 
 // ---------- Auth codes ----------


### PR DESCRIPTION
Came out of a review of a 4h25m production traffic window (2026-07-24 00:57–05:22 UTC, 9,895 requests). Only **13%** of that traffic was real MCP work; **73%** was one client retrying with no `Authorization` header, and the `429`s throttling it turned out to be an accident.

## 1. The OAuth limiter was leaking onto `/mcp`

`createOAuthRouter()` had `oauth.use("*", rateLimitAuth)`, and the router is mounted at `/` because the OAuth paths are spec-fixed there. Hono applies a sub-app's wildcard middleware to **every path of the parent app**, so the per-IP 30/min OAuth limiter was also governing `/mcp` — and running *ahead* of `authenticateBearer`:

```
app.all("/mcp", authenticateBearer, rateLimit, handleMcp)
//              ^ rateLimitAuth (per-IP, 30/min) already ran
```

So authenticated MCP traffic was capped at **30 req/min per IP** — half the intended 60/min per-*user* limit, and shared across every user behind one egress address. The Anthropic egress range carries the majority of this server's traffic; it stayed under 30/min in the sampled window, which is the only reason this hasn't surfaced as random 429s for unrelated users.

Fixed by registering the limiter on the six OAuth paths explicitly. A test asserts `OAUTH_PATHS` matches the routes Hono actually registered, so a future route added without protection fails the suite. The leak test was verified to fail against the old code.

## 2. Replaced the accidental throttle with a real one

Removing the leak removes the only thing shedding the storm, so `banRepeatAuthFailures` now runs before `authenticateBearer`: **20 consecutive** auth failures trip an escalating ban (5/10/20/40/60 min), and banned requests are shed with a `429` before any token lookup and kept out of the access log.

*Consecutive* is the load-bearing detail — any successful auth from that IP resets the counter, so a corporate NAT with one broken client and real users never accumulates 20 in a row. A total-count threshold would ban the innocent.

Replaying the observed pattern (7,214 requests over 265 min) through the real middleware:

```
access-log lines emitted: 160  (was 7214)  →  97.8% reduction
[ban] lines: 8
```

## 3. Fixed an outage amplifier the bans would have created

`getUserIdByToken` collapsed "token not found" and "Supabase unreachable" into a single `null`. With bans layered on top, a database blip would `401` every user, accrue 20 strikes against every IP, and keep them shed for 5–60 minutes **after** recovery — turning a short outage into a much longer self-inflicted one.

Split into a discriminated `TokenLookup`. An `unavailable` lookup still answers `401` exactly as before, but records no strike. Returning `503` there instead is more correct and is tracked separately in #48.

## Testing

`110 pass, 0 fail` (baseline 84 → +26). `bunx tsc --noEmit` clean across `src/`.

New coverage includes the NAT-safety property end-to-end, ban-announced-exactly-once, shed-without-a-token-lookup, outage-never-bans-anyone, escalation and decay behaviour, and the `/mcp` leak regression.

## Notes for review

- **Judgment call:** `clearAuthFailures` zeroes strikes and lifts the ban but *preserves* the escalation level, so a single valid request can't launder a repeat offender back to the 5-minute tier. Easy to flip if you'd rather a success fully forgets the IP.
- Ban state is in-memory, consistent with the existing limiter's single-instance assumption (`rate-limit.ts` already notes it needs a shared store to scale horizontally).
- Tuning constants live at the top of `src/rate-limit.ts`.
- Unrelated: `bun run format` rewrites files across the repo — see #49. Only touched files were formatted here.

Merging this ships to production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
