### PR TITLE
chore(release): bump version to 1.21.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "nutrition-mcp",
-    "version": "1.20.0",
+    "version": "1.21.0",
     "description": "A remote MCP server for personal nutrition tracking. Log meals, track macros, and review nutrition history through Claude.",
     "author": "akutishevsky",
     "license": "MIT",

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
     "name": "io.github.akutishevsky/nutrition-mcp",
     "title": "Nutrition MCP",
     "description": "Personal nutrition tracking — log meals, track macros, and review history through conversation.",
-    "version": "1.20.0",
+    "version": "1.21.0",
     "websiteUrl": "https://nutrition-mcp.com/",
     "repository": {
         "url": "https://github.com/akutishevsky/nutrition-mcp",

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -2798,7 +2798,7 @@ async function buildMcpServer(c: Context, userId: string): Promise<McpServer> {
     const server = new McpServer(
         {
             name: "nutrition-mcp",
-            version: "1.20.0",
+            version: "1.21.0",
             icons: [
                 {
                     src: `${baseUrl}/favicon.ico`,


### PR DESCRIPTION
Bumps the version in all three required places (`package.json`, `src/mcp.ts` McpServer constructor, `server.json`) from `1.20.0` to `1.21.0`.

## Why

Seven commits have shipped to production since the `v1.20.0` tag, but `serverInfo.version` still reports `1.20.0` to every connected client. Two of them changed real behaviour:

| Commit | Change | Runtime impact |
|---|---|---|
| `39476e1` | `fix(auth)`: scoped OAuth rate limiter + new `banRepeatAuthFailures` middleware on `/mcp` | Yes — new middleware in the request chain |
| `601639d` | ToS page, privacy corrections, "estimates, not medical or dietary advice" in `SERVER_INSTRUCTIONS` and five tool descriptions; new `/terms` + `/privacy/` routes | Yes — model-facing text and new routes |
| `4852e80`, `7761e83` | Prettier config, CI format gate, tree reformat | No |
| `b1f9ec8`, `eb920ec`, `5d29f3e` | Product Hunt badge added then removed, onboarding copy | No |

Minor rather than patch: model-visible surface changed (server instructions and tool descriptions) alongside new HTTP routes.

## Registry note

No registry-visible field in `server.json` changed (`name`, `title`, `description`, `websiteUrl`, `remotes` are all identical), so republishing is optional — this keeps the listing's version in step with what is deployed rather than fixing anything broken.

## Verification

- `bun test` — 110 pass, 0 fail
- `bun run format:check` — clean

## After merge

The publish workflow verifies the tag matches `server.json`, so tag only once this is on `main`:

```
git tag v1.21.0 && git push origin v1.21.0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)