### PR TITLE
fix(auth): serve OAuth discovery at the path-folded URLs clients request

### DIFF
--- a/src/discovery.test.ts
+++ b/src/discovery.test.ts
@@ -1,0 +1,167 @@
+import { test, expect } from "bun:test";
+import { Hono } from "hono";
+import {
+    MCP_PATH,
+    registerDiscoveryRoutes,
+    resourceMetadataUrl,
+} from "./discovery.js";
+
+const HOST = "nutrition-mcp.com";
+const ORIGIN = `https://${HOST}`;
+
+// Mirrors how src/index.ts wires discovery up. index.ts itself is never imported
+// by tests — it boots a server and warms widgets on import.
+function buildTestApp() {
+    const app = new Hono();
+    registerDiscoveryRoutes(app);
+    return app;
+}
+
+// Production sits behind DigitalOcean's proxy, so getBaseUrl reads the forwarded
+// headers rather than the request URL. Drive the routes the way the proxy does.
+function fetchDiscovery(app: Hono, path: string) {
+    return app.request(`http://localhost${path}`, {
+        headers: { "x-forwarded-proto": "https", "x-forwarded-host": HOST },
+    });
+}
+
+async function json(app: Hono, path: string): Promise<Record<string, unknown>> {
+    const res = await fetchDiscovery(app, path);
+    expect(res.status, `${path} should be served`).toBe(200);
+    return (await res.json()) as Record<string, unknown>;
+}
+
+// The bug from #51: the MCP endpoint is https://host/mcp — it has a path — but
+// metadata was served only at the root, so clients folding that path into the
+// discovery URL got a 404, retried every 30 minutes, and never authenticated.
+// Each of these is a shape a real client was observed requesting.
+const PROTECTED_RESOURCE_PATHS = [
+    "/.well-known/oauth-protected-resource/mcp",
+    "/mcp/.well-known/oauth-protected-resource",
+];
+const AUTHORIZATION_SERVER_PATHS = [
+    "/.well-known/oauth-authorization-server/mcp",
+    "/mcp/.well-known/oauth-authorization-server",
+];
+
+test("every discovery URL a client may derive from /mcp is served", async () => {
+    const app = buildTestApp();
+    for (const path of [
+        "/.well-known/oauth-protected-resource",
+        "/.well-known/oauth-authorization-server",
+        ...PROTECTED_RESOURCE_PATHS,
+        ...AUTHORIZATION_SERVER_PATHS,
+    ]) {
+        const res = await fetchDiscovery(app, path);
+        expect(res.status, `${path} must not 404`).toBe(200);
+    }
+});
+
+// RFC 9728 §3.3: the `resource` returned MUST be identical to the identifier the
+// requested well-known URL was derived from. So the root and path-aware
+// documents cannot share a body — returning the origin from the /mcp variant
+// would make a strict client discard it, which is the same dead end as a 404.
+test("protected-resource metadata echoes the identifier its URL was derived from", async () => {
+    const app = buildTestApp();
+
+    const root = await json(app, "/.well-known/oauth-protected-resource");
+    expect(root.resource).toBe(ORIGIN);
+
+    for (const path of PROTECTED_RESOURCE_PATHS) {
+        const body = await json(app, path);
+        expect(body.resource, `${path} identifies the MCP endpoint`).toBe(
+            `${ORIGIN}${MCP_PATH}`,
+        );
+    }
+});
+
+test("protected-resource metadata always points at this origin as the auth server", async () => {
+    const app = buildTestApp();
+    for (const path of [
+        "/.well-known/oauth-protected-resource",
+        ...PROTECTED_RESOURCE_PATHS,
+    ]) {
+        const body = await json(app, path);
+        expect(body.authorization_servers).toEqual([ORIGIN]);
+    }
+});
+
+// RFC 8414 §3.3: a client checks that `issuer` matches the authorization server
+// it asked about. Our issuer is the bare origin, so the /mcp aliases must not
+// "helpfully" append the path — every copy has to be byte-identical or the
+// aliases get discarded by exactly the conformant clients they exist for.
+test("authorization-server metadata is identical on every route it is served from", async () => {
+    const app = buildTestApp();
+    const canonical = await json(
+        app,
+        "/.well-known/oauth-authorization-server",
+    );
+    expect(canonical.issuer).toBe(ORIGIN);
+    expect(canonical.token_endpoint).toBe(`${ORIGIN}/token`);
+
+    for (const path of AUTHORIZATION_SERVER_PATHS) {
+        expect(
+            await json(app, path),
+            `${path} matches the canonical doc`,
+        ).toEqual(canonical);
+    }
+});
+
+// The 401 challenge must advertise the path-aware document. RFC 9728 §3.3 says a
+// document fetched from a `resource_metadata` pointer MUST carry a `resource`
+// identical to the URL the client requested — that is /mcp, so pointing at the
+// root document (resource: the bare origin) hands strict clients a document they
+// are required to reject.
+test("the advertised resource_metadata URL serves a document naming /mcp", async () => {
+    const app = buildTestApp();
+    const advertised = resourceMetadataUrl(ORIGIN);
+    expect(advertised.startsWith(ORIGIN)).toBe(true);
+
+    const body = await json(app, advertised.slice(ORIGIN.length));
+    expect(body.resource).toBe(`${ORIGIN}${MCP_PATH}`);
+});
+
+// The /mcp/.well-known/* aliases live under the path of the *authenticated* MCP
+// endpoint. If that route ever widened to a prefix match (or the aliases were
+// registered after it), discovery would be swallowed by authenticateBearer and
+// answer 401 — leaving a client unable to discover how to authenticate because
+// it is not authenticated. Mirrors index.ts's registration order.
+test("the authenticated /mcp route does not swallow its well-known aliases", async () => {
+    const app = new Hono();
+    registerDiscoveryRoutes(app);
+    let mcpHits = 0;
+    app.all(MCP_PATH, (c) => {
+        mcpHits++;
+        return c.json({ error: "unauthorized" }, 401);
+    });
+
+    for (const path of [
+        `${MCP_PATH}/.well-known/oauth-protected-resource`,
+        `${MCP_PATH}/.well-known/oauth-authorization-server`,
+    ]) {
+        const res = await fetchDiscovery(app, path);
+        expect(
+            res.status,
+            `${path} is public metadata, not the MCP endpoint`,
+        ).toBe(200);
+    }
+    expect(mcpHits, "no discovery request reached the MCP handler").toBe(0);
+
+    // ...and the MCP endpoint itself is still routed.
+    expect((await fetchDiscovery(app, MCP_PATH)).status).toBe(401);
+    expect(mcpHits).toBe(1);
+});
+
+// getBaseUrl derives everything from the request, so a preview deployment or a
+// local run must never emit nutrition-mcp.com URLs.
+test("discovery documents are built from the requesting host", async () => {
+    const app = buildTestApp();
+    const res = await app.request(
+        "http://localhost:8080/.well-known/oauth-protected-resource/mcp",
+        { headers: { host: "localhost:8080" } },
+    );
+    expect(await res.json()).toMatchObject({
+        resource: "http://localhost:8080/mcp",
+        authorization_servers: ["http://localhost:8080"],
+    });
+});

--- a/src/discovery.ts
+++ b/src/discovery.ts
@@ -1,0 +1,110 @@
+import type { Context, Hono } from "hono";
+import { getBaseUrl } from "./url.js";
+
+// The path component of this server's MCP endpoint. Discovery URLs are derived
+// from it, so the two can never drift apart.
+export const MCP_PATH = "/mcp";
+
+// The canonical resource identifier clients authenticate against: the MCP
+// endpoint *including* its path, not the bare origin. RFC 8707 §2 asks the
+// client to send "the most specific URI that it can", and the MCP spec's
+// canonical-server-URI rule says the same.
+export function mcpResourceUrl(baseUrl: string): string {
+    return `${baseUrl}${MCP_PATH}`;
+}
+
+// The resource-metadata URL a 401 should advertise via WWW-Authenticate. This is
+// the path-aware document, because RFC 9728 §3.3 requires the `resource` of a
+// document fetched from a `resource_metadata` pointer to be *identical* to the
+// URL the client requested — that is `https://host/mcp`, so the root document
+// (whose `resource` is the bare origin) is one a strict client MUST reject.
+export function resourceMetadataUrl(baseUrl: string): string {
+    return `${baseUrl}/.well-known/oauth-protected-resource${MCP_PATH}`;
+}
+
+// RFC 9728 protected-resource metadata.
+//
+// `resource` is NOT a free choice: §3.3 requires it to equal the identifier the
+// requested well-known URL was derived from, so the root document and the
+// path-aware document must carry *different* values and cannot share a body.
+export function protectedResourceMetadata(baseUrl: string, resource: string) {
+    return {
+        resource,
+        authorization_servers: [baseUrl],
+        bearer_methods_supported: ["header"],
+    };
+}
+
+// RFC 8414 authorization server metadata. Byte-identical on every route that
+// serves it: the issuer is this origin with no path, so `issuer` must stay the
+// bare origin or the RFC 8414 §3.3 issuer-match check fails and conformant
+// clients discard the document.
+export function authorizationServerMetadata(baseUrl: string) {
+    return {
+        issuer: baseUrl,
+        authorization_endpoint: `${baseUrl}/authorize`,
+        token_endpoint: `${baseUrl}/token`,
+        registration_endpoint: `${baseUrl}/register`,
+        grant_types_supported: ["authorization_code", "refresh_token"],
+        response_types_supported: ["code"],
+        code_challenge_methods_supported: ["S256"],
+        token_endpoint_auth_methods_supported: ["none", "client_secret_post"],
+    };
+}
+
+// Every discovery URL we answer, and why.
+//
+// The MCP endpoint is `https://host/mcp` — it has a path — and the well-known
+// conventions fold that path into the discovery URL. Serving metadata only at
+// the root left real clients looping every 30 minutes on 404s and never
+// authenticating (#51). The shapes:
+//
+//   .../.well-known/<suffix>/mcp   path *insertion* — RFC 8414 §3.1, RFC 9728
+//                                  §3.1, and what the MCP spec and the TS SDK
+//                                  actually request first.
+//   /mcp/.well-known/<suffix>      path *appending* — spec-mandated only for
+//                                  openid-configuration, but observed from
+//                                  clients that hand-roll the OAuth suffix. A
+//                                  tolerant alias; cheap, and it unsticks them.
+//   /.well-known/<suffix>          the root fallback, kept for clients that
+//                                  probe the origin. Unchanged.
+//
+// Deliberately NOT rate-limited (see #50, which scoped `rateLimitAuth` to the
+// six OAuth paths): these are static JSON built from a request header, with no
+// auth, no DB, and no per-caller state — nothing a limiter would protect. They
+// are also the endpoints a stuck client hammers, and throttling discovery is a
+// good way to keep it stuck.
+export function registerDiscoveryRoutes(app: Hono): void {
+    const protectedResource =
+        (resource: (baseUrl: string) => string) => (c: Context) => {
+            const baseUrl = getBaseUrl(c);
+            return c.json(
+                protectedResourceMetadata(baseUrl, resource(baseUrl)),
+            );
+        };
+    const authorizationServer = (c: Context) =>
+        c.json(authorizationServerMetadata(getBaseUrl(c)));
+
+    app.get(
+        "/.well-known/oauth-protected-resource",
+        protectedResource((baseUrl) => baseUrl),
+    );
+    app.get(
+        `/.well-known/oauth-protected-resource${MCP_PATH}`,
+        protectedResource(mcpResourceUrl),
+    );
+    app.get(
+        `${MCP_PATH}/.well-known/oauth-protected-resource`,
+        protectedResource(mcpResourceUrl),
+    );
+
+    app.get("/.well-known/oauth-authorization-server", authorizationServer);
+    app.get(
+        `/.well-known/oauth-authorization-server${MCP_PATH}`,
+        authorizationServer,
+    );
+    app.get(
+        `${MCP_PATH}/.well-known/oauth-authorization-server`,
+        authorizationServer,
+    );
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,7 @@ import {
 import { handleMcp } from "./mcp.js";
 import { startExportCleanup } from "./export.js";
 import { getLandingStats, type LandingStats } from "./supabase.js";
-import { getBaseUrl } from "./url.js";
+import { registerDiscoveryRoutes } from "./discovery.js";
 import { maskIp } from "./net.js";
 import { warmWidgets } from "./widgets.js";
 
@@ -97,29 +97,10 @@ app.use(
     }),
 );
 
-// Protected resource metadata (MCP spec requirement)
-app.get("/.well-known/oauth-protected-resource", (c) => {
-    const baseUrl = getBaseUrl(c);
-    return c.json({
-        resource: baseUrl,
-        authorization_servers: [baseUrl],
-    });
-});
-
-// OAuth authorization server metadata
-app.get("/.well-known/oauth-authorization-server", (c) => {
-    const baseUrl = getBaseUrl(c);
-    return c.json({
-        issuer: baseUrl,
-        authorization_endpoint: `${baseUrl}/authorize`,
-        token_endpoint: `${baseUrl}/token`,
-        registration_endpoint: `${baseUrl}/register`,
-        grant_types_supported: ["authorization_code", "refresh_token"],
-        response_types_supported: ["code"],
-        code_challenge_methods_supported: ["S256"],
-        token_endpoint_auth_methods_supported: ["none", "client_secret_post"],
-    });
-});
+// OAuth discovery metadata (MCP spec requirement) — protected-resource and
+// authorization-server documents, served at the root and at the path-folded
+// variants clients derive from the /mcp endpoint. See src/discovery.ts.
+registerDiscoveryRoutes(app);
 
 // Glama connector ownership verification. Glama polls this file and matches the
 // maintainer email against the Glama account email to claim the listing.

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,6 +1,7 @@
 import type { Context, Next } from "hono";
 import { getUserIdByToken } from "./supabase.js";
 import { maskIp } from "./net.js";
+import { resourceMetadataUrl } from "./discovery.js";
 
 // Declare the context variables this middleware sets. Without it, c.get/c.set on
 // an untyped `new Hono()` app types its keys as `never`, so index.ts cannot read
@@ -59,10 +60,9 @@ function rejectUnauthenticated(
         );
     }
 
-    const resourceMetadataUrl = `${getBaseUrl(c)}/.well-known/oauth-protected-resource`;
     c.header(
         "WWW-Authenticate",
-        `Bearer resource_metadata="${resourceMetadataUrl}"`,
+        `Bearer resource_metadata="${resourceMetadataUrl(getBaseUrl(c))}"`,
     );
     return c.json({ error, error_description: description }, 401);
 }
@@ -87,7 +87,7 @@ export const authenticateBearer = async (c: Context, next: Next) => {
         // outage would ban every active user and outlast the outage itself.
         c.header(
             "WWW-Authenticate",
-            `Bearer resource_metadata="${getBaseUrl(c)}/.well-known/oauth-protected-resource"`,
+            `Bearer resource_metadata="${resourceMetadataUrl(getBaseUrl(c))}"`,
         );
         return c.json(
             {


### PR DESCRIPTION
Closes #51.

## What was actually wrong

The issue's "also worth checking — possibly the actual root cause" hunch was right, and it's stricter than a missing route.

**RFC 9728 §3.3** requires `resource` to be *identical* to the identifier the requested well-known URL was derived from — and, when the document was reached via a `WWW-Authenticate` `resource_metadata` pointer, identical to the URL the client actually requested. Our 401 pointed at the root document, whose `resource` was `https://nutrition-mcp.com` while the client had requested `https://nutrition-mcp.com/mcp`. A conformant client **MUST NOT use** that document — so the one endpoint in the failing loop that returned 200 was also a dead end. Root and path-aware documents therefore carry different `resource` values and cannot share a body.

So this PR adds the missing routes *and* repoints the 401 challenge.

## Spec findings (verified against primary sources, not memory)

Per the checklist in the issue:

- [x] **Which URLs must a client try?** MCP spec (rev. 2025-11-25, current) mandates path-insertion first, then root, for protected-resource metadata. For authorization-server metadata the priority list is keyed on the **issuer** from `authorization_servers` — ours has no path, so a strictly conformant client only ever hits the root. The clients probing `/.well-known/oauth-authorization-server/mcp` are deriving AS discovery from the *resource* path; that's a known client-side bug ([claude-ai-mcp#376](https://github.com/anthropics/claude-ai-mcp/issues/376), [vscode#278300](https://github.com/microsoft/vscode/issues/278300)) and worth tolerating.
- [x] **RFC 8414 §3.1 / RFC 9728 §3.1 path insertion** confirmed: `/.well-known/<suffix>/<path>`.
- [x] **`/mcp/.well-known/…` (path *appending*)** matches no spec revision — the spec mandates it only for `openid-configuration`, and only when the AS issuer itself has a path. Served here as a tolerant alias exactly as proposed.

## Routes served

| Route | Body |
|---|---|
| `/.well-known/oauth-protected-resource` | `resource: <origin>` (unchanged) |
| `/.well-known/oauth-protected-resource/mcp` | `resource: <origin>/mcp` |
| `/mcp/.well-known/oauth-protected-resource` | `resource: <origin>/mcp` |
| `/.well-known/oauth-authorization-server` | unchanged |
| `/.well-known/oauth-authorization-server/mcp` | byte-identical to root |
| `/mcp/.well-known/oauth-authorization-server` | byte-identical to root |

`issuer` stays the bare origin on the AS aliases — appending the path would fail RFC 8414 §3.3's issuer check and get the aliases discarded by exactly the conformant clients they exist for.

`WWW-Authenticate` on both 401 branches now advertises `.../oauth-protected-resource/mcp`.

## Why changing the advertised `resource` is safe here

The issue flagged risk to already-issued tokens. Verified directly: `oauth.ts` and `supabase.ts` contain **zero** `resource`/`aud`/`audience` references. This server never reads the RFC 8707 `resource` parameter, and its tokens carry no audience binding — nothing validates against the old value, so no staged dual-audience rollout is needed.

## Rate limiting — the deliberate decision the issue asked for

**Left unthrottled.** These are static JSON built from a request header: no auth, no DB, no per-caller state, nothing a limiter protects. They're also precisely the endpoints a stuck client hammers, so throttling discovery is a good way to keep it stuck. Reasoning is recorded in the code.

Adding them to `OAUTH_PATHS` would also have broken `oauth.test.ts:146`'s set-equality invariant; registering on `app` alongside the existing well-known routes keeps it intact.

## Structure

Extracted to `src/discovery.ts` — bodies are built by shared helpers rather than duplicated, and tests can drive the routes directly (`index.ts` boots a server and warms widgets on import, so tests can't import it).

## Verification

Booted locally and replayed the exact failing loop from the issue — all four requests now succeed:

```
/.well-known/oauth-protected-resource      → resource: https://nutrition-mcp.com
/.well-known/oauth-protected-resource/mcp  → resource: https://nutrition-mcp.com/mcp
/mcp/.well-known/oauth-protected-resource  → resource: https://nutrition-mcp.com/mcp
AS root vs /mcp alias                      → IDENTICAL
WWW-Authenticate → https://nutrition-mcp.com/.well-known/oauth-protected-resource/mcp
```

7 new tests in `src/discovery.test.ts` — these endpoints had **no** coverage before. One pins that the authenticated `/mcp` route doesn't swallow its own well-known aliases; the failure mode there is a client unable to discover how to authenticate *because* it isn't authenticated.

`bun test`: 117 pass, 0 fail. `src/` typechecks clean; `format:check` passes.

## After merge

Per the issue's success criterion: watch that discovery 404s go to zero and the `24.193.44.x` 30-minute retry cycle disappears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
