### PR TITLE
chore(release): bump version to 1.21.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "nutrition-mcp",
-    "version": "1.21.0",
+    "version": "1.21.1",
     "description": "A remote MCP server for personal nutrition tracking. Log meals, track macros, and review nutrition history through Claude.",
     "author": "akutishevsky",
     "license": "MIT",

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
     "name": "io.github.akutishevsky/nutrition-mcp",
     "title": "Nutrition MCP",
     "description": "Personal nutrition tracking — log meals, track macros, and review history through conversation.",
-    "version": "1.21.0",
+    "version": "1.21.1",
     "websiteUrl": "https://nutrition-mcp.com/",
     "repository": {
         "url": "https://github.com/akutishevsky/nutrition-mcp",

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -2798,7 +2798,7 @@ async function buildMcpServer(c: Context, userId: string): Promise<McpServer> {
     const server = new McpServer(
         {
             name: "nutrition-mcp",
-            version: "1.21.0",
+            version: "1.21.1",
             icons: [
                 {
                     src: `${baseUrl}/favicon.ico`,


### PR DESCRIPTION
Patch release for the OAuth discovery fix in #55 (closes #51).

Bumps the version in all three places that must stay in sync:

- `package.json`
- `src/mcp.ts` (McpServer constructor)
- `server.json`

Merging this ships 1.21.1 to production; the `v1.21.1` tag then refreshes the MCP Registry listing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
