### PR TITLE
chore: release v1.23.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "nutrition-mcp",
-    "version": "1.22.0",
+    "version": "1.23.0",
     "description": "A remote MCP server for personal nutrition tracking. Log meals, track macros, and review nutrition history through Claude.",
     "author": "akutishevsky",
     "license": "MIT",

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
     "name": "io.github.akutishevsky/nutrition-mcp",
     "title": "Nutrition MCP",
     "description": "Personal nutrition tracking — log meals, track macros, review history, import from another app.",
-    "version": "1.22.0",
+    "version": "1.23.0",
     "websiteUrl": "https://nutrition-mcp.com/",
     "repository": {
         "url": "https://github.com/akutishevsky/nutrition-mcp",

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -3823,7 +3823,7 @@ async function buildMcpServer(c: Context, userId: string): Promise<McpServer> {
     const server = new McpServer(
         {
             name: "nutrition-mcp",
-            version: "1.22.0",
+            version: "1.23.0",
             icons: [
                 {
                     src: `${baseUrl}/favicon.ico`,


### PR DESCRIPTION
Bumps 1.22.0 → 1.23.0 in the three places that must agree: `package.json`, the `McpServer` constructor in `src/mcp.ts`, and `server.json`. The publish workflow refuses to publish when the git tag disagrees with `server.json`, so all three matter.

**Minor, not patch:** fiber, sugar and alcohol tracking plus two new tools (`set_alcohol_tracking`, `get_alcohol_tracking`, 35 → 37). New capability, no breaking change to any existing tool.

## This does not ship the feature

That already shipped in #59 — merging to `main` deploys, and every client hitting `https://nutrition-mcp.com/mcp` picked it up when DigitalOcean finished. This bump exists **only** to refresh the MCP Registry listing, which is discovery metadata pointing at that URL rather than an artifact anyone runs.

## Suggested order

1. Merge #60 first (the public copy), so the tag lands on a tree whose docs match the code.
2. Merge this.
3. Then push the tag — `git tag v1.23.0 && git push origin v1.23.0` — which triggers `.github/workflows/publish-mcp.yml`: tests, tag-vs-`server.json` check, then publish via `mcp-publisher` using GitHub OIDC.

Nothing breaks if the order differs; the registry entry would just point at a commit whose docs lag by one merge.

**Do not re-tag `v1.23.0` once it publishes** — registry versions are immutable, so a correction needs a fresh version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)