### PR TITLE
fix(import): round calories before writing to the integer column

### DIFF
--- a/src/csv.test.ts
+++ b/src/csv.test.ts
@@ -726,7 +726,14 @@ test("toKcal divides kJ by 4.184 and rounds to a whole kcal", () => {
     expect(toKcal(920, "kj")).toBe(220); // 219.88 -> a Cronometer-sized meal
     expect(toKcal(8368, "kj")).toBe(2000); // exactly 2000 kcal
     expect(toKcal(0, "kj")).toBe(0);
-    // kcal passes through untouched, decimals included.
+});
+
+test("toKcal rounds a kcal column too", () => {
+    // Not a formality: Cronometer's "Energy (kcal)" carries two decimals, and
+    // an integer column rejects those outright (22P02) instead of truncating,
+    // so a passed-through 388.54 failed the whole row.
     expect(toKcal(220, "kcal")).toBe(220);
-    expect(toKcal(219.88, "kcal")).toBe(219.88);
+    expect(toKcal(388.54, "kcal")).toBe(389);
+    expect(toKcal(219.88, "kcal")).toBe(220);
+    expect(toKcal(0.4, "kcal")).toBe(0);
 });

--- a/src/csv.ts
+++ b/src/csv.ts
@@ -807,15 +807,15 @@ export function sniffEnergyUnit(header: string, values: number[]): EnergyUnit {
 }
 
 /**
- * Convert an energy value to kcal.
+ * Convert an energy value to kcal, rounded to a whole number.
  *
- * kJ values are rounded to a whole number: the calories column is an integer in
- * the DB, so a fractional kcal is dropped downstream anyway, and rounding here
- * keeps the widget's preview and control totals identical to what the server
- * will store. kcal passes through untouched — including its decimals, which the
- * server is free to round itself.
+ * Both branches round, because the calories column is an integer in the DB:
+ * rounding here keeps the widget's preview and control totals identical to what
+ * the server stores. A kcal column is NOT exempt — Cronometer exports "Energy
+ * (kcal)" with two decimals, and passing those through used to make Postgres
+ * reject the row outright (22P02) rather than truncate it.
  */
 export function toKcal(value: number, unit: EnergyUnit): number {
-    if (unit === "kcal") return value;
+    if (unit === "kcal") return Math.round(value);
     return Math.round(value / KJ_PER_KCAL);
 }

--- a/src/import.test.ts
+++ b/src/import.test.ts
@@ -258,6 +258,43 @@ test("validateRow produces a MealInput ready for insertMeal", () => {
     expect("carbs_g" in v.resolved.input).toBe(false);
 });
 
+test("validateRow rounds fractional calories to the integer column", () => {
+    // Every Cronometer export writes "Energy (kcal)" with two decimals, and
+    // meals.calories is `integer` — Postgres rejects 388.54 outright (22P02)
+    // rather than truncating it, which failed most rows of a real backfill.
+    // Rounded here rather than at insert time so the dry-run echo the user
+    // approves shows the number that will actually be stored.
+    const v = validateRow(
+        row({ source_line: 2, calories: 388.54, protein_g: 12.35 }),
+        0,
+        { tz: TZ, nowMs: NOW },
+        undefined,
+    );
+    expect(v.ok).toBe(true);
+    if (!v.ok) return;
+    expect(v.resolved.input.calories).toBe(389);
+    // Macro columns are `numeric`, so their decimals must survive untouched.
+    expect(v.resolved.input.protein_g).toBe(12.35);
+});
+
+test("rows differing only below the kcal rounding boundary both import", async () => {
+    // 388.11 and 388.42 both store as 388, so rounding makes their content
+    // digests collide where the raw values would not have. The per-call
+    // occurrence ordinal is what keeps them two rows rather than one silently
+    // deduplicated row.
+    const { deps, inserted } = makeStore();
+    const result = await runImport(
+        args([
+            row({ source_line: 2, calories: 388.11 }),
+            row({ source_line: 3, calories: 388.42 }),
+        ]),
+        deps,
+    );
+    expect(result.summary.created).toBe(2);
+    expect(result.summary.deduplicated).toBe(0);
+    expect(inserted.map((m) => m.calories)).toEqual([388, 388]);
+});
+
 test("validateRow carries fiber, sugar and alcohol through to the MealInput", () => {
     const v = validateRow(
         row({ source_line: 4, fiber_g: 4.5, sugar_g: 12, alcohol_g: 14 }),

--- a/src/import.ts
+++ b/src/import.ts
@@ -24,6 +24,7 @@ import { z } from "zod";
 import type { MealInput, MealInsertResult } from "./supabase.js";
 import { dateInTz, zonedHourUtc, zonedWallClockToUtc } from "./tz.js";
 import { decodeEscapeSequences } from "./normalize.js";
+import { toStoredInteger } from "./units.js";
 
 export type MealType = MealInput["meal_type"];
 
@@ -732,7 +733,11 @@ export function validateRow(
         meal_type: mealType,
         logged_at: ts.value.iso,
     };
-    if (row.calories !== undefined) input.calories = row.calories;
+    // Rounded here rather than left to insertMeal so the dry-run echo and the
+    // per-row report show the number that will actually be stored — a fitness
+    // export's kcal column is routinely fractional (Cronometer's always is).
+    if (row.calories !== undefined)
+        input.calories = toStoredInteger(row.calories);
     if (row.protein_g !== undefined) input.protein_g = row.protein_g;
     if (row.carbs_g !== undefined) input.carbs_g = row.carbs_g;
     if (row.fat_g !== undefined) input.fat_g = row.fat_g;

--- a/src/supabase.ts
+++ b/src/supabase.ts
@@ -1,7 +1,7 @@
 import { createClient, type SupabaseClient } from "@supabase/supabase-js";
 import { zonedDayStartUtc, zonedNextDayStartUtc } from "./tz.js";
 import { decodeEscapeSequences } from "./normalize.js";
-import { isWeightUnit, type WeightUnit } from "./units.js";
+import { isWeightUnit, toStoredInteger, type WeightUnit } from "./units.js";
 import { isDrinkUnit, type DrinkUnit } from "./alcohol.js";
 import { escapeLikePattern, tokenizeQuery } from "./search.js";
 
@@ -182,12 +182,21 @@ export async function insertMeal(
 ): Promise<MealInsertResult> {
     const sb = getSupabase();
 
+    // calories is an integer column and Postgres rejects a fractional value
+    // outright (22P02), so round before anything else reads the input — the
+    // digest below included, or re-logging the same meal would derive a key
+    // from 388.54 while the stored row said 389 and the dedup would miss.
+    const meal: MealInput =
+        input.calories == null
+            ? input
+            : { ...input, calories: toStoredInteger(input.calories) };
+
     // Resolve logged_at once so the digest and the persisted row agree.
-    const loggedAt = input.logged_at ?? new Date().toISOString();
+    const loggedAt = meal.logged_at ?? new Date().toISOString();
     // Always populate the key: use the client's if given, otherwise derive a
     // stable one from the request content (see mealIdempotencyKey).
     const idempotencyKey =
-        input.idempotency_key ?? mealIdempotencyKey(userId, input, loggedAt);
+        meal.idempotency_key ?? mealIdempotencyKey(userId, meal, loggedAt);
 
     const { data: existing, error: selErr } = await sb
         .from("meals")
@@ -202,18 +211,18 @@ export async function insertMeal(
         .from("meals")
         .insert({
             user_id: userId,
-            description: decodeEscapeSequences(input.description),
-            meal_type: input.meal_type,
-            calories: input.calories ?? null,
-            protein_g: input.protein_g ?? null,
-            carbs_g: input.carbs_g ?? null,
-            fat_g: input.fat_g ?? null,
-            fiber_g: input.fiber_g ?? null,
-            sugar_g: input.sugar_g ?? null,
-            alcohol_g: input.alcohol_g ?? null,
+            description: decodeEscapeSequences(meal.description),
+            meal_type: meal.meal_type,
+            calories: meal.calories ?? null,
+            protein_g: meal.protein_g ?? null,
+            carbs_g: meal.carbs_g ?? null,
+            fat_g: meal.fat_g ?? null,
+            fiber_g: meal.fiber_g ?? null,
+            sugar_g: meal.sugar_g ?? null,
+            alcohol_g: meal.alcohol_g ?? null,
             logged_at: loggedAt,
             notes:
-                input.notes != null ? decodeEscapeSequences(input.notes) : null,
+                meal.notes != null ? decodeEscapeSequences(meal.notes) : null,
             idempotency_key: idempotencyKey,
         })
         .select()
@@ -402,7 +411,9 @@ export async function updateMeal(
     if (fields.description !== undefined)
         update.description = decodeEscapeSequences(fields.description);
     if (fields.meal_type !== undefined) update.meal_type = fields.meal_type;
-    if (fields.calories !== undefined) update.calories = fields.calories;
+    // Integer column — see toStoredInteger.
+    if (fields.calories !== undefined)
+        update.calories = toStoredInteger(fields.calories);
     if (fields.protein_g !== undefined) update.protein_g = fields.protein_g;
     if (fields.carbs_g !== undefined) update.carbs_g = fields.carbs_g;
     if (fields.fat_g !== undefined) update.fat_g = fields.fat_g;
@@ -605,14 +616,23 @@ export async function upsertNutritionGoals(
         .upsert(
             {
                 user_id: userId,
-                daily_calories: input.daily_calories ?? null,
+                // daily_calories and daily_water_ml are integer columns; the
+                // gram targets are numeric(6,2). See toStoredInteger — a water
+                // goal converted from "half a gallon" arrives fractional.
+                daily_calories:
+                    input.daily_calories == null
+                        ? null
+                        : toStoredInteger(input.daily_calories),
                 daily_protein_g: input.daily_protein_g ?? null,
                 daily_carbs_g: input.daily_carbs_g ?? null,
                 daily_fat_g: input.daily_fat_g ?? null,
                 daily_fiber_g: input.daily_fiber_g ?? null,
                 daily_sugar_g: input.daily_sugar_g ?? null,
                 daily_alcohol_g: input.daily_alcohol_g ?? null,
-                daily_water_ml: input.daily_water_ml ?? null,
+                daily_water_ml:
+                    input.daily_water_ml == null
+                        ? null
+                        : toStoredInteger(input.daily_water_ml),
                 target_weight_g: input.target_weight_g ?? null,
                 updated_at: new Date().toISOString(),
             },

--- a/src/units.test.ts
+++ b/src/units.test.ts
@@ -6,6 +6,7 @@ import {
     isWeightUnit,
     pickWriteUnit,
     isPlausibleWeightGrams,
+    toStoredInteger,
     WEIGHT_UNITS,
 } from "./units.js";
 
@@ -95,4 +96,19 @@ test("isWeightUnit guards kg/lb only", () => {
     expect(isWeightUnit("")).toBe(false);
     expect(isWeightUnit(undefined)).toBe(false);
     for (const u of WEIGHT_UNITS) expect(isWeightUnit(u)).toBe(true);
+});
+
+test("toStoredInteger rounds fractional values for the integer columns", () => {
+    // The shipped bug this guards: a Cronometer "Energy (kcal)" cell like
+    // 388.54 reached an `integer` column and Postgres rejected the whole row
+    // with 22P02, so most of a backfill failed. Rounding, not rejecting.
+    expect(toStoredInteger(388.54)).toBe(389);
+    expect(toStoredInteger(2363.25)).toBe(2363);
+    expect(toStoredInteger(78.08)).toBe(78);
+    expect(toStoredInteger(0.5)).toBe(1);
+    // Whole numbers must pass through byte-identical: they are what every
+    // already-stored row was hashed from, so a shifted value here would break
+    // idempotency-key dedup for every past meal.
+    expect(toStoredInteger(300)).toBe(300);
+    expect(toStoredInteger(0)).toBe(0);
 });

--- a/src/units.ts
+++ b/src/units.ts
@@ -1,6 +1,8 @@
-// Weight unit handling. Weight is stored canonically as integer grams; these
-// pure helpers convert between grams and the user-facing units (kg / lb) so all
-// conversion happens server-side rather than being delegated to the model.
+// Unit handling for the columns that are stored as whole numbers. Weight is
+// stored canonically as integer grams; these pure helpers convert between grams
+// and the user-facing units (kg / lb) so all conversion happens server-side
+// rather than being delegated to the model. Energy is stored as whole kcal —
+// see toStoredCalories at the bottom.
 
 export type WeightUnit = "kg" | "lb";
 
@@ -67,4 +69,27 @@ export function pickWriteUnit(
         );
     }
     return unit;
+}
+
+/**
+ * Round an energy or volume value to what its column can actually hold.
+ *
+ * `meals.calories`, `nutrition_goals.daily_calories` and
+ * `nutrition_goals.daily_water_ml` are `integer` columns, so Postgres rejects a
+ * fractional value outright — `22P02 invalid input syntax for type integer:
+ * "388.54"` — and the whole write fails. Fractional values are not exotic: Open
+ * Food Facts returns decimal kcal from lookup_barcode, and Cronometer's
+ * "Energy (kcal)" column is decimal in every export, so a Cronometer backfill
+ * used to fail on most of its rows.
+ *
+ * Every write path rounds rather than rejecting. A tenth of a kcal is noise
+ * against numbers that are estimates to begin with, so losing it is strictly
+ * better than losing the row — and a schema-level `.int()` would reject the
+ * caller's most common input for no benefit.
+ *
+ * Callers must round BEFORE deriving an idempotency key, so that the key and
+ * the stored row describe the same meal.
+ */
+export function toStoredInteger(value: number): number {
+    return Math.round(value);
 }


### PR DESCRIPTION
## The bug

`meals.calories` is an `integer` column ([migration](https://github.com/akutishevsky/nutrition-mcp/blob/main/supabase/migrations/20260417044712_remote_schema.sql#L49)), but **no write path rounded**. Postgres does not truncate a fractional value into an int column — it rejects the whole statement with `22P02 invalid input syntax for type integer: "388.54"`, so every affected row died on insert.

Cronometer writes `Energy (kcal)` with two decimals in every export, so a Cronometer backfill failed on essentially all of its rows. Open Food Facts also returns decimal kcal, so `lookup_barcode` → `log_meal` hit the same error.

`src/csv.ts` already documented the assumption — *"kcal passes through untouched — including its decimals, which the server is free to round itself"* — but the server never did.

Observed in production on 27 Jul: a burst of `22P02` in the Postgres log, and in `tool_analytics` 2 failed `bulk_import_meals` (`import_failed`) plus 2 failed `log_meal` (`supabase_error`).

## The fix

Adds `toStoredInteger()` to `src/units.ts` and applies it at every write into an integer column:

- **`insertMeal`** rounds **before** deriving the idempotency digest, so the key and the stored row describe the same meal. Deriving a key from `388.54` while storing `389` would make re-logging that meal miss the dedup.
- **`updateMeal`**, and **`upsertNutritionGoals`** for both `daily_calories` and `daily_water_ml` — the same latent bug, reachable by a water goal converted from a non-metric volume.
- **`import.ts` `validateRow`** rounds too, so the dry-run echo the user approves shows the number that will actually be stored.
- **`csv.ts` `toKcal`** now rounds the kcal branch as well as kJ, keeping the widget's preview and control totals identical to storage.

Rounding rather than rejecting: a tenth of a kcal is noise against numbers that are estimates anyway, and a schema-level `.int()` would reject the caller's most common input for no benefit.

`calories` stays `integer` — every read path already renders whole kcal, so a type migration on the populated production table buys nothing.

## Tests

New cases in `units.test.ts`, `import.test.ts` and `csv.test.ts`, including two rows that only collide *after* rounding — the per-call occurrence ordinal is what keeps them two rows rather than one silently deduplicated row. 370 pass, prettier clean.

## Note for after the merge

Re-running a previously failed import is safe: rows that succeeded before had integer calories, so their digests are unchanged and dedupe to a clean no-op, while the rows that failed now insert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)