### PR TITLE
chore: release v1.23.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "nutrition-mcp",
-    "version": "1.23.0",
+    "version": "1.23.1",
     "description": "A remote MCP server for personal nutrition tracking. Log meals, track macros, and review nutrition history through Claude.",
     "author": "akutishevsky",
     "license": "MIT",

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
     "name": "io.github.akutishevsky/nutrition-mcp",
     "title": "Nutrition MCP",
     "description": "Personal nutrition tracking — log meals, track macros, review history, import from another app.",
-    "version": "1.23.0",
+    "version": "1.23.1",
     "websiteUrl": "https://nutrition-mcp.com/",
     "repository": {
         "url": "https://github.com/akutishevsky/nutrition-mcp",

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -3823,7 +3823,7 @@ async function buildMcpServer(c: Context, userId: string): Promise<McpServer> {
     const server = new McpServer(
         {
             name: "nutrition-mcp",
-            version: "1.23.0",
+            version: "1.23.1",
             icons: [
                 {
                     src: `${baseUrl}/favicon.ico`,


### PR DESCRIPTION
Patch release for #62 — rounds calories before writing to the `integer` `meals.calories` column. Postgres rejects a fractional value with `22P02` rather than truncating it, so Cronometer's two-decimal kcal column failed most rows of a backfill.

Bumped in all three places the version has to match — `package.json`, the `McpServer` constructor in `src/mcp.ts`, and `server.json` — because the publish workflow refuses to publish when the git tag disagrees with `server.json`.

This bump exists only to refresh the MCP Registry listing. The fix itself already shipped when #62 merged: merging to `main` deploys, and the registry is discovery metadata pointing at `https://nutrition-mcp.com/mcp`, not the artifact clients run.

Tag `v1.23.1` follows once this is on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)