### PR TITLE
fix(trends): average fiber/sugar/alcohol over covered days only

### DIFF
--- a/public/widgets/src/shared/macros.js
+++ b/public/widgets/src/shared/macros.js
@@ -204,11 +204,18 @@ function macroLabelGoal(m, b) {
 // The sub-components of one macro that are worth showing: fiber and sugar under
 // carbs. Same rule the water bar uses — an untracked metric is noise rather
 // than a zero, so a sub only appears once it has data or a goal of its own.
+//
+// `null` is not "no data yet, treat as zero" — it is the covered-days signal
+// (see trendsDayPayloadOf / avgOf): a range with zero covered days for this
+// nutrient has nothing to average, so the sub is dropped entirely even when a
+// goal is set, matching computeTrends/formatStatLine suppressing the whole
+// section rather than printing "0g of 30g target".
 function subMacrosOf(m, ctx) {
     return MACROS.filter(
         (s) =>
             s.role === "sub" &&
             s.parent === m.key &&
+            ctx.vals[s.key] != null &&
             ((ctx.vals[s.key] ?? 0) > 0 ||
                 (ctx.goal ? (ctx.goal[s.key] ?? null) != null : false)),
     );
@@ -310,11 +317,14 @@ function macroBar(m, ctx) {
 // Alcohol — a plain stat line, never a ring: grams with the drink count as the
 // intuitive gloss ("2.1 US drinks · 28 g"), plus the limit when one is set.
 //
-// null vs 0 is load-bearing. `alcohol_g: null` is how every payload in
-// src/mcp.ts says "this user does not track alcohol" (see AlcoholDisplay), so
-// the line is dropped entirely. A 0 from a user who DOES track it is a real
-// alcohol-free day and stays on screen — unlike the water bar, whose 0 means
-// "never logged any" because water has no such opt-in to distinguish the two.
+// null vs 0 is load-bearing. `alcohol_g: null` is how a payload in src/mcp.ts
+// says "nothing to show here" — either the user does not track alcohol at all
+// (see AlcoholDisplay), or (trends' per-day/averaged series only) this day or
+// window has zero covered days for it (see trendsDayPayloadOf) — so the line
+// is dropped entirely either way. A 0 from a user who DOES track it, on a day
+// or window that DOES cover it, is a real alcohol-free reading and stays on
+// screen — unlike the water bar, whose 0 means "never logged any" because
+// water has no such opt-in to distinguish the two.
 function macroStat(m, ctx) {
     const grams = ctx.vals?.[m.key];
     if (grams == null) return "";

--- a/public/widgets/src/templates/trends.html
+++ b/public/widgets/src/templates/trends.html
@@ -10,8 +10,10 @@
   Shown after get_trends. The tool sends up to 30 days of daily series, and the
   7 / 14 / 30-day toggle slices it CLIENT-SIDE and re-renders — no host round-trip,
   so switching ranges is instant. Each range shows a calories/day line chart and
-  the trailing average vs goal as rings (average over the window, empty days
-  counted as 0, matching the tool's text output).
+  the trailing average vs goal as rings (average over the window; calories,
+  protein, carbs, fat and water count empty days as 0, while fiber, sugar and
+  alcohol average only over the days that recorded them — see avgOf below —
+  matching the tool's text output).
 
   Data arrives as the `structuredContent` of the get_trends tool result; the
   shared bridge (shared/bridge.js) reads it across host conventions and calls
@@ -64,6 +66,12 @@
                     date = d.toISOString().slice(0, 10);
                     const w = Math.sin(i / 3);
                     const skip = i === 4 || i === 11; // a couple of unlogged days
+                    // A few extra days with meals logged but no fiber/sugar on
+                    // them — pre-feature-style rows — so the sample exercises
+                    // the "recorded on some but not all days" case that this
+                    // widget must average correctly (null, not 0).
+                    const noFiberSugar =
+                        !skip && (i === 2 || i === 18 || i === 25);
                     const r = (n) => Math.round(n * 10) / 10;
                     days.push({
                         date,
@@ -71,12 +79,13 @@
                         protein_g: skip ? 0 : Math.round(150 + w * 18),
                         carbs_g: skip ? 0 : Math.round(212 + w * 28),
                         fat_g: skip ? 0 : Math.round(68 + w * 9),
-                        fiber_g: skip ? 0 : r(26 + w * 6),
-                        sugar_g: skip ? 0 : r(58 + w * 14),
-                        // Alcohol tracking ON in this sample, and 0 on most
-                        // days — a real alcohol-free day, which still shows.
-                        // null on every day (tracking off) hides the stat line.
-                        alcohol_g: skip || i % 7 ? 0 : r(13.9 + w * 4),
+                        fiber_g: skip || noFiberSugar ? null : r(26 + w * 6),
+                        sugar_g: skip || noFiberSugar ? null : r(58 + w * 14),
+                        // Alcohol tracking ON in this sample: null on an
+                        // unlogged day (no data), 0 on a real alcohol-free
+                        // day (still shows), a value on the rest. null on
+                        // every day (tracking off) hides the stat line.
+                        alcohol_g: skip ? null : i % 7 ? 0 : r(13.9 + w * 4),
                         water_ml: skip ? 0 : Math.round(2200 + w * 320),
                     });
                 }
@@ -115,8 +124,14 @@
                         })[c],
                 );
             }
-            // Trailing average over exactly the days shown: sum / count, empty
-            // days included as 0 — matches the tool's text trailingAverage.
+            // Trailing average over the days that actually carry this key:
+            // sum / count of non-null days — matches computeTrends'
+            // coveredSeries (src/insights.ts), which is where the tool's text
+            // trailingAverage comes from. Calories/protein/carbs/fat/water are
+            // never null (every day counts, as always), but fiber_g, sugar_g
+            // and alcohol_g arrive null on a day that never recorded them —
+            // dividing by days.length there would count a no-data day as a
+            // real zero, exactly the drift this fixes.
             //
             // A key that is null on EVERY day averages to null, not 0. That is
             // the alcohol opt-in: alcohol_g arrives null when the user has
@@ -132,7 +147,7 @@
                     sum += d[key] || 0;
                 }
                 if (!seen) return null;
-                return sum / days.length;
+                return sum / seen;
             }
 
             // MACROS + the macro panel builder (calories hero, protein/carbs/fat

--- a/src/mcp.test.ts
+++ b/src/mcp.test.ts
@@ -9,6 +9,7 @@ import {
     mealBreakdown,
     goalsPayloadOf,
     totalsPayloadOf,
+    trendsDayPayloadOf,
     hasActiveTarget,
     nutrientPresence,
     rangeAverages,
@@ -18,6 +19,7 @@ import {
     START_IMPORT_OUTPUT_SCHEMA,
     GOALS_ITEM,
     TOTALS_ITEM,
+    TRENDS_DAY_ITEM,
     MEAL_BREAKDOWN_ITEM,
     MAX_CALORIES,
     MAX_MACRO_G,
@@ -732,6 +734,84 @@ describe("structuredContent literals satisfy their schemas", () => {
 
     test("no goals at all is null, not a half-filled object", () => {
         expect(goalsPayloadOf(null, "us")).toBeNull();
+    });
+});
+
+// Regression coverage for https://github.com/akutishevsky/nutrition-mcp/issues/67:
+// the trends widget re-averaged fiber/sugar/alcohol over every day in a slice
+// instead of only the days that recorded them, because a day's per-day payload
+// summed those nutrients with `?? 0` just like every other totals payload — so
+// the widget's client-side average (trends.html's avgOf) could never tell "not
+// recorded" from "recorded zero". trendsDayPayloadOf is the fix: it nulls out
+// fiber_g/sugar_g/alcohol_g on a day that dayCarries says didn't record them.
+describe("trendsDayPayloadOf", () => {
+    const bucketWith = (mealsForDay: Meal[]): DailyBucket => ({
+        date: "2026-07-20",
+        meals: mealsForDay,
+        waterMl: 1000,
+        calories: mealsForDay.reduce((s, m) => s + (m.calories ?? 0), 0),
+        protein_g: 25,
+        carbs_g: 90,
+        fat_g: 20,
+        fiber_g: mealsForDay.reduce((s, m) => s + (m.fiber_g ?? 0), 0),
+        sugar_g: mealsForDay.reduce((s, m) => s + (m.sugar_g ?? 0), 0),
+        alcohol_g: mealsForDay.reduce((s, m) => s + (m.alcohol_g ?? 0), 0),
+        mealTypes: new Set(["dinner"]),
+    });
+
+    test("nulls fiber/sugar/alcohol on a day that never recorded them", () => {
+        const bucket = bucketWith([
+            meal({ fiber_g: null, sugar_g: null, alcohol_g: null }),
+        ]);
+        const payload = trendsDayPayloadOf(bucket, "us");
+        expect(payload.fiber_g).toBeNull();
+        expect(payload.sugar_g).toBeNull();
+        expect(payload.alcohol_g).toBeNull();
+        // Everything else sums normally — only the three partial nutrients
+        // get the covered-days treatment.
+        expect(payload.calories).toBe(bucket.calories);
+        expect(() => TRENDS_DAY_ITEM.parse(payload)).not.toThrow();
+    });
+
+    test("keeps a real recorded zero as 0, not null", () => {
+        const bucket = bucketWith([
+            meal({ fiber_g: 0, sugar_g: 0, alcohol_g: 0 }),
+        ]);
+        const payload = trendsDayPayloadOf(bucket, "us");
+        expect(payload.fiber_g).toBe(0);
+        expect(payload.sugar_g).toBe(0);
+        expect(payload.alcohol_g).toBe(0);
+    });
+
+    test("alcohol tracking off nulls alcohol_g regardless of coverage", () => {
+        const bucket = bucketWith([meal({ alcohol_g: 14 })]);
+        expect(trendsDayPayloadOf(bucket, null).alcohol_g).toBeNull();
+    });
+
+    test("a day with no meals at all is null across all three partial nutrients", () => {
+        const payload = trendsDayPayloadOf(bucketWith([]), "us");
+        expect(payload.fiber_g).toBeNull();
+        expect(payload.sugar_g).toBeNull();
+        expect(payload.alcohol_g).toBeNull();
+        expect(() => TRENDS_DAY_ITEM.parse(payload)).not.toThrow();
+    });
+
+    // The exact drift the issue reported: fiber recorded on 5 of 30 days at
+    // 30 g averaged out to 5 g/day in the widget (150 / 30) instead of 30
+    // (150 / 5). Once uncovered days are null, filtering them out before
+    // averaging — what the fixed client-side avgOf now does — recovers 30.
+    test("covered-days average recovers the true figure once uncovered days are null", () => {
+        const covered = Array.from({ length: 5 }, () =>
+            trendsDayPayloadOf(bucketWith([meal({ fiber_g: 30 })]), "us"),
+        );
+        const uncovered = Array.from({ length: 25 }, () =>
+            trendsDayPayloadOf(bucketWith([meal({ fiber_g: null })]), "us"),
+        );
+        const days = [...uncovered, ...covered];
+        const seen = days.filter((d) => d.fiber_g != null);
+        expect(seen).toHaveLength(5);
+        const avg = seen.reduce((s, d) => s + d.fiber_g!, 0) / seen.length;
+        expect(avg).toBe(30);
     });
 });
 

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -366,6 +366,18 @@ export const TOTALS_ITEM = z.object({
     water_ml: z.number(),
 });
 
+// get_trends' per-day series shape: like TOTALS_ITEM, but fiber_g/sugar_g are
+// nullable too. Everywhere else a day's totals are a real sum for that one
+// day, so 0 is unambiguous — but the trends widget re-averages this series
+// CLIENT-SIDE across a slice of days (see trends.html's avgOf), and there a
+// summed 0 on a day that never recorded fiber/sugar is indistinguishable from
+// a real zero. Null is the "not recorded" signal, built by trendsDayPayloadOf.
+export const TRENDS_DAY_ITEM = TOTALS_ITEM.extend({
+    date: z.string(),
+    fiber_g: z.number().nullable(),
+    sugar_g: z.number().nullable(),
+});
+
 // Which standard-drink convention the widget should render alcohol_g in. The
 // payloads carry canonical grams, so without this a UK user saw "US drinks" in
 // the widget while the text output beside it said "UK units". Null doubles as
@@ -430,6 +442,46 @@ export function totalsPayloadOf(totals: DailyTotals, alcohol: AlcoholDisplay) {
         sugar_g: Math.round(totals.sugar_g * 10) / 10,
         alcohol_g: alcohol ? Math.round(totals.alcohol_g * 10) / 10 : null,
         water_ml: totals.water_ml,
+    };
+}
+
+// get_trends ships this per day in its `days` series, which the widget slices
+// to 7/14/30 and re-averages CLIENT-SIDE (see trends.html's avgOf) instead of
+// round-tripping to the server. totalsPayloadOf sums fiber/sugar/alcohol with
+// `?? 0`, so a day that never recorded them is indistinguishable from a real
+// zero — the widget's average then divides by every day in the slice instead
+// of the covered ones, drifting from the text output's `coveredSeries` rule
+// (src/insights.ts). Null here is that missing-vs-zero signal, mirroring
+// dayCarries/coveredDailyAverage; alcohol_g can already be null for tracking
+// being off, which takes precedence over the per-day coverage null.
+export function trendsDayPayloadOf(
+    bucket: DailyBucket,
+    alcohol: AlcoholDisplay,
+) {
+    const totals = totalsPayloadOf(
+        {
+            calories: bucket.calories,
+            protein_g: bucket.protein_g,
+            carbs_g: bucket.carbs_g,
+            fat_g: bucket.fat_g,
+            fiber_g: bucket.fiber_g,
+            sugar_g: bucket.sugar_g,
+            alcohol_g: bucket.alcohol_g,
+            water_ml: bucket.waterMl,
+        },
+        alcohol,
+    );
+    return {
+        date: bucket.date,
+        ...totals,
+        fiber_g: dayCarries(bucket.meals, "fiber_g") ? totals.fiber_g : null,
+        sugar_g: dayCarries(bucket.meals, "sugar_g") ? totals.sugar_g : null,
+        alcohol_g:
+            totals.alcohol_g == null
+                ? null
+                : dayCarries(bucket.meals, "alcohol_g")
+                  ? totals.alcohol_g
+                  : null,
     };
 }
 
@@ -3448,7 +3500,7 @@ export function registerTools(
                 drink_unit: DRINK_UNIT_FIELD,
                 goals: GOALS_ITEM.nullable(),
                 // Up to 30 days of daily series; the widget slices to 7/14/30.
-                days: z.array(TOTALS_ITEM.extend({ date: z.string() })),
+                days: z.array(TRENDS_DAY_ITEM),
             },
             // Link the tool to its interactive trends UI (MCP Apps).
             ...uiMeta(TRENDS_WIDGET_URI),
@@ -3503,24 +3555,14 @@ export function registerTools(
                                 : 30,
                             drink_unit: alcohol,
                             goals: goalsPayload,
-                            // Rounded through totalsPayloadOf so the series is
-                            // shaped exactly like every other totals payload.
-                            days: seriesBuckets.map((b) => ({
-                                date: b.date,
-                                ...totalsPayloadOf(
-                                    {
-                                        calories: b.calories,
-                                        protein_g: b.protein_g,
-                                        carbs_g: b.carbs_g,
-                                        fat_g: b.fat_g,
-                                        fiber_g: b.fiber_g,
-                                        sugar_g: b.sugar_g,
-                                        alcohol_g: b.alcohol_g,
-                                        water_ml: b.waterMl,
-                                    },
-                                    alcohol,
-                                ),
-                            })),
+                            // Rounded through trendsDayPayloadOf, which nulls
+                            // out fiber/sugar/alcohol on days that didn't
+                            // record them so the widget's client-side average
+                            // (avgOf in trends.html) can skip them instead of
+                            // counting a no-data day as a real zero.
+                            days: seriesBuckets.map((b) =>
+                                trendsDayPayloadOf(b, alcohol),
+                            ),
                         },
                     };
                 },


### PR DESCRIPTION
## Summary
- `get_trends`'s per-day series summed fiber_g/sugar_g/alcohol_g with `?? 0`, so a day that never recorded a nutrient was indistinguishable from a real zero — the trends widget's client-side 7/14/30-day average then divided by every day in the slice instead of only the days that recorded it, drifting from the text output's covered-days rule (fiber recorded on 5 of 30 days at 30g showed as 5g in the widget).
- New `trendsDayPayloadOf` (src/mcp.ts) nulls fiber_g/sugar_g/alcohol_g on days `dayCarries` says weren't recorded, backed by a new `TRENDS_DAY_ITEM` output schema.
- `avgOf` in `trends.html` now divides by the count of non-null days instead of the full slice length, and `subMacrosOf` in `shared/macros.js` no longer renders a fiber/sugar row as "0g of Xg target" when there's actually zero coverage.

Fixes #67

## Test plan
- [x] `bun test` — 375 pass (5 new tests in `src/mcp.test.ts` cover null/zero/tracking-off/no-meals cases and reproduce the reported 5-of-30-days-at-30g scenario)
- [x] `bun test src/widgets.test.ts` — widget assembly still clean
- [x] `bun run format:check` — clean
- [x] Independently reviewed by two adversarial code-review passes (server-side and widget-side) against the actual `dayCarries`/`coveredSeries` logic

🤖 Generated with [Claude Code](https://claude.com/claude-code)