### PR TITLE
fix(import): normalize 12-hour and unpadded times before sending

### DIFF
--- a/public/widgets/import-time.test.ts
+++ b/public/widgets/import-time.test.ts
@@ -1,0 +1,204 @@
+// Behaviour tests for the import widget's buildRows() — issue #64: a raw time
+// cell (a separate Time column, or a time riding along in the date cell) was
+// appended to the ISO date verbatim. The server's LOCAL_DATETIME_RE only
+// accepts zero-padded 24-hour HH:MM[:SS], so an unpadded 24-hour time
+// ("9:15") or a 12-hour time ("9:15 AM" — Cronometer's own Time column shape)
+// matched none of the accepted forms and every such row was rejected. The fix
+// runs the raw cell through normalizeTime (src/csv.ts) before appending it.
+//
+// This also covers the "bonus symptom" from the issue: the preview's
+// no-time check (/\d\d:\d\d/) missed unpadded times like "9:15" and
+// mislabeled those rows "will be logged at midday" even though they had a
+// real time — fixed for free once logged_at always carries a zero-padded
+// time when one was present.
+//
+// Same evaluation technique as macros.test.ts and import-run.test.ts: the
+// real assembled widget script is run as one script with only the
+// `initWidget({…})` bootstrap cut off.
+import { test, expect } from "bun:test";
+
+interface ImportRow {
+    source_line: number;
+    logged_at: string;
+    description: string | undefined;
+    meal_type: string | undefined;
+    calories: number | undefined;
+    carbs_g: number | undefined;
+    fat_g: number | undefined;
+}
+
+async function freshImportWidget() {
+    const { getWidgetHtml } = await import("../../src/widgets");
+    const html = await getWidgetHtml("import-meals");
+    const script = html.slice(
+        html.lastIndexOf("<script>") + "<script>".length,
+        html.lastIndexOf("</script>"),
+    );
+    const boot = script.indexOf("initWidget({");
+    if (boot === -1) throw new Error("import-meals bootstrap not found");
+    const factory = new Function(
+        `${script.slice(0, boot)}
+         return { S, buildRows };`,
+    );
+    return factory() as {
+        S: {
+            table: unknown;
+            mapping: Record<string, number>;
+            dateFormat: string;
+            energyUnit: string;
+            rows: ImportRow[];
+            badDates: number;
+            skipped: number;
+        };
+        buildRows: () => void;
+    };
+}
+
+// A Cronometer-shaped table: Day/Time split, 12-hour Time column — the exact
+// shape modeled by the fixture in src/csv.test.ts that motivated the issue.
+function cronometerTable() {
+    return {
+        headers: [
+            "Day",
+            "Time",
+            "Group",
+            "Food Name",
+            "Amount",
+            "Energy (kcal)",
+            "Carbs (g)",
+            "Fat (g)",
+        ],
+        rows: [
+            [
+                "2026-01-15",
+                "9:15 AM",
+                "Breakfast",
+                "Oats, rolled",
+                "58.00 g",
+                "220",
+                "37.5",
+                "4.1",
+            ],
+            [
+                "2026-01-15",
+                "1:00 PM",
+                "Lunch",
+                "Chicken breast, roasted",
+                "120.00 g",
+                "198",
+                "0",
+                "4.3",
+            ],
+        ],
+        sourceLines: [2, 3],
+        encoding: "utf-8",
+        delimiter: ",",
+        decimalSeparator: ".",
+        warnings: [],
+        skippedTotalsRows: 0,
+        skippedBlankRows: 0,
+    };
+}
+
+function cronometerMapping() {
+    return {
+        deleted: -1,
+        logged_at: 0,
+        time: 1,
+        meal_type: 2,
+        description: 3,
+        calories: 5,
+        protein_g: -1,
+        carbs_g: 6,
+        fat_g: 7,
+        fiber_g: -1,
+        sugar_g: -1,
+        alcohol_g: -1,
+        notes: -1,
+    };
+}
+
+test("a 12-hour Time column (Cronometer) produces a zero-padded 24-hour logged_at", async () => {
+    const w = await freshImportWidget();
+    w.S.table = cronometerTable();
+    w.S.mapping = cronometerMapping();
+    w.S.dateFormat = "iso";
+    w.S.energyUnit = "kcal";
+
+    w.buildRows();
+
+    expect(w.S.rows).toHaveLength(2);
+    // 9:15 AM -> 09:15, not the raw "2026-01-15 9:15 AM" the server rejects.
+    expect(w.S.rows[0]!.logged_at).toBe("2026-01-15 09:15");
+    // 1:00 PM -> 13:00.
+    expect(w.S.rows[1]!.logged_at).toBe("2026-01-15 13:00");
+    // Nothing was dropped as a bad date — this used to fail every row.
+    expect(w.S.badDates).toBe(0);
+    expect(w.S.skipped).toBe(0);
+    // The "no time" check (/\d\d:\d\d/) now finds a real zero-padded time, so
+    // neither row is mislabeled as timeless / logged at midday.
+    for (const r of w.S.rows) {
+        expect(/\d\d:\d\d/.test(r.logged_at)).toBe(true);
+    }
+});
+
+test("an unpadded 24-hour Time column is zero-padded too", async () => {
+    const w = await freshImportWidget();
+    const table = cronometerTable();
+    table.rows[0]![1] = "9:15"; // unpadded 24-hour, no AM/PM
+    w.S.table = table;
+    w.S.mapping = cronometerMapping();
+    w.S.dateFormat = "iso";
+    w.S.energyUnit = "kcal";
+
+    w.buildRows();
+
+    expect(w.S.rows[0]!.logged_at).toBe("2026-01-15 09:15");
+    expect(w.S.badDates).toBe(0);
+});
+
+test("a time embedded in the date cell is normalized the same way", async () => {
+    const w = await freshImportWidget();
+    const table = cronometerTable();
+    // No separate Time column: the whole timestamp rides in Day instead.
+    table.headers = table.headers.filter((h) => h !== "Time");
+    table.rows = table.rows.map((r) => {
+        const [day, time, ...rest] = r;
+        return [`${day} ${time}`, ...rest];
+    });
+    w.S.table = table;
+    w.S.mapping = { ...cronometerMapping(), time: -1 };
+    // Column indices after removing Time shift left by one.
+    w.S.mapping.meal_type = 1;
+    w.S.mapping.description = 2;
+    w.S.mapping.calories = 4;
+    w.S.mapping.carbs_g = 5;
+    w.S.mapping.fat_g = 6;
+    w.S.dateFormat = "iso";
+    w.S.energyUnit = "kcal";
+
+    w.buildRows();
+
+    expect(w.S.rows[0]!.logged_at).toBe("2026-01-15 09:15");
+    expect(w.S.rows[1]!.logged_at).toBe("2026-01-15 13:00");
+    expect(w.S.badDates).toBe(0);
+});
+
+test("an unparseable time is dropped, not failed — the row still imports, dateless", async () => {
+    const w = await freshImportWidget();
+    const table = cronometerTable();
+    table.rows[0]![1] = "not a time";
+    w.S.table = table;
+    w.S.mapping = cronometerMapping();
+    w.S.dateFormat = "iso";
+    w.S.energyUnit = "kcal";
+
+    w.buildRows();
+
+    expect(w.S.rows).toHaveLength(2);
+    expect(w.S.badDates).toBe(0);
+    // Bare date only — no time appended, so this row now correctly falls
+    // into the "no time" preview notice instead of silently misdating.
+    expect(w.S.rows[0]!.logged_at).toBe("2026-01-15");
+    expect(/\d\d:\d\d/.test(w.S.rows[0]!.logged_at)).toBe(false);
+});

--- a/public/widgets/src/templates/import-meals.html
+++ b/public/widgets/src/templates/import-meals.html
@@ -627,8 +627,14 @@
                     let when = iso;
                     // A separate time column is common (Cronometer: Day + Time);
                     // otherwise keep a time that rode along in the date cell,
-                    // which toIsoDate drops.
-                    const time = cell(r, m.time) || timeInDateCell(rawWhen);
+                    // which toIsoDate drops. Either can be unpadded 12-hour
+                    // ("9:15 AM") — the server only accepts zero-padded 24-hour
+                    // HH:MM, so normalizeTime converts it. A time that fails to
+                    // parse is dropped rather than failing the whole row: the
+                    // meal still imports, dated but timeless (server default:
+                    // local noon), and shows up in the noTime notice below.
+                    const rawTime = cell(r, m.time) || timeInDateCell(rawWhen);
+                    const time = rawTime ? normalizeTime(rawTime) : null;
                     if (time) when = when + " " + time;
 
                     // Calories only: protein/carbs/fat/fiber/sugar/alcohol are
@@ -913,7 +919,7 @@
                         esc(dateFormatLabel(S.dateFormat)) +
                         ", so rows like it will be skipped"
                     );
-                const time = timeInDateCell(raw);
+                const time = normalizeTime(timeInDateCell(raw));
                 return esc(raw) + " → " + esc(iso + (time ? " " + time : ""));
             }
             function energyExampleHtml() {

--- a/src/csv.test.ts
+++ b/src/csv.test.ts
@@ -16,6 +16,7 @@ import {
     isDeletedRow,
     sniffDateFormat,
     toIsoDate,
+    normalizeTime,
     sniffEnergyUnit,
     toKcal,
 } from "./csv.js";
@@ -672,6 +673,101 @@ test("toIsoDate output is accepted by the server's resolveLoggedAt", () => {
     expect(resolveLoggedAt("18/07/2026", "Europe/Kyiv", Date.now()).ok).toBe(
         false,
     );
+});
+
+// ---------- time conversion ----------
+
+test("normalizeTime pads an unpadded 24-hour hour", () => {
+    // The server's LOCAL_DATETIME_RE demands exactly 2-2 digits, so "9:15"
+    // would be rejected even though it names a real time.
+    expect(normalizeTime("9:15")).toBe("09:15");
+    expect(normalizeTime("0:05")).toBe("00:05");
+    // Already padded: unchanged.
+    expect(normalizeTime("09:15")).toBe("09:15");
+    expect(normalizeTime("23:15")).toBe("23:15");
+    expect(normalizeTime("00:00")).toBe("00:00");
+});
+
+test("normalizeTime converts 12-hour AM/PM to 24-hour", () => {
+    // Cronometer's Time column shape — the exact case from issue #64.
+    expect(normalizeTime("9:15 AM")).toBe("09:15");
+    expect(normalizeTime("1:00 PM")).toBe("13:00");
+    // The two hours a 12-hour clock spells unintuitively.
+    expect(normalizeTime("12:00 AM")).toBe("00:00"); // midnight
+    expect(normalizeTime("12:00 PM")).toBe("12:00"); // noon
+    expect(normalizeTime("12:30 AM")).toBe("00:30");
+    expect(normalizeTime("12:30 PM")).toBe("12:30");
+    expect(normalizeTime("11:59 PM")).toBe("23:59");
+});
+
+test("normalizeTime accepts the export-observed AM/PM spellings", () => {
+    for (const v of [
+        "9:15 AM",
+        "9:15AM",
+        "9:15am",
+        "9:15 am",
+        "9:15 a.m.",
+        "9:15a.m.",
+        "9:15a",
+    ]) {
+        expect(normalizeTime(v)).toBe("09:15");
+    }
+    for (const v of ["1:00 PM", "1:00pm", "1:00 p.m.", "1:00p"]) {
+        expect(normalizeTime(v)).toBe("13:00");
+    }
+});
+
+test("normalizeTime preserves seconds when present", () => {
+    expect(normalizeTime("9:15:07")).toBe("09:15:07");
+    expect(normalizeTime("9:15:07 AM")).toBe("09:15:07");
+    expect(normalizeTime("11:59:59 PM")).toBe("23:59:59");
+});
+
+test("normalizeTime rejects out-of-range and unparseable values", () => {
+    // Minutes/seconds out of range.
+    expect(normalizeTime("9:60")).toBeNull();
+    expect(normalizeTime("9:15:60")).toBeNull();
+    // 24-hour value out of range with no meridiem to reinterpret it by.
+    expect(normalizeTime("24:00")).toBeNull();
+    expect(normalizeTime("25:15")).toBeNull();
+    // A 12-hour clock never carries these hours.
+    expect(normalizeTime("13:00 PM")).toBeNull();
+    expect(normalizeTime("00:15 AM")).toBeNull();
+    expect(normalizeTime("0:15 PM")).toBeNull();
+    // Blank-ish and junk cells.
+    for (const v of ["", "  ", "n/a", "-", undefined, "Breakfast", "9"]) {
+        expect(normalizeTime(v)).toBeNull();
+    }
+});
+
+test("normalizeTime output is accepted by the server's resolveLoggedAt", () => {
+    // The contract that matters, mirroring the toIsoDate test above: normalising
+    // client-side is pointless unless the result actually lands in
+    // resolveLoggedAt's local-time branch. This is issue #64 end-to-end — a
+    // Cronometer row with a "9:15 AM" Time column, reproduced from the
+    // Cronometer-shaped fixture earlier in this file.
+    const iso = toIsoDate("2026-01-15", "iso");
+    const time = normalizeTime("9:15 AM");
+    expect(iso).toBe("2026-01-15");
+    expect(time).toBe("09:15");
+
+    const r = resolveLoggedAt(
+        `${iso} ${time}`,
+        "Europe/Kyiv",
+        Date.parse("2026-01-20T12:00:00Z"),
+    );
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+        expect(r.value.fromBareDate).toBe(false);
+        // Kyiv is +02:00 in January, so 09:15 local is 07:15Z.
+        expect(r.value.iso).toBe("2026-01-15T07:15:00.000Z");
+    }
+
+    // And the raw, un-normalized cell the widget used to send is rejected
+    // server-side — every single row, which is exactly issue #64's failure.
+    expect(
+        resolveLoggedAt(`${iso} 9:15 AM`, "Europe/Kyiv", Date.now()).ok,
+    ).toBe(false);
 });
 
 // ---------- energy units ----------

--- a/src/csv.ts
+++ b/src/csv.ts
@@ -756,6 +756,67 @@ export function toIsoDate(
     return `${String(year).padStart(4, "0")}-${String(month).padStart(2, "0")}-${String(day).padStart(2, "0")}`;
 }
 
+// ---------- times ----------
+//
+// The server's LOCAL_DATETIME_RE (src/import.ts) only accepts zero-padded
+// 24-hour HH:MM[:SS] — it has to, since it also parses the T-joined form of a
+// full timestamp, where "9:15 AM" would be ambiguous with other fields. But
+// exports hand back whatever their own locale prints: Cronometer's Time
+// column is unpadded 12-hour ("9:15 AM"), and a date cell's trailing time
+// (captured by CELL_TIME_RE in the widget) carries the same shapes. Sending
+// either straight through made the server reject every single row.
+
+const TIME_RE = /^(\d{1,2}):(\d{2})(?::(\d{2}))?\s*([ap])?\.?m?\.?$/i;
+
+/**
+ * Convert a raw time cell to zero-padded 24-hour `HH:MM` or `HH:MM:SS`, or
+ * null when it cannot be trusted. Accepts an optional trailing am/pm marker
+ * in any of the export-observed spellings ("AM", "am", "a.m.", "9:15a").
+ *
+ * A meridiem marker switches validation to the 12-hour range (1-12) and
+ * converts to 24-hour; its absence keeps the value in 24-hour range (0-23)
+ * unchanged but still zero-pads it, so an already-correct "9:15" (missing
+ * only its leading zero) is not rejected for lack of an AM/PM marker.
+ */
+export function normalizeTime(raw: string | undefined): string | null {
+    if (raw === undefined) return null;
+    const text = raw.trim();
+    if (text === "") return null;
+
+    const m = TIME_RE.exec(text);
+    if (!m) return null;
+
+    let hour = Number(m[1]);
+    const minute = Number(m[2]);
+    const second = m[3] !== undefined ? Number(m[3]) : undefined;
+    const meridiem = m[4] ? m[4].toLowerCase() : null;
+
+    if (minute > 59) return null;
+    if (second !== undefined && second > 59) return null;
+
+    if (meridiem) {
+        // A 12-hour clock never carries an hour outside 1-12 (no "00" or
+        // "13 PM"); reject rather than guess what was meant.
+        if (hour < 1 || hour > 12) return null;
+        hour =
+            meridiem === "a"
+                ? hour === 12
+                    ? 0
+                    : hour
+                : hour === 12
+                  ? 12
+                  : hour + 12;
+    } else if (hour > 23) {
+        return null;
+    }
+
+    const hh = String(hour).padStart(2, "0");
+    const mm = String(minute).padStart(2, "0");
+    return second === undefined
+        ? `${hh}:${mm}`
+        : `${hh}:${mm}:${String(second).padStart(2, "0")}`;
+}
+
 // ---------- energy ----------
 
 export type EnergyUnit = "kcal" | "kj";


### PR DESCRIPTION
## Summary
- The bulk-import widget built `logged_at` by appending a raw time cell straight onto the ISO date (`"9:15 AM"` -> `"2026-01-15 9:15 AM"`), but the server's `LOCAL_DATETIME_RE` (`src/import.ts`) only accepts zero-padded 24-hour `HH:MM[:SS]`. Every row from an export with a 12-hour or unpadded Time column — Cronometer's own `Time` column shape, e.g. `9:15 AM` — matched none of the three accepted timestamp forms, so the dry run of chunk 0 failed and the whole import aborted.
- Added `normalizeTime()` to `src/csv.ts` (right after `toIsoDate`, same "tested module inlined via `@inlinets`" pattern already used for the CSV parser and, most recently, the import chunker in #87) to convert both unpadded 24-hour and 12-hour AM/PM times to the server's accepted shape before appending.
- Wired it into both places the widget appends a time to a date: `buildRows()` (the real per-row conversion) and `dateExampleHtml()` (the "worked example" preview, so it stays honest about what will actually be sent).
- An unparseable time cell is dropped rather than failing the whole row — the meal still imports as a bare date (server default: local noon) instead of being rejected outright.
- Fixes the issue's "bonus symptom" for free: the preview's no-time check (`/\d\d:\d\d/`) was missing unpadded times like `9:15` and mislabeling those rows "will be logged at midday" even though they had a real time — once `buildRows()` always emits a zero-padded time when one is present, that regex matches correctly.

## Tests
- `src/csv.test.ts` (6 new tests): unpadded-hour padding, full 12-hour AM/PM conversion table (including the two hours a 12-hour clock spells unintuitively — 12:00 AM/PM), every export-observed AM/PM spelling, seconds preservation, out-of-range/garbage rejection, and — mirroring the existing `toIsoDate`/`resolveLoggedAt` contract test — a test that calls the real server-side `resolveLoggedAt` directly to prove the normalized output is genuinely accepted and the raw `"9:15 AM"` the widget used to send is genuinely rejected (the actual before/after of this bug).
- `public/widgets/import-time.test.ts` (4 new tests, new file): evaluates the real assembled widget script (same technique as `macros.test.ts` / `import-run.test.ts`) against a Cronometer-shaped fixture matching `src/csv.test.ts`'s existing one — proves `buildRows()` produces a correct zero-padded `logged_at` end-to-end for a separate Time column (12h and unpadded 24h) and for a time embedded in the date cell, plus the graceful-degradation path for an unparseable time.

Verified with two independent review passes: one hand-traced the regex against the server's actual `LOCAL_DATETIME_RE` and checked the tests aren't fooling themselves, the other swept the codebase for any other place a raw time might leak through un-normalized. Both came back clean — no other instance of this bug class found. (The second pass also flagged, as a separate unrelated observation, that `log_meal`/`update_meal` don't validate `logged_at` through the server's strict parser the way `log_water`/`log_weight` do — a different code path, not a live bug, noted here only as a possible future hardening item.)

Fixes #64.

## Test plan
- [x] `bun test` — 405 pass
- [x] `bun run format:check`
- [x] `bunx tsc --noEmit` — no new errors in touched files
- [x] Verified the assembled widget HTML inlines `normalizeTime` correctly (3 call sites, no leftover TS syntax)

🤖 Generated with [Claude Code](https://claude.com/claude-code)