### PR TITLE
fix(widgets): add ChatGPT Apps SDK compatibility aliases

### DIFF
--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -983,8 +983,20 @@ export function registerTools(
     // buildMcpServer registers tools per request, this makes widget display a
     // per-user setting: with widgets off, tools/list advertises no UI link, so
     // hosts render no widget. Spreads to nothing when disabled.
+    // "openai/outputTemplate" mirrors ui.resourceUri for ChatGPT: it has honored
+    // the MCP Apps standard since 2026-02-22, but still reads the pre-standard
+    // Apps SDK alias on some surfaces, and hosts that know neither key ignore
+    // both. The two values must stay identical — ChatGPT drops the widget
+    // silently if the alias points at an unregistered URI.
     const uiMeta = (resourceUri: string) =>
-        widgetsEnabled ? { _meta: { ui: { resourceUri } } } : {};
+        widgetsEnabled
+            ? {
+                  _meta: {
+                      ui: { resourceUri },
+                      "openai/outputTemplate": resourceUri,
+                  },
+              }
+            : {};
 
     server.registerTool(
         "log_meal",
@@ -1248,6 +1260,10 @@ export function registerTools(
                 destructiveHint: false,
                 idempotentHint: true,
             },
+            // ChatGPT's legacy Apps SDK path only lets a widget call tools
+            // flagged widgetAccessible; without it the import-meals panel there
+            // cannot reach its write path. Other hosts ignore the key.
+            _meta: { "openai/widgetAccessible": true },
         },
         async (args) => {
             return withAnalytics(


### PR DESCRIPTION
## Why

Widgets render in Claude and MCP Inspector but not in ChatGPT. ChatGPT natively supports the official MCP Apps standard (our mechanism) since 2026-02-22, so the server contract is not the blocker — but some ChatGPT surfaces still key on the pre-standard Apps SDK metadata, and OpenAI's troubleshooting guide recommends carrying the aliases. This PR adds them as a low-cost hedge; hosts that know neither key ignore both, so Claude behavior is unchanged.

## What

- `uiMeta()` now emits `"openai/outputTemplate"` alongside `ui.resourceUri` (same `ui://` URI — a mismatch makes ChatGPT drop the widget silently). Covers all 7 widget-linked tools.
- `bulk_import_meals` carries `"openai/widgetAccessible": true`, without which ChatGPT's legacy path blocks the import-meals widget from calling its write tool.

The widget-side bridge already has a `window.openai` / `openai:set_globals` fallback, so no client-side changes are needed.

## Remaining ChatGPT-side steps (not fixable in code)

After this deploys, the connector must be **Refreshed** in ChatGPT's connector settings and tested in a **new conversation** — ChatGPT caches tool metadata and widget HTML at connect time. The connector must also be added under **Developer mode**; outside it, custom connectors run without app widgets. If widgets still don't render after that with a single-tool prompt on desktop web, it matches an open ChatGPT renderer regression (openai/openai-apps-sdk-examples#222).

## Testing

- `bun test` — 405 pass, 0 fail
- `bun run format:check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)