### PR TITLE
fix(delete): report not-found instead of false success

### DIFF
--- a/src/mcp.test.ts
+++ b/src/mcp.test.ts
@@ -867,6 +867,9 @@ const db = {
     meals: [] as Meal[],
     inserted: [] as Record<string, unknown>[],
     profilePatches: [] as Record<string, unknown>[],
+    // Ids the delete stubs consider to exist. Deleting one removes it, so a
+    // second delete of the same id reports "not found" like the real table.
+    rowIds: new Set<string>(),
 };
 
 mock.module("./supabase.js", () => ({
@@ -896,6 +899,13 @@ mock.module("./supabase.js", () => ({
         db.meals = [saved];
         return saved;
     },
+    deleteMeal: async (_userId: string, id: string) => {
+        const before = db.meals.length;
+        db.meals = db.meals.filter((m) => m.id !== id);
+        return db.meals.length < before;
+    },
+    deleteWater: async (_userId: string, id: string) => db.rowIds.delete(id),
+    deleteWeight: async (_userId: string, id: string) => db.rowIds.delete(id),
     countMeals: async () => db.meals.length,
     existingIdempotencyKeys: async () => new Set<string>(),
     getPreferredWeightUnit: async () =>
@@ -927,6 +937,7 @@ beforeEach(() => {
     db.meals = [];
     db.inserted = [];
     db.profilePatches = [];
+    db.rowIds = new Set<string>();
 });
 
 interface ToolResult {
@@ -1430,4 +1441,63 @@ describe("bulk_import_meals surfaces hidden alcohol", () => {
             expect(text).toContain("set_alcohol_tracking");
         });
     });
+});
+
+// ---------- delete tools report what actually happened ----------
+
+// A delete that matched no row (stale id, typo, or an id belonging to another
+// user — filtered out by the `user_id` eq) used to still print "deleted", so
+// the model told the user the entry was gone while it kept showing up in every
+// summary and total. Each handler must branch on whether a row matched.
+describe("delete tools distinguish deleted from not-found", () => {
+    const cases: {
+        tool: string;
+        id: string;
+        seed: (id: string) => void;
+        deleted: string;
+        notFound: string;
+    }[] = [
+        {
+            tool: "delete_meal",
+            id: "m1",
+            seed: (id) => {
+                db.meals = [storedMeal({ id })];
+            },
+            deleted: "Meal m1 deleted.",
+            notFound: "No meal found with id m1.",
+        },
+        {
+            tool: "delete_water",
+            id: "w1",
+            seed: (id) => db.rowIds.add(id),
+            deleted: "Water entry w1 deleted.",
+            notFound: "No water entry found with id w1.",
+        },
+        {
+            tool: "delete_weight",
+            id: "k1",
+            seed: (id) => db.rowIds.add(id),
+            deleted: "Weight entry k1 deleted.",
+            notFound: "No weight entry found with id k1.",
+        },
+    ];
+
+    for (const c of cases) {
+        test(`${c.tool} confirms a row it removed`, async () => {
+            c.seed(c.id);
+            await withTools(null, async (call) => {
+                expect(textOf(await call(c.tool, { id: c.id }))).toBe(
+                    c.deleted,
+                );
+            });
+        });
+
+        test(`${c.tool} does not claim success for an unknown id`, async () => {
+            await withTools(null, async (call) => {
+                const text = textOf(await call(c.tool, { id: c.id }));
+                expect(text).toBe(c.notFound);
+                expect(text).not.toContain("deleted.");
+            });
+        });
+    }
 });

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -2401,10 +2401,15 @@ export function registerTools(
             return withAnalytics(
                 "delete_meal",
                 async () => {
-                    await deleteMeal(userId, id);
+                    const deleted = await deleteMeal(userId, id);
                     return {
                         content: [
-                            { type: "text", text: `Meal ${id} deleted.` },
+                            {
+                                type: "text",
+                                text: deleted
+                                    ? `Meal ${id} deleted.`
+                                    : `No meal found with id ${id}.`,
+                            },
                         ],
                     };
                 },
@@ -2682,12 +2687,14 @@ export function registerTools(
             return withAnalytics(
                 "delete_water",
                 async () => {
-                    await deleteWater(userId, id);
+                    const deleted = await deleteWater(userId, id);
                     return {
                         content: [
                             {
                                 type: "text",
-                                text: `Water entry ${id} deleted.`,
+                                text: deleted
+                                    ? `Water entry ${id} deleted.`
+                                    : `No water entry found with id ${id}.`,
                             },
                         ],
                     };

--- a/src/supabase.ts
+++ b/src/supabase.ts
@@ -437,14 +437,18 @@ export async function searchMeals(
     return merged.slice(0, limit);
 }
 
-export async function deleteMeal(userId: string, id: string): Promise<void> {
-    const { error } = await getSupabase()
+/** True when a row matched and was deleted; false when the id is unknown or
+ *  belongs to another user — the handler must not claim success either way. */
+export async function deleteMeal(userId: string, id: string): Promise<boolean> {
+    const { data, error } = await getSupabase()
         .from("meals")
         .delete()
         .eq("id", id)
-        .eq("user_id", userId);
+        .eq("user_id", userId)
+        .select("id");
 
     if (error) throw new Error(`Failed to delete meal: ${error.message}`);
+    return (data?.length ?? 0) > 0;
 }
 
 export async function updateMeal(
@@ -826,14 +830,20 @@ export async function getWaterInRange(
     return (data as WaterEntry[]) ?? [];
 }
 
-export async function deleteWater(userId: string, id: string): Promise<void> {
-    const { error } = await getSupabase()
+/** True when a row matched and was deleted; see deleteMeal. */
+export async function deleteWater(
+    userId: string,
+    id: string,
+): Promise<boolean> {
+    const { data, error } = await getSupabase()
         .from("water_log")
         .delete()
         .eq("id", id)
-        .eq("user_id", userId);
+        .eq("user_id", userId)
+        .select("id");
 
     if (error) throw new Error(`Failed to delete water: ${error.message}`);
+    return (data?.length ?? 0) > 0;
 }
 
 // ---------- Weight log ----------


### PR DESCRIPTION
Fixes #72.

## Problem

`deleteMeal` and `deleteWater` issued a delete with no row check and returned `void`; their handlers unconditionally answered `Meal ${id} deleted.` A stale or typo'd UUID — or an id belonging to another user, filtered out by the `user_id` eq — matched zero rows, yet the user was told the entry was gone while it kept showing up in every summary and total.

`deleteWeight` was already fixed this way; this brings the other two to parity.

## Change

- `src/supabase.ts` — both functions append `.select("id")` and return `(data?.length ?? 0) > 0`, matching `deleteWeight`.
- `src/mcp.ts` — both handlers branch: `No meal found with id X.` / `No water entry found with id X.`

## Tests

`src/mcp.test.ts` gains a table-driven block covering **all three** delete tools (weight included — it was unpinned too), asserting both the deleted and not-found message. Verified load-bearing: reverting just the handler change fails the two new "unknown id" cases.

The `supabase.ts` bodies themselves stay uncovered — there is no injection seam for the PostgREST client and the test's module mock replaces those functions outright. The `.select("id")` append is the same line already shipped and reviewed in `deleteWeight`.

`bun test` 411 pass / 0 fail · `bun run typecheck` clean · prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)