### PR TITLE
chore: add a test script so `bun run test` works

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
         "dev": "bun --watch src/index.ts",
         "inspect": "bunx @modelcontextprotocol/inspector",
         "harness": "bun run scripts/widget-harness.ts",
+        "test": "bun test",
         "format": "bunx prettier --write .",
         "format:check": "bunx prettier --check .",
         "typecheck": "bun run scripts/typecheck.ts",


### PR DESCRIPTION
## Why

`bun test` is a Bun **builtin subcommand**, not an npm script — which is why tests have always run fine with no `test` entry in `package.json`, and why both workflows call it directly (`.github/workflows/ci.yml:36`, `.github/workflows/publish-mcp.yml:36`).

The gap: Bun's builtin fallback applies to `bun <cmd>` but **not** `bun run <cmd>`. So `bun run test` — the npm muscle-memory path, and the form every other command in this repo takes (`bun run typecheck`, `bun run format`) — fails on the missing script.

## Change

One line: `"test": "bun test"`.

CI is deliberately left alone; both workflows keep invoking `bun test` directly, so this adds no indirection to the pipeline.

## Verification

Both paths run the same suite, and the script does **not** recurse into itself (the builtin still wins for the bare form):

- `bun run test` → 405 pass / 0 fail
- `bun test` → 405 pass / 0 fail
- prettier clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)