### PR TITLE
fix(delete_account): stop writing an orphaned analytics row after the wipe (#71)

### DIFF
--- a/src/analytics.ts
+++ b/src/analytics.ts
@@ -11,6 +11,19 @@ interface AnalyticsRecord {
     invoked_at: string;
 }
 
+/**
+ * Identity recorded for a tool call that wipes the caller's own analytics rows.
+ *
+ * `delete_account` deletes `tool_analytics` as its *first* step, but
+ * `withAnalytics` persists its row *after* the handler resolves — and
+ * `tool_analytics.user_id` is a plain varchar with no FK, so that insert
+ * succeeds and resurrects a row for a user the tool just promised was gone.
+ * Recording the deletion under a sentinel keeps the operational signal (how
+ * often deletions run, how long they take, whether they failed) while retaining
+ * no identifier for the deleted account.
+ */
+export const DELETED_ACCOUNT_ANALYTICS_ID = "[deleted]";
+
 interface AnalyticsContext {
     userId: string;
     sessionId?: string;

--- a/src/mcp.test.ts
+++ b/src/mcp.test.ts
@@ -31,6 +31,7 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
 import * as actualSupabase from "./supabase.js";
+import { DELETED_ACCOUNT_ANALYTICS_ID } from "./analytics.js";
 import { formatFoodResult, type FoodResult } from "./foods.js";
 import {
     buildDailyBuckets,
@@ -870,15 +871,26 @@ const db = {
     // Ids the delete stubs consider to exist. Deleting one removes it, so a
     // second delete of the same id reports "not found" like the real table.
     rowIds: new Set<string>(),
+    analyticsRows: [] as Record<string, unknown>[],
+    accountWipes: 0,
 };
 
 mock.module("./supabase.js", () => ({
     ...actualSupabase,
-    // analytics.ts persists every tool call through getSupabase(); swallow it
-    // so a test never depends on Supabase env vars being present.
+    // analytics.ts persists every tool call through getSupabase(); intercept it
+    // so a test never depends on Supabase env vars being present, and so the
+    // rows it would have written can be asserted on.
     getSupabase: () => ({
-        from: () => ({ insert: async () => ({ error: null }) }),
+        from: (table: string) => ({
+            insert: async (row: Record<string, unknown>) => {
+                if (table === "tool_analytics") db.analyticsRows.push(row);
+                return { error: null };
+            },
+        }),
     }),
+    deleteAllUserData: async () => {
+        db.accountWipes += 1;
+    },
     getProfile: async () => db.profile,
     getUserTimezone: async () => db.profile?.timezone ?? "UTC",
     getNutritionGoals: async () => db.goals,
@@ -938,6 +950,8 @@ beforeEach(() => {
     db.inserted = [];
     db.profilePatches = [];
     db.rowIds = new Set<string>();
+    db.analyticsRows = [];
+    db.accountWipes = 0;
 });
 
 interface ToolResult {
@@ -1500,4 +1514,54 @@ describe("delete tools distinguish deleted from not-found", () => {
             });
         });
     }
+});
+
+// ---------- delete_account leaves no trace of the deleted user ----------
+
+// deleteAllUserData deletes tool_analytics first, then withAnalytics inserts a
+// fresh row once the handler resolves. tool_analytics.user_id is a plain
+// varchar with no FK, so that insert succeeds and puts the just-deleted user's
+// id straight back into the table the tool promised it had emptied. The row
+// itself is still worth keeping — it must simply not be attributable.
+describe("delete_account analytics", () => {
+    const rowsFor = (tool: string) =>
+        db.analyticsRows.filter((r) => r.tool_name === tool);
+
+    test("a completed deletion is recorded under the sentinel, not the user", async () => {
+        await withTools(null, async (call) => {
+            expect(
+                textOf(await call("delete_account", { confirm: true })),
+            ).toContain("permanently deleted");
+        });
+
+        expect(db.accountWipes).toBe(1);
+        const rows = rowsFor("delete_account");
+        expect(rows).toHaveLength(1);
+        expect(rows[0]!.user_id).toBe(DELETED_ACCOUNT_ANALYTICS_ID);
+        expect(rows[0]!.success).toBe(true);
+        expect(db.analyticsRows.some((r) => r.user_id === "u1")).toBe(false);
+    });
+
+    test("a cancelled deletion stays attributed to the user", async () => {
+        await withTools(null, async (call) => {
+            expect(
+                textOf(await call("delete_account", { confirm: false })),
+            ).toContain("cancelled");
+        });
+
+        expect(db.accountWipes).toBe(0);
+        const rows = rowsFor("delete_account");
+        expect(rows).toHaveLength(1);
+        expect(rows[0]!.user_id).toBe("u1");
+    });
+
+    test("other tools still record the real user id", async () => {
+        await withTools(null, async (call) => {
+            await call("get_timezone");
+        });
+
+        const rows = rowsFor("get_timezone");
+        expect(rows).toHaveLength(1);
+        expect(rows[0]!.user_id).toBe("u1");
+    });
 });

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -39,7 +39,7 @@ import {
     type WaterEntry,
     type WeightEntry,
 } from "./supabase.js";
-import { withAnalytics } from "./analytics.js";
+import { DELETED_ACCOUNT_ANALYTICS_ID, withAnalytics } from "./analytics.js";
 import {
     todayInTz,
     validateTz,
@@ -3874,7 +3874,13 @@ export function registerTools(
                         ],
                     };
                 },
-                { userId },
+                // deleteAllUserData wipes tool_analytics before anything else,
+                // so the row withAnalytics writes once this handler settles
+                // must not carry the id it just erased. Only the cancelled path
+                // (nothing deleted) still belongs to the real user.
+                {
+                    userId: confirm ? DELETED_ACCOUNT_ANALYTICS_ID : userId,
+                },
             );
         },
     );


### PR DESCRIPTION
Closes #71.

## The bug

`deleteAllUserData` deletes `tool_analytics` as its **first** step (of 11), but `withAnalytics` persists its row **after** the handler resolves. `tool_analytics.user_id` is `character varying(255)` with no FK, no CHECK, and no uuid type, so that insert succeeds — putting the just-deleted user's id straight back into the table the tool had promised was emptied.

That missing FK is worth calling out: `tool_analytics` is the one user-scoped table without `references auth.users(id) on delete cascade`. Every other table would have rejected the write. Here Postgres accepts it silently, which is why the orphan went unnoticed.

## The fix

Record a completed deletion under a `"[deleted]"` sentinel. This anonymizes rather than skips, so the operational signal survives — how often deletions run, how long they take, whether they failed — while no identifier for the wiped account is retained.

The decision comes from `confirm` alone, which is known before the handler runs, so no new `withAnalytics` option or callback was needed:

```ts
{ userId: confirm ? DELETED_ACCOUNT_ANALYTICS_ID : userId }
```

Two paths that fall out of this for free:

- **Error path covered.** If `deleteAllUserData` throws mid-wipe, `tool_analytics` has already been purged, so that failure row must be anonymized too — and is.
- **Cancelled path untouched.** `confirm: false` deletes nothing, so it stays attributed to the real user.

`delete_meal` / `delete_water` / `delete_weight` are row-scoped and touch neither `tool_analytics` nor the auth user, so `delete_account` is the only instance of this hazard.

## Tests

The existing `mock.module("./supabase.js", …)` stub in `src/mcp.test.ts` swallowed analytics inserts; it now records them, and stubs `deleteAllUserData`. Three cases:

1. A completed deletion is recorded under the sentinel, and no row carries `u1`.
2. A cancelled deletion stays attributed to `u1`.
3. An unrelated tool (`get_timezone`) still records `u1` — so the anonymization cannot over-reach.

Verified non-vacuous by reverting the handler change: case 1 fails, 2 and 3 pass.

Full suite: **414 pass, 0 fail**. Prettier clean.

## Out of scope

The audit turned up a separate, unrelated gap: `deleteAllUserData` doesn't clear the in-memory maps keyed by `userId` — `buckets` / `authFailures` in `src/rate-limit.ts`, `sessions` in `src/oauth.ts`. Nothing reaches disk and it evicts on its own. Happy to file an issue if it's worth tracking.

## Note on shipping

Per `CLAUDE.md`, merging to `main` deploys to production. No version bump or tag is included here, since this is a behaviour fix rather than a registry release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)