### PR TITLE
fix(averages): say which denominator each daily average used (#70)

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1900,7 +1900,8 @@
                                                         </div>
                                                     </div>
                                                     <div class="wdg-section">
-                                                        7-day average vs goal
+                                                        7-day average (all
+                                                        calendar days) vs goal
                                                     </div>
                                                     <div class="wdg-hero">
                                                         <div class="wdg-gauge">

--- a/public/widgets/src/templates/nutrition-summary.html
+++ b/public/widgets/src/templates/nutrition-summary.html
@@ -41,6 +41,7 @@
                 start_date: "2026-07-05",
                 end_date: "2026-07-07",
                 logged_days: 3,
+                days_in_range: 3,
                 goals: {
                     calories: 2200,
                     protein_g: 160,
@@ -298,6 +299,20 @@
           </div>`;
             }
 
+            // "3 days logged", or "15 of 30 days logged" when the payload also
+            // says how wide the window was. `days_in_range` is OPTIONAL — a host
+            // replaying a tool result from before it existed has no such field,
+            // and older payloads must render exactly as they always did, so it
+            // is only used when it is a real number larger than logged_days.
+            function loggedDaysCaption(data) {
+                const logged = data.logged_days;
+                const span = Number(data.days_in_range);
+                const plural = logged === 1 ? "" : "s";
+                return Number.isFinite(span) && span > logged
+                    ? `${logged} of ${span} days logged`
+                    : `${logged} day${plural} logged`;
+            }
+
             function render(data) {
                 const root = document.getElementById("root");
                 if (
@@ -316,9 +331,15 @@
                     .slice()
                     .sort((a, b) => (a.date < b.date ? -1 : 1));
                 const multi = days.length > 1;
-                const heroLabel = multi ? "Daily average" : "Total";
+                // Name the denominator: this average divides by the days that
+                // actually have a log, while the trends widget's rings divide
+                // by every calendar day in the window. Same macros, different
+                // number — labelling both is the fix for issue #70.
+                const heroLabel = multi
+                    ? "Daily average (logged days)"
+                    : "Total";
                 const range = multi
-                    ? `${data.start_date} → ${data.end_date} · ${data.logged_days} day${data.logged_days === 1 ? "" : "s"} logged`
+                    ? `${data.start_date} → ${data.end_date} · ${loggedDaysCaption(data)}`
                     : days[0].date;
 
                 // Calories hero + protein/carbs/fat row + water bar + alcohol

--- a/public/widgets/src/templates/trends.html
+++ b/public/widgets/src/templates/trends.html
@@ -15,6 +15,14 @@
   alcohol average only over the days that recorded them — see avgOf below —
   matching the tool's text output).
 
+  The denominator is EVERY CALENDAR DAY in the window, not just the logged ones:
+  these rings answer "how am I doing across this stretch of time?", so a skipped
+  day pulls the average down. That deliberately differs from the
+  get_nutrition_summary dashboard, whose hero rings divide by logged days only
+  and answer "how does a day I actually log look?" (issue #70). Both are correct
+  for their question and both name their denominator on screen — keep the
+  section title below explicit if you touch it.
+
   Data arrives as the `structuredContent` of the get_trends tool result; the
   shared bridge (shared/bridge.js) reads it across host conventions and calls
   render(). Standalone preview uses the SAMPLE below.
@@ -303,7 +311,7 @@
           </header>
           <div class="seg" role="tablist" aria-label="Trend window">${seg}</div>
           ${chart}
-          <div class="section-title">${range}-day average vs goal</div>
+          <div class="section-title">${range}-day average (all calendar days) vs goal</div>
           ${panel}`;
             }
 

--- a/public/widgets/summary-caption.test.ts
+++ b/public/widgets/summary-caption.test.ts
@@ -1,0 +1,66 @@
+// Behaviour test for the nutrition-summary widget's loggedDaysCaption() —
+// issue #70. The hero rings on this dashboard average over the days that carry
+// a log, while the get_trends rings average over every calendar day in the
+// window, so the same 15-of-30-days month legitimately reads 2000 kcal here and
+// 1000 kcal there. The caption is half of how a reader tells them apart, which
+// makes its exact wording load-bearing rather than cosmetic.
+//
+// The other half is that `days_in_range` is OPTIONAL: a host replaying a tool
+// result recorded before the field existed must render byte-identically to
+// before, so every unusable value has to fall through to the legacy string.
+//
+// Same evaluation technique as import-time.test.ts: the real assembled widget
+// script is run as one script with only the `initWidget({…})` bootstrap cut off.
+import { test, expect } from "bun:test";
+
+async function freshSummaryWidget() {
+    const { getWidgetHtml } = await import("../../src/widgets");
+    const html = await getWidgetHtml("nutrition-summary");
+    const script = html.slice(
+        html.lastIndexOf("<script>") + "<script>".length,
+        html.lastIndexOf("</script>"),
+    );
+    const boot = script.indexOf("initWidget({");
+    if (boot === -1) throw new Error("nutrition-summary bootstrap not found");
+    const factory = new Function(
+        `${script.slice(0, boot)}
+         return { loggedDaysCaption };`,
+    );
+    return factory() as {
+        loggedDaysCaption: (data: Record<string, unknown>) => string;
+    };
+}
+
+const { loggedDaysCaption } = await freshSummaryWidget();
+
+test("a window with gaps names both denominators", () => {
+    expect(loggedDaysCaption({ logged_days: 15, days_in_range: 30 })).toBe(
+        "15 of 30 days logged",
+    );
+});
+
+test("a fully logged window keeps the plain caption", () => {
+    expect(loggedDaysCaption({ logged_days: 30, days_in_range: 30 })).toBe(
+        "30 days logged",
+    );
+});
+
+// The pre-#70 payload shape. Anything that is not a usable span has to render
+// exactly as it always did, plural included — a host is free to replay an old
+// tool result at us, and "undefined days logged" would be a visible regression.
+test("a payload without days_in_range renders as it always did", () => {
+    for (const span of [undefined, null, "oops", NaN]) {
+        expect(loggedDaysCaption({ logged_days: 7, days_in_range: span })).toBe(
+            "7 days logged",
+        );
+    }
+    expect(loggedDaysCaption({ logged_days: 1 })).toBe("1 day logged");
+});
+
+// A span narrower than the days we hold is incoherent; prefer the caption that
+// cannot be wrong over one that asserts a denominator we do not trust.
+test("a span smaller than the logged days falls back", () => {
+    expect(loggedDaysCaption({ logged_days: 7, days_in_range: 3 })).toBe(
+        "7 days logged",
+    );
+});

--- a/scripts/widget-harness.ts
+++ b/scripts/widget-harness.ts
@@ -172,6 +172,12 @@ function hostPage(widget: string, params: URLSearchParams): string {
             start_date: "2026-07-09",
             end_date: "2026-07-15",
             logged_days: days.length,
+            // 2026-07-09 → 2026-07-15 is 7 calendar days and all 7 are logged,
+            // so this previews the no-gap caption. The gappy branch (where the
+            // header reads "15 of 30 days logged") is pinned by
+            // public/widgets/summary-caption.test.ts; edit both dates together
+            // if you want to eyeball it here.
+            days_in_range: days.length,
             goals,
             averages: {
                 calories: 2076,

--- a/src/insights.test.ts
+++ b/src/insights.test.ts
@@ -389,3 +389,94 @@ test("computeWeeklyDigest reports a zero-limit nutrient held at zero as clear", 
     const out = computeWeeklyDigest(buckets, goals({ daily_sugar_g: 0 }));
     expect(out).toContain("  Sugar: 0g / 0g limit (clear)");
 });
+
+// ---------- the calendar-day denominator is stated (issue #70) ----------
+//
+// get_trends divides calories/protein/carbs/fat/water by every day in the
+// window; get_nutrition_summary divides the same nutrients by logged days.
+// Both are right for their own question, so the trends side must say which one
+// it answered — otherwise the two figures differ 2x with nothing to reconcile.
+
+/** `days` consecutive days from 2026-06-01 where only the LAST `loggedDays`
+ * carry a meal; the rest are genuine gaps (no meals, no water). */
+function gappyBuckets(
+    days: number,
+    loggedDays: number,
+    fields: Partial<Meal> = {},
+): DailyBucket[] {
+    const start = new Date("2026-06-01T00:00:00Z");
+    const meals: Meal[] = [];
+    for (let i = days - loggedDays; i < days; i++) {
+        const d = new Date(start);
+        d.setUTCDate(d.getUTCDate() + i);
+        meals.push(meal(`${d.toISOString().slice(0, 10)}T12:00:00Z`, fields));
+    }
+    const end = new Date(start);
+    end.setUTCDate(end.getUTCDate() + days - 1);
+    return buildDailyBuckets(
+        meals,
+        [],
+        "2026-06-01",
+        end.toISOString().slice(0, 10),
+        "UTC",
+    );
+}
+
+test("computeTrends states the calendar-day denominator when the window has gaps", () => {
+    // 30 calendar days, 15 of them logged at 2000 kcal: 30000/30 = 1000.
+    const buckets = gappyBuckets(30, 15, { calories: 2000 });
+    const out = computeTrends(buckets, goals());
+    expect(out).toContain(
+        "  30d avg: 1000 kcal (calendar-day average; 15 of 30 days logged)",
+    );
+    // The summary's logged-day figure for the same window would be 2000; the
+    // note is the only thing that keeps the two from reading as a contradiction.
+    expect(out).not.toContain("  30d avg: 1000 kcal\n");
+});
+
+test("computeTrends adds no denominator note when every day is logged", () => {
+    const buckets = gappyBuckets(30, 30, { calories: 2000 });
+    const out = computeTrends(buckets, goals());
+    expect(out).toContain("  30d avg: 2000 kcal");
+    expect(out).not.toContain("calendar-day average");
+    expect(out).not.toContain("days logged)");
+});
+
+test("computeTrends notes the gap only on the windows that have one", () => {
+    // Last 7 days solid, nothing before them: 7d is clean, 30d is 7 of 30.
+    const buckets = gappyBuckets(30, 7, { calories: 2100 });
+    const out = computeTrends(buckets, goals());
+    expect(out).toContain("  7d avg: 2100 kcal\n");
+    expect(out).not.toContain("7d avg: 2100 kcal (calendar-day average");
+    expect(out).toContain(
+        "  14d avg: 1050 kcal (calendar-day average; 7 of 14 days logged)",
+    );
+    expect(out).toContain(
+        "  30d avg: 490 kcal (calendar-day average; 7 of 30 days logged)",
+    );
+});
+
+test("computeTrends keeps the partial-nutrient note when the window also has gaps", () => {
+    // Only one note per line, and for fiber it is the narrower "days with data".
+    const buckets = gappyBuckets(30, 10, { fiber_g: 30 });
+    const out = computeTrends(buckets, goals());
+    expect(out).toContain("  30d avg: 30g (10 of 30 days with data)");
+    expect(out).not.toContain("30g (10 of 30 days with data) (calendar-day");
+    expect(out).not.toContain("30d avg: 30g (calendar-day average");
+});
+
+test("computeWeeklyDigest states the calendar-day denominator on a gappy week", () => {
+    const buckets = gappyBuckets(7, 3, { calories: 2100 });
+    const out = computeWeeklyDigest(buckets, goals());
+    expect(out).toContain(
+        "Daily averages (per calendar day; 3 of 7 days logged):",
+    );
+    expect(out).toContain("  Calories: 900 kcal");
+});
+
+test("computeWeeklyDigest keeps the plain header on a fully logged week", () => {
+    const buckets = gappyBuckets(7, 7, { calories: 2100 });
+    const out = computeWeeklyDigest(buckets, goals());
+    expect(out).toContain("Daily averages:");
+    expect(out).not.toContain("per calendar day");
+});

--- a/src/insights.ts
+++ b/src/insights.ts
@@ -47,7 +47,11 @@ function addDays(date: string, days: number): string {
     return d.toISOString().slice(0, 10);
 }
 
-function dateDiffDays(start: string, end: string): number {
+/** Whole calendar days from `start` to `end`, both YYYY-MM-DD. Exported so
+ * mcp.ts can size a range in calendar days with the same arithmetic that
+ * buildDailyBuckets uses to lay them out — the summary and trends must not
+ * disagree about how long a window is. */
+export function dateDiffDays(start: string, end: string): number {
     const a = new Date(`${start}T00:00:00Z`).getTime();
     const b = new Date(`${end}T00:00:00Z`).getTime();
     return Math.round((b - a) / (1000 * 60 * 60 * 24));
@@ -151,6 +155,12 @@ interface Trailing {
     /** Days that counted, and calendar days the window actually spans. */
     days: number;
     window: number;
+    /** Calendar days in the window carrying any log at all (nonEmpty). For a
+     * full series this is what makes the denominator visible — `days` equals
+     * `window` there by construction, so it is the only number that can tell a
+     * 30-of-30 average apart from a 15-of-30 one. Informational for a covered
+     * series, whose own note already names its narrower denominator. */
+    loggedDays: number;
 }
 
 interface StatSeries {
@@ -163,21 +173,28 @@ interface StatSeries {
 }
 
 /** A nutrient that has always been summed with `?? 0`: every day in the window
- * counts, exactly as before. */
+ * counts, exactly as before. The denominator is therefore CALENDAR days — an
+ * unlogged day is a real zero, which is the right question for "how much am I
+ * eating per day", and the wrong one for "how much do I eat on a day I eat".
+ * mcp.ts's `rangeAverages` deliberately answers the second with a logged-day
+ * denominator, so the same window can legitimately yield two figures 2x apart;
+ * each side therefore has to say which it is. Ours is said by `loggedDays`,
+ * which formatStatLine turns into a note whenever the window has gaps. */
 function fullSeries(
     buckets: DailyBucket[],
     field: keyof DailyBucket,
 ): StatSeries {
-    const daily = buckets.map((b) => b[field] as number);
     return {
-        values: daily,
+        values: buckets.map((b) => b[field] as number),
         trailing: WINDOWS.map((n) => {
-            const slice = daily.slice(-n);
+            const slice = buckets.slice(-n);
+            const values = slice.map((b) => b[field] as number);
             return {
                 n,
-                avg: slice.length > 0 ? mean(slice) : null,
-                days: slice.length,
+                avg: values.length > 0 ? mean(values) : null,
+                days: values.length,
                 window: slice.length,
+                loggedDays: slice.filter(nonEmpty).length,
             };
         }),
         partial: false,
@@ -201,6 +218,7 @@ function coveredSeries(
                 avg: values.length > 0 ? mean(values) : null,
                 days: values.length,
                 window: slice.length,
+                loggedDays: slice.filter(nonEmpty).length,
             };
         }),
         partial: true,
@@ -265,7 +283,17 @@ type StatDirection = "floor" | "ceiling";
 
 /** Renders one nutrient's block. Returns null when a partial nutrient has no
  * data anywhere in the window — the caller drops the section rather than
- * printing an average of nothing as "0g" next to a target. */
+ * printing an average of nothing as "0g" next to a target.
+ *
+ * Every trailing average states its denominator whenever that denominator is
+ * not the obvious one: a partial nutrient names the days it found data on, a
+ * full nutrient names the days that were logged at all out of the calendar
+ * window it divided by. Silence means "no gaps", so the common fully-logged
+ * line is unchanged. This exists because get_nutrition_summary's rangeAverages
+ * divides the same nutrients by LOGGED days on purpose (issue #70): a model
+ * narrating both in one chat would otherwise report two contradictory "average
+ * daily calories" with nothing to reconcile them. The fix is disclosure on
+ * both sides, not one shared denominator — the two answer different questions. */
 function formatStatLine(
     label: string,
     unit: string,
@@ -286,10 +314,15 @@ function formatStatLine(
             parts.push(`  ${t.n}d avg: no data`);
             continue;
         }
-        const note =
-            t.days < t.window
+        // At most one note: the narrower denominator is the informative one, and
+        // a partial nutrient's "days with data" already implies the gap.
+        const note = partial
+            ? t.days < t.window
                 ? ` (${t.days} of ${t.window} days with data)`
-                : "";
+                : ""
+            : t.loggedDays < t.window
+              ? ` (calendar-day average; ${t.loggedDays} of ${t.window} days logged)`
+              : "";
         parts.push(`  ${t.n}d avg: ${round(t.avg)}${unit}${note}`);
     }
     if (targetApplies(target, direction)) {
@@ -733,7 +766,17 @@ export function computeWeeklyDigest(
         `Logged ${logged.length}/${buckets.length} days, ${totalMeals} meals total.`,
     );
     lines.push("");
-    lines.push("Daily averages:");
+    // Calories/protein/carbs/fat/water below divide by every day in the week,
+    // logged or not; only the partial nutrients carry their own "over N days"
+    // note. On a week with gaps say so once in the header rather than on five
+    // rows — the "Logged X/N days" line above supplies the count but does not
+    // claim to be these averages' denominator. A fully-logged week has nothing
+    // to disclose and keeps the original header.
+    lines.push(
+        logged.length < buckets.length
+            ? `Daily averages (per calendar day; ${logged.length} of ${buckets.length} days logged):`
+            : "Daily averages:",
+    );
     // `noun` is "target" for a floor and "limit" for a ceiling (sugar, alcohol);
     // calling a sugar cap a "target" invites reading the shortfall as a shortfall.
     const line = (

--- a/src/mcp.test.ts
+++ b/src/mcp.test.ts
@@ -13,6 +13,7 @@ import {
     hasActiveTarget,
     nutrientPresence,
     rangeAverages,
+    loggedDayAverageNote,
     startImportPayload,
     alcoholHiddenNote,
     registerTools,
@@ -39,7 +40,7 @@ import {
     computeWeeklyDigest,
     type DailyBucket,
 } from "./insights.js";
-import type { Meal, NutritionGoals } from "./supabase.js";
+import type { Meal, NutritionGoals, WaterEntry } from "./supabase.js";
 
 function meal(over: Partial<Meal> = {}): Meal {
     return {
@@ -598,9 +599,133 @@ describe("summary and trends agree on the same window", () => {
         expect(trendAvg("Sugar", "30d")).toBe(round1(summary.averages.sugar_g));
     });
 
-    test("calories still divide by every day in both", () => {
+    // NOT a test of the two calorie denominators — this fixture logs all 30 of
+    // its 30 days, so "per logged day" and "per calendar day" are the same
+    // divisor and the divergence issue #70 reported cannot appear here. What it
+    // does prove is that a fully-logged window makes them coincide, and that
+    // neither side then apologises for a gap it doesn't have. The gap case is
+    // pinned in the next block.
+    test("a fully-logged window: both denominators coincide, silently", () => {
+        expect(byDate.size).toBe(30);
         expect(round1(summary.averages.calories)).toBe(600);
         expect(trendAvg("Calories", "30d")).toBe(600);
+        expect(trendsText).not.toContain("calendar-day average");
+        expect(loggedDayAverageNote(byDate.size, 30)).toBe("");
+    });
+});
+
+// ---------- Regression pin for issue #70 ----------
+//
+// The two tools report different daily figures for the same window, and BOTH
+// are right: rangeAverages divides by the days the user actually logged ("what
+// does a day I eat look like?"), computeTrends divides by every calendar day
+// in the window ("what am I averaging this month?"). #70 was never that one of
+// them miscounts — it was that neither said which it was, so 2000 kcal in the
+// summary and 1000 kcal in trends read as a bug. The fix is disclosure on both
+// sides, not one shared denominator: changing either divisor would rewrite the
+// figures users' history is built on. So this block pins both numbers AND both
+// notes; dropping either note, or quietly unifying the denominators, fails here.
+describe("logged-day and calendar-day averages diverge, and both say so (#70)", () => {
+    const END = "2026-07-26";
+    const START = "2026-06-27"; // 30 calendar days inclusive
+    const DAYS_IN_RANGE = 30;
+    const LOGGED_DAYS = 15;
+    const dayAt = (i: number) => {
+        const d = new Date(`${START}T00:00:00Z`);
+        d.setUTCDate(d.getUTCDate() + i);
+        return d.toISOString().slice(0, 10);
+    };
+
+    // Every other day logged — 15 of 30 — at a flat 2000 kcal / 100 g protein /
+    // 200 g carbs / 80 g fat / 2000 ml water. A flat value on exactly half the
+    // days makes the divergence exactly 2x on every nutrient, which is the
+    // widest it can be and the shape the issue described. fiber/sugar/alcohol
+    // stay null: they have their own covered-days denominator (tested above)
+    // and would only confuse this pin.
+    const meals: Meal[] = [];
+    const water: WaterEntry[] = [];
+    for (let i = 0; i < DAYS_IN_RANGE; i += 2) {
+        meals.push(
+            meal({
+                id: `d-${i}`,
+                logged_at: `${dayAt(i)}T12:00:00.000Z`,
+                calories: 2000,
+                protein_g: 100,
+                carbs_g: 200,
+                fat_g: 80,
+                fiber_g: null,
+                sugar_g: null,
+                alcohol_g: null,
+            }),
+        );
+        water.push({
+            id: `w-${i}`,
+            user_id: "u1",
+            amount_ml: 2000,
+            logged_at: `${dayAt(i)}T12:00:00.000Z`,
+            notes: null,
+            created_at: `${dayAt(i)}T12:00:00.000Z`,
+            idempotency_key: null,
+        });
+    }
+
+    // The summary's own aggregation: group by local date, then rangeAverages
+    // over only the dates that exist (byDate never holds an unlogged day).
+    const byDate = new Map<string, Meal[]>();
+    for (const m of meals) {
+        const date = m.logged_at.slice(0, 10);
+        byDate.set(date, [...(byDate.get(date) ?? []), m]);
+    }
+    const summary = rangeAverages(
+        [...byDate.entries()].sort().map(([, dayMeals]) => {
+            const totals = sumMeals(dayMeals);
+            totals.water_ml = 2000;
+            return { meals: dayMeals, totals };
+        }),
+    );
+
+    const trendsText = computeTrends(
+        buildDailyBuckets(meals, water, START, END, "UTC"),
+        null,
+    );
+
+    test("the summary averages over the 15 logged days", () => {
+        expect(byDate.size).toBe(LOGGED_DAYS);
+        expect(summary.averages.calories).toBe(2000);
+        expect(summary.averages.protein_g).toBe(100);
+        expect(summary.averages.carbs_g).toBe(200);
+        expect(summary.averages.fat_g).toBe(80);
+        expect(summary.averages.water_ml).toBe(2000);
+    });
+
+    // Same data, half the figure, because the 15 unlogged days count as zeros.
+    test("trends averages the same nutrients over all 30 calendar days", () => {
+        expect(trendsText).toContain("30d avg: 1000 kcal");
+        expect(trendsText).toContain("30d avg: 50g"); // protein
+        expect(trendsText).toContain("30d avg: 100g"); // carbs
+        expect(trendsText).toContain("30d avg: 40g"); // fat
+        expect(trendsText).toContain("30d avg: 1000 ml");
+    });
+
+    test("every trends figure carries the calendar-day note", () => {
+        for (const line of [
+            "30d avg: 1000 kcal",
+            "30d avg: 50g",
+            "30d avg: 100g",
+            "30d avg: 40g",
+            "30d avg: 1000 ml",
+        ]) {
+            expect(trendsText).toContain(
+                `${line} (calendar-day average; ${LOGGED_DAYS} of ${DAYS_IN_RANGE} days logged)`,
+            );
+        }
+    });
+
+    test("the summary note names the same two numbers, the other way round", () => {
+        const note = loggedDayAverageNote(LOGGED_DAYS, DAYS_IN_RANGE);
+        expect(note).toContain(`${LOGGED_DAYS} of the ${DAYS_IN_RANGE} days`);
+        expect(note).toContain("per logged day");
+        expect(note).toContain("get_trends");
     });
 });
 
@@ -866,6 +991,7 @@ const db = {
     profile: null as actualSupabase.Profile | null,
     goals: null as NutritionGoals | null,
     meals: [] as Meal[],
+    water: [] as WaterEntry[],
     inserted: [] as Record<string, unknown>[],
     profilePatches: [] as Record<string, unknown>[],
     // Ids the delete stubs consider to exist. Deleting one removes it, so a
@@ -896,6 +1022,12 @@ mock.module("./supabase.js", () => ({
     getNutritionGoals: async () => db.goals,
     getMealsByDate: async () => db.meals,
     getWaterByDate: async () => [],
+    // The range readers behind get_nutrition_summary. They ignore the dates and
+    // hand back whatever the test staged: the fixtures below already sit inside
+    // the window they ask for, and filtering here would only re-implement the
+    // query under test.
+    getMealsInRange: async () => db.meals,
+    getWaterInRange: async () => db.water,
     insertMeal: async (_userId: string, input: Record<string, unknown>) => {
         db.inserted.push(input);
         const saved = storedMeal(input);
@@ -947,6 +1079,7 @@ beforeEach(() => {
     db.profile = { ...PROFILE_BASE };
     db.goals = null;
     db.meals = [];
+    db.water = [];
     db.inserted = [];
     db.profilePatches = [];
     db.rowIds = new Set<string>();
@@ -956,6 +1089,7 @@ beforeEach(() => {
 
 interface ToolResult {
     content: { type: string; text: string }[];
+    structuredContent?: Record<string, unknown>;
     isError?: boolean;
 }
 
@@ -1563,5 +1697,133 @@ describe("delete_account analytics", () => {
         const rows = rowsFor("get_timezone");
         expect(rows).toHaveLength(1);
         expect(rows[0]!.user_id).toBe("u1");
+    });
+});
+
+// ---------- the summary states its own denominator (issue #70) ----------
+//
+// The unit-level pin above proves the two aggregations legitimately disagree.
+// This proves get_nutrition_summary SAYS so, which is the actual fix: the
+// calendar length of the window rides on the wire next to logged_days, and the
+// text warns the model that get_trends will print a smaller figure for the same
+// days. Neither is reachable from a pure function — both are assembled in the
+// handler — so this goes through the real tool.
+describe("get_nutrition_summary discloses its logged-day denominator", () => {
+    const START = "2026-06-27";
+    const END = "2026-07-26"; // 30 calendar days inclusive
+    const dayAt = (i: number) => {
+        const d = new Date(`${START}T00:00:00Z`);
+        d.setUTCDate(d.getUTCDate() + i);
+        return d.toISOString().slice(0, 10);
+    };
+
+    /** `step` 2 logs every other day (15 of 30), `step` 1 logs all 30. */
+    function stage(step: number): void {
+        db.meals = [];
+        db.water = [];
+        for (let i = 0; i < 30; i += step) {
+            db.meals.push(
+                meal({
+                    id: `d-${i}`,
+                    logged_at: `${dayAt(i)}T12:00:00.000Z`,
+                    calories: 2000,
+                    protein_g: 100,
+                    carbs_g: 200,
+                    fat_g: 80,
+                    fiber_g: null,
+                    sugar_g: null,
+                    alcohol_g: null,
+                }),
+            );
+            db.water.push({
+                id: `w-${i}`,
+                user_id: "u1",
+                amount_ml: 2000,
+                logged_at: `${dayAt(i)}T12:00:00.000Z`,
+                notes: null,
+                created_at: `${dayAt(i)}T12:00:00.000Z`,
+                idempotency_key: null,
+            });
+        }
+    }
+
+    interface SummaryPayload {
+        logged_days: number;
+        days_in_range: number;
+        averages: Record<string, number>;
+    }
+
+    const summarize = async (call: CallTool) =>
+        call("get_nutrition_summary", { start_date: START, end_date: END });
+
+    test("a half-logged window reports 15 logged days out of 30 in range", async () => {
+        stage(2);
+        await withTools(null, async (call) => {
+            const r = await summarize(call);
+            const sc = r.structuredContent as unknown as SummaryPayload;
+            expect(sc.logged_days).toBe(15);
+            expect(sc.days_in_range).toBe(30);
+            // Per LOGGED day — the same 2000 kcal a user sees on any one of the
+            // days they ate, not the 1000 get_trends reports for the month.
+            expect(sc.averages.calories).toBe(2000);
+            expect(sc.averages.protein_g).toBe(100);
+            expect(sc.averages.carbs_g).toBe(200);
+            expect(sc.averages.fat_g).toBe(80);
+            expect(sc.averages.water_ml).toBe(2000);
+        });
+    });
+
+    test("...and the text tells the model which denominator that was", async () => {
+        stage(2);
+        await withTools(null, async (call) => {
+            const text = textOf(await summarize(call));
+            expect(text).toContain(
+                "Daily averages are per logged day — 15 of the 30 days in range.",
+            );
+            expect(text).toContain(
+                "get_trends averages over all 30 calendar days instead",
+            );
+        });
+    });
+
+    // No gap, nothing to disclose: the note would be noise on what is the
+    // common case for anyone logging daily.
+    test("a fully-logged window stays silent about the denominator", async () => {
+        stage(1);
+        await withTools(null, async (call) => {
+            const r = await summarize(call);
+            const sc = r.structuredContent as unknown as SummaryPayload;
+            expect(sc.logged_days).toBe(30);
+            expect(sc.days_in_range).toBe(30);
+            expect(sc.averages.calories).toBe(2000);
+            expect(textOf(r)).not.toContain("per logged day");
+        });
+    });
+
+    // days_in_range is a declared outputSchema field, so the early return for a
+    // window with nothing in it has to carry it too or the SDK rejects the
+    // result outright.
+    test("an empty range still reports the size of the window", async () => {
+        await withTools(null, async (call) => {
+            const r = await summarize(call);
+            const sc = r.structuredContent as unknown as SummaryPayload;
+            expect(r.isError).toBeFalsy();
+            expect(sc.logged_days).toBe(0);
+            expect(sc.days_in_range).toBe(30);
+        });
+    });
+
+    // A single-day range is 1 day, not 0 — an off-by-one here would make the
+    // note read "1 of the 0 days in range" on the most ordinary query there is.
+    test("a single-day range spans one day", async () => {
+        stage(1);
+        await withTools(null, async (call) => {
+            const r = (await call("get_nutrition_summary", {
+                start_date: START,
+                end_date: START,
+            })) as ToolResult;
+            const sc = r.structuredContent as unknown as SummaryPayload;
+            expect(sc.days_in_range).toBe(1);
+        });
     });
 });

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -55,6 +55,7 @@ import {
     computeWeightTrend,
     dayCarries,
     coveredDailyAverage,
+    dateDiffDays,
     type DailyBucket,
 } from "./insights.js";
 import {
@@ -243,6 +244,16 @@ export function nutrientPresence(meals: Meal[]): NutrientPresence {
 // for a nutrient is excluded from both its numerator and its denominator. A
 // nutrient nobody recorded reports 0 over 0 days, which callers must render as
 // "not recorded" rather than as a genuine zero.
+//
+// LOGGED days, deliberately — and that is where this parts company with
+// get_trends, which divides the same nutrients by every CALENDAR day in the
+// window. Both are right for their own question ("what does a day I eat look
+// like?" vs. "what am I averaging over the month?"), so issue #70 was closed by
+// DISCLOSING the divergence rather than unifying it: a 15-of-30-days window
+// legitimately reads 2000 kcal here and 1000 kcal there. Each side now names
+// its own denominator in its text output (loggedDayAverageNote below, and the
+// calendar-day note in insights.ts). Silently switching either one would
+// rewrite the figures every existing user's history is built on.
 export function rangeAverages(
     perDay: Array<{ meals: Meal[]; totals: DailyTotals }>,
 ): {
@@ -279,6 +290,20 @@ export function rangeAverages(
             alcohol_g: alcohol.days,
         },
     };
+}
+
+/** The model-facing half of the #70 fix: says out loud that these averages
+ *  divide by logged days, and that get_trends will therefore print a smaller
+ *  number for the same window. Empty when the window is fully logged — the two
+ *  denominators coincide there, so the note would be pure noise on the common
+ *  path. Pure and exported so the exact shipped wording is testable without
+ *  standing up the whole tool. */
+export function loggedDayAverageNote(
+    loggedDays: number,
+    daysInRange: number,
+): string {
+    if (loggedDays >= daysInRange) return "";
+    return `\n\n(Daily averages are per logged day — ${loggedDays} of the ${daysInRange} days in range. get_trends averages over all ${daysInRange} calendar days instead, so its daily figures will be lower.)`;
 }
 
 // insights.ts is deliberately free of Supabase, so it cannot know about the
@@ -1845,6 +1870,12 @@ export function registerTools(
                 start_date: z.string(),
                 end_date: z.string(),
                 logged_days: z.number(),
+                // The calendar length of the window, so a consumer can see the
+                // denominator behind `averages` for itself: these are per
+                // LOGGED day, while get_trends divides the same nutrients by
+                // all `days_in_range` days (issue #70). Without both numbers a
+                // client cannot tell a full month from a fortnight of gaps.
+                days_in_range: z.number(),
                 drink_unit: DRINK_UNIT_FIELD,
                 goals: GOALS_ITEM.nullable(),
                 averages: TOTALS_ITEM,
@@ -1874,6 +1905,15 @@ export function registerTools(
             return withAnalytics(
                 "get_nutrition_summary",
                 async () => {
+                    // Sized with insights.ts's own arithmetic (the function
+                    // buildDailyBuckets lays its buckets out with), so the two
+                    // tools cannot disagree about how long a window is. Clamped
+                    // because a reversed range would otherwise report 0 or less
+                    // days and make the note read as nonsense.
+                    const daysInRange = Math.max(
+                        1,
+                        dateDiffDays(start_date, end_date) + 1,
+                    );
                     const tz = await getUserTimezone(userId);
                     const [meals, water, goals] = await Promise.all([
                         getMealsInRange(userId, start_date, end_date, tz),
@@ -1895,6 +1935,7 @@ export function registerTools(
                                 start_date,
                                 end_date,
                                 logged_days: 0,
+                                days_in_range: daysInRange,
                                 drink_unit: alcohol,
                                 goals: goalsPayload,
                                 averages: totalsPayloadOf(
@@ -1994,6 +2035,7 @@ export function registerTools(
 
                     const footer =
                         coverageNote +
+                        loggedDayAverageNote(days.length, daysInRange) +
                         (goals
                             ? ""
                             : "\n\n(Tip: set daily targets with set_nutrition_goals to see progress percentages.)");
@@ -2009,6 +2051,7 @@ export function registerTools(
                             start_date,
                             end_date,
                             logged_days: days.length,
+                            days_in_range: daysInRange,
                             drink_unit: alcohol,
                             goals: goalsPayload,
                             averages,


### PR DESCRIPTION
Fixes #70.

## The bug

`get_nutrition_summary` divides calories/protein/carbs/fat/water by **logged** days (`rangeAverages`; `byDate` only ever contains dates with a meal or water row). `get_trends` divides the same nutrients by every **calendar** day, zeros included (`fullSeries`). Each side is individually documented as deliberate, but nothing labelled the difference.

A user who logs 15 of the last 30 days at 2000 kcal saw `averages.calories = 2000` in the summary and "30d avg: 1000 kcal" in trends. A model narrating both in one chat reported two 2×-different "average daily calories" with no qualifier.

## The fix: disclose, don't unify

Both denominators are correct for their own question — *"what does a day I actually eat look like?"* vs *"what am I averaging across this stretch of time?"* — and silently switching either would rewrite the figures every existing user's history is built on. So each side now names its own denominator, and the divergence is pinned by tests instead of being invisible.

The issue's exact scenario, after the change:

```
SUMMARY averages.calories = 2000
(Daily averages are per logged day — 15 of the 30 days in range. get_trends
averages over all 30 calendar days instead, so its daily figures will be lower.)

Calories:
  30d avg: 1000 kcal (calendar-day average; 15 of 30 days logged)
```

### `src/insights.ts` — trends side
- `Trailing.loggedDays` counts days with any log in each trailing window, making the gap visible to `formatStatLine` (for a full series `days === window` by construction, so nothing else could tell 30-of-30 apart from 15-of-30).
- A full nutrient's trailing average gains `(calendar-day average; N of M days logged)` when the window has gaps. The partial-nutrient note is unchanged, and at most one note ever appears per line.
- `computeWeeklyDigest` says it once in its `Daily averages:` header rather than on five rows.
- **A fully-logged window emits no note at all** — output is byte-identical, so the common path gains no noise.

### `src/mcp.ts` — summary side
- `days_in_range: z.number()` joins `logged_days` in the `outputSchema`, emitted on **every** return path including the empty-range early return.
- New exported pure helper `loggedDayAverageNote()` adds the model-facing note, naming `get_trends` explicitly so the model can reconcile the two figures itself. Empty when the window is fully logged.
- The window is sized with insights.ts's own `dateDiffDays` (now exported) — the same arithmetic `buildDailyBuckets` lays its buckets out with, so the two tools cannot disagree about how long a window is. Clamped to ≥1 so a reversed range can't print nonsense.

### Widgets
- Summary hero: `Daily average` → `Daily average (logged days)`; header caption becomes `15 of 30 days logged` when the payload carries a wider span.
- Trends ring: `30-day average vs goal` → `30-day average (all calendar days) vs goal`. The two parentheticals are deliberately parallel so the dashboards read as a matched pair.
- `days_in_range` is treated as **optional**: a host replaying a tool result recorded before the field existed renders exactly as it always did, plural handling included.
- `public/index.html`'s static landing-page mock of the trends widget was updated to match the shipped label.

## Tests

The old cross-check test was titled *"calories still divide by every day in both"*, but its fixture logs all 30 days — so the divergence it named was invisible to it, exactly as the issue notes. It is renamed to what it actually proves, and the real behaviour is now pinned with gap fixtures:

- `src/insights.test.ts` — gappy window carries the note; fully-logged window carries none; the note appears only on the trailing windows that have a gap (7d clean, 14d/30d noted); a partial nutrient keeps its own note and gains no second one.
- `src/mcp.test.ts` — a 15-of-30 fixture asserting the 2× split across **all five** nutrients, that both texts name the same two numbers from their own side, plus integration tests through the real MCP server for `days_in_range` (half-logged, fully-logged, empty range, single-day off-by-one).
- `public/widgets/summary-caption.test.ts` (new) — the caption's wording and, importantly, that every unusable `days_in_range` value falls back to the pre-#70 string.

`bun test`: **433 pass, 0 fail**. Tree is prettier-clean.

## Note on shipping

Per CLAUDE.md, merging to `main` ships to production — this changes model-facing tool text and widget labels, which go live with the deploy. No version bump or tag is needed unless you want to refresh the registry listing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)