### PR TITLE
feat(landing): odometer for the headline stat, and world-map dots sized by timezone share

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -2372,36 +2372,29 @@
                     </div>
 
                     <div class="stat-row" id="stat-row">
-                        <div class="stat">
-                            <span class="stat-num" data-stat="food_logs"
+                        <div class="odo-hero">
+                            <span
+                                class="odo"
+                                data-odo="total_calories"
+                                role="img"
+                                aria-label="Calories tracked"
                                 >—</span
                             >
-                            <span class="stat-cap">Food logs</span>
+                            <span class="odo-cap">Calories tracked</span>
                         </div>
-                        <div class="stat">
-                            <span class="stat-num" data-stat="total_calories"
-                                >—</span
+                        <p class="odo-rest">
+                            <span
+                                ><b data-stat="food_logs">—</b> food logs</span
                             >
-                            <span class="stat-cap">Calories tracked</span>
-                        </div>
-                        <div class="stat">
-                            <span class="stat-num" data-stat="total_protein_g"
-                                >—</span
+                            <span
+                                ><b data-stat="total_protein_g">—</b>
+                                protein</span
                             >
-                            <span class="stat-cap">Protein</span>
-                        </div>
-                        <div class="stat">
-                            <span class="stat-num" data-stat="total_carbs_g"
-                                >—</span
+                            <span
+                                ><b data-stat="total_carbs_g">—</b> carbs</span
                             >
-                            <span class="stat-cap">Carbs</span>
-                        </div>
-                        <div class="stat">
-                            <span class="stat-num" data-stat="total_fat_g"
-                                >—</span
-                            >
-                            <span class="stat-cap">Fat</span>
-                        </div>
+                            <span><b data-stat="total_fat_g">—</b> fat</span>
+                        </p>
                     </div>
 
                     <div class="map-block" id="map-block">
@@ -3009,12 +3002,6 @@
                 function fmtInt(n) {
                     return Math.round(n).toLocaleString("en-US");
                 }
-                function fmtCompact(n) {
-                    return new Intl.NumberFormat("en-US", {
-                        notation: "compact",
-                        maximumFractionDigits: 1,
-                    }).format(Math.round(n));
-                }
                 function fmtKg(n) {
                     return fmtInt(n) + " kg";
                 }
@@ -3024,12 +3011,6 @@
                             return v;
                         },
                         fmt: fmtInt,
-                    },
-                    total_calories: {
-                        to: function (v) {
-                            return v;
-                        },
-                        fmt: fmtCompact,
                     },
                     timezones: {
                         to: function (v) {
@@ -3071,6 +3052,68 @@
                     }
                     requestAnimationFrame(step);
                 }
+                // ---------- odometer ----------
+                // Builds one reel per digit of the real total, so the digits
+                // that roll are the digits that are true — nothing is invented
+                // to make the motion look better. Reels further right spin
+                // through more cycles and take longer, so the leading digits
+                // settle first and the tail is still turning, the way a
+                // mechanical counter reads.
+                var ODO_MAX_CYCLES = 6;
+                function setOdometer(el, value) {
+                    var text = fmtInt(value);
+                    el.setAttribute("aria-label", text + " calories tracked");
+                    el.textContent = "";
+                    if (reduceMotion) {
+                        el.textContent = text;
+                        return;
+                    }
+                    var strips = [],
+                        i = 0;
+                    text.split("").forEach(function (ch) {
+                        if (ch < "0" || ch > "9") {
+                            var sep = document.createElement("span");
+                            sep.className = "odo-sep";
+                            sep.textContent = ch;
+                            el.appendChild(sep);
+                            return;
+                        }
+                        var cycles = Math.min(ODO_MAX_CYCLES, 2 + i);
+                        var reel = document.createElement("span");
+                        reel.className = "odo-reel";
+                        var strip = document.createElement("span");
+                        strip.className = "odo-strip";
+                        for (var c = 0; c <= cycles; c++) {
+                            for (var d = 0; d < 10; d++) {
+                                var cell = document.createElement("span");
+                                cell.textContent = d;
+                                strip.appendChild(cell);
+                            }
+                        }
+                        strip.style.transitionDuration = 1.1 + i * 0.12 + "s";
+                        // Land on a cell whose face is ch, `cycles` turns down.
+                        // Expressed as a share of the strip's own height so the
+                        // reel stays in register at any font size.
+                        var cells = (cycles + 1) * 10;
+                        var stop = cycles * 10 + Number(ch);
+                        strips.push([strip, (stop / cells) * 100]);
+                        reel.appendChild(strip);
+                        el.appendChild(reel);
+                        i++;
+                    });
+                    // Paint at rest first. Moving in the same frame as the
+                    // insert gives the strip no start value to animate from, so
+                    // the transition is skipped and the number just appears.
+                    requestAnimationFrame(function () {
+                        requestAnimationFrame(function () {
+                            strips.forEach(function (s) {
+                                s[0].style.transform =
+                                    "translateY(-" + s[1] + "%)";
+                            });
+                        });
+                    });
+                }
+
                 function setStats(stats) {
                     Object.keys(FORMATS).forEach(function (key) {
                         if (typeof stats[key] !== "number") return;
@@ -3081,6 +3124,12 @@
                                 animate(el, c.to(stats[key]), c.fmt);
                             });
                     });
+                    document
+                        .querySelectorAll("[data-odo]")
+                        .forEach(function (el) {
+                            var v = stats[el.dataset.odo];
+                            if (typeof v === "number") setOdometer(el, v);
+                        });
                 }
 
                 // ---------- world map ----------

--- a/public/index.html
+++ b/public/index.html
@@ -3137,8 +3137,30 @@
                 // UTC-equivalent zones all resolve to the map center [500,250]
                 // (lon 0, lat 0 — open ocean), so plotting them drops a bogus
                 // dot in the middle of the map. Skip them.
-                var UTC_TZS = { UTC: 1, "Etc/UTC": 1, "Etc/GMT": 1 };
-                function buildMap(mapData, activeTzs) {
+                // gen-map-data.ts parks all of these on null island, so every
+                // one of them has to be skipped — GMT and Etc/Greenwich were
+                // missing here, and a profile on either would have drawn a dot
+                // in the middle of the Atlantic.
+                var UTC_TZS = {
+                    UTC: 1,
+                    "Etc/UTC": 1,
+                    "Etc/GMT": 1,
+                    GMT: 1,
+                    "Etc/Greenwich": 1,
+                };
+                // [halo, core] radius per level. Radii step by roughly √2 in
+                // area terms rather than linearly, because a circle is read by
+                // its area: doubling the radius would look like four times the
+                // share. Level 3 is the old fixed size, so a typical dot is
+                // unchanged and only the extremes move.
+                var TZ_RADII = [
+                    [5.5, 2.0],
+                    [7.0, 2.5],
+                    [9.0, 3.2],
+                    [11.5, 3.9],
+                    [14.5, 4.7],
+                ];
+                function buildMap(mapData, tzLevels) {
                     var svg = document.getElementById("world-svg");
                     if (!svg || !mapData) return;
                     var landFrag = document.createDocumentFragment();
@@ -3151,28 +3173,49 @@
                         landFrag.appendChild(c);
                     });
                     svg.appendChild(landFrag);
+                    function sizeDot(dot, level) {
+                        var r = TZ_RADII[level - 1];
+                        dot.halo.setAttribute("r", r[0]);
+                        dot.core.setAttribute("r", r[1]);
+                        dot.level = level;
+                    }
                     var seen = {};
-                    (activeTzs || []).forEach(function (tz, i) {
+                    var plotted = 0;
+                    Object.keys(tzLevels || {}).forEach(function (tz) {
                         if (UTC_TZS[tz]) return;
                         var pt = mapData.tz[tz];
                         if (!pt) return;
+                        var level = Math.min(
+                            TZ_RADII.length,
+                            Math.max(1, Math.round(tzLevels[tz]) || 1),
+                        );
+                        // Alias spellings (Europe/Kiev vs Europe/Kyiv) project
+                        // to the same coordinates and so share one dot. Keep
+                        // the larger level rather than whichever name came
+                        // first, so the dot is never smaller than the busiest
+                        // zone standing on it.
                         var k = pt[0] + "," + pt[1];
-                        if (seen[k]) return;
-                        seen[k] = true;
+                        if (seen[k]) {
+                            if (level > seen[k].level) sizeDot(seen[k], level);
+                            return;
+                        }
                         var halo = document.createElementNS(SVGNS, "circle");
                         halo.setAttribute("cx", pt[0]);
                         halo.setAttribute("cy", pt[1]);
-                        halo.setAttribute("r", "9");
                         halo.setAttribute("class", "tz-halo");
                         if (!reduceMotion)
-                            halo.style.animationDelay = (i % 6) * 0.45 + "s";
+                            halo.style.animationDelay =
+                                (plotted % 6) * 0.45 + "s";
                         var core = document.createElementNS(SVGNS, "circle");
                         core.setAttribute("cx", pt[0]);
                         core.setAttribute("cy", pt[1]);
-                        core.setAttribute("r", "3.2");
                         core.setAttribute("class", "tz-core");
+                        var dot = { halo: halo, core: core, level: 0 };
+                        sizeDot(dot, level);
+                        seen[k] = dot;
                         svg.appendChild(halo);
                         svg.appendChild(core);
+                        plotted++;
                     });
                 }
 
@@ -3189,7 +3232,7 @@
                     .then(function (res) {
                         var stats = res[0];
                         setStats(stats);
-                        buildMap(res[1], stats.timezone_list);
+                        buildMap(res[1], stats.timezone_levels);
                     })
                     .catch(function () {
                         var row = document.getElementById("stat-row");

--- a/public/styles.css
+++ b/public/styles.css
@@ -919,29 +919,70 @@ html:has(body.landing) {
 
 /* ---------- stats ---------- */
 .stat-row {
-    display: grid;
-    grid-template-columns: repeat(5, 1fr);
-    gap: 1.5rem 1rem;
     text-align: center;
 }
-.stat {
+.odo-hero {
     display: flex;
     flex-direction: column;
-    gap: 0.3rem;
+    align-items: center;
+    gap: 0.5rem;
 }
-.stat-num {
+/* Odometer. One reel per digit: a strip of stacked 0-9 cycles clipped to a
+   single cell, slid so the cell on show is the final digit. --cell is the unit
+   for both the clip height and the travel, so they can never drift apart.
+   Reels are laid out as flex items, which is why the tracking is carried by
+   letter-spacing inside each cell rather than by margins between them. */
+.odo {
+    --cell: 1.08em;
+    display: inline-flex;
     font-family: var(--font-display);
     font-weight: 800;
-    font-size: clamp(2rem, 4.5vw, 3.4rem);
+    font-size: clamp(2.5rem, 6.4vw, 6rem);
     line-height: 1;
-    letter-spacing: -0.04em;
+    letter-spacing: -0.045em;
     color: var(--ink);
     font-variant-numeric: tabular-nums;
 }
-.stat-cap {
-    font-size: 0.85rem;
-    font-weight: 400;
+.odo-reel {
+    display: block;
+    height: var(--cell);
+    overflow: hidden;
+}
+/* Travel is a percentage of the strip's own height, not `n * var(--cell)`:
+   changing an unregistered custom property inside calc() does not reliably
+   start a transition, so the reels snapped instead of rolling. A percentage is
+   an ordinary transform change, and it stays in register when the clamped
+   font-size — and with it --cell — changes on resize. */
+.odo-strip {
+    display: block;
+    transform: translateY(0);
+    transition: transform 1.2s cubic-bezier(0.22, 1, 0.36, 1);
+}
+.odo-strip span,
+.odo-sep {
+    display: block;
+    height: var(--cell);
+    line-height: var(--cell);
+}
+.odo-cap {
+    font-size: 0.95rem;
     color: var(--ink-2);
+}
+.odo-rest {
+    display: flex;
+    justify-content: center;
+    flex-wrap: wrap;
+    gap: 0.5rem clamp(1.25rem, 3vw, 2.5rem);
+    margin-top: clamp(1.5rem, 3vw, 2.25rem);
+    font-size: 0.95rem;
+    color: var(--ink-2);
+    font-variant-numeric: tabular-nums;
+}
+.odo-rest b {
+    font-family: var(--font-display);
+    font-weight: 700;
+    letter-spacing: -0.02em;
+    color: var(--ink);
 }
 
 /* ---------- world map ---------- */
@@ -1980,9 +2021,6 @@ html:has(body.landing) {
     }
 }
 @media (max-width: 720px) {
-    .stat-row {
-        grid-template-columns: repeat(3, 1fr);
-    }
     .features-grid,
     .steps3,
     .compare,
@@ -2001,9 +2039,6 @@ html:has(body.landing) {
     }
 }
 @media (max-width: 460px) {
-    .stat-row {
-        grid-template-columns: repeat(2, 1fr);
-    }
     .seg label {
         font-size: 0.75rem;
         gap: 0.3rem;
@@ -2017,6 +2052,10 @@ html:has(body.landing) {
     .tz-halo,
     .msg {
         animation: none;
+    }
+    /* belt and braces: setOdometer() also renders the plain number instead */
+    .odo-strip {
+        transition: none;
     }
 }
 

--- a/src/supabase.test.ts
+++ b/src/supabase.test.ts
@@ -5,6 +5,8 @@ import {
     alcoholTrackingEnabledFromProfile,
     preferredDrinkUnitFromProfile,
     fetchAllPages,
+    timezoneLevels,
+    TZ_LEVEL_THRESHOLDS,
     type MealInput,
     type Profile,
 } from "./supabase.js";
@@ -341,5 +343,80 @@ describe("fetchAllPages", () => {
         const { fetchPage } = paged(rows);
         const result = await fetchAllPages(fetchPage, 5);
         expect(result.map((r) => r.id)).toEqual(rows.map((r) => r.id));
+    });
+});
+
+describe("timezoneLevels", () => {
+    // Sizes the landing-page world map, and is the privacy boundary in front of
+    // the exact per-timezone counts: /api/stats is public and unauthenticated,
+    // so only these buckets are ever served.
+
+    test("never leaks a count — only levels 1..5 come out", () => {
+        const levels = timezoneLevels({
+            "Europe/Berlin": 38,
+            "America/New_York": 11,
+            "Pacific/Apia": 1,
+        });
+        for (const value of Object.values(levels)) {
+            expect(Number.isInteger(value)).toBe(true);
+            expect(value).toBeGreaterThanOrEqual(1);
+            expect(value).toBeLessThanOrEqual(TZ_LEVEL_THRESHOLDS.length + 1);
+        }
+        expect(Object.keys(levels).sort()).toEqual([
+            "America/New_York",
+            "Europe/Berlin",
+            "Pacific/Apia",
+        ]);
+    });
+
+    test("a lone profile and the busiest timezone land in different buckets", () => {
+        // The whole point of the change: with one radius for everything the map
+        // said nothing. 1 of 273 must not read the same as 38 of 273.
+        const levels = timezoneLevels({ big: 38, small: 1, rest: 234 });
+        expect(levels.small).toBe(1);
+        expect(levels.big).toBeGreaterThan(levels.small);
+    });
+
+    test("levels are shares, not ranks — scaling everything changes nothing", () => {
+        const small = timezoneLevels({ a: 1, b: 2, c: 4, d: 8, e: 85 });
+        const large = timezoneLevels({
+            a: 100,
+            b: 200,
+            c: 400,
+            d: 800,
+            e: 8500,
+        });
+        expect(large).toEqual(small);
+    });
+
+    test("threshold boundaries are inclusive", () => {
+        // 1 in 100 is exactly the first threshold (0.01) and must step up.
+        const levels = timezoneLevels({ edge: 1, rest: 99 });
+        expect(levels.edge).toBe(2);
+        // a hair under stays at level 1
+        const under = timezoneLevels({ edge: 1, rest: 100 });
+        expect(under.edge).toBe(1);
+    });
+
+    test("the largest possible share saturates at the top level", () => {
+        const levels = timezoneLevels({ only: 5 });
+        expect(levels.only).toBe(TZ_LEVEL_THRESHOLDS.length + 1);
+    });
+
+    test("no profiles yields no dots rather than a divide by zero", () => {
+        expect(timezoneLevels({})).toEqual({});
+        expect(timezoneLevels({ a: 0 })).toEqual({});
+    });
+
+    test("zero and malformed counts are dropped, not plotted at level 1", () => {
+        // A timezone with no profiles must not appear on the map at all, and a
+        // non-numeric value from the DB must not poison the total.
+        const levels = timezoneLevels({
+            real: 10,
+            empty: 0,
+            negative: -3,
+            junk: undefined as unknown as number,
+        });
+        expect(Object.keys(levels)).toEqual(["real"]);
     });
 });

--- a/src/supabase.test.ts
+++ b/src/supabase.test.ts
@@ -373,8 +373,11 @@ describe("timezoneLevels", () => {
         // The whole point of the change: with one radius for everything the map
         // said nothing. 1 of 273 must not read the same as 38 of 273.
         const levels = timezoneLevels({ big: 38, small: 1, rest: 234 });
+        // Asserted as exact levels rather than `big > small`: under
+        // noUncheckedIndexedAccess a lookup is number | undefined, and
+        // toBeGreaterThan would not accept that as its argument.
         expect(levels.small).toBe(1);
-        expect(levels.big).toBeGreaterThan(levels.small);
+        expect(levels.big).toBe(TZ_LEVEL_THRESHOLDS.length + 1);
     });
 
     test("levels are shares, not ranks — scaling everything changes nothing", () => {

--- a/src/supabase.ts
+++ b/src/supabase.ts
@@ -1293,6 +1293,53 @@ export interface LandingStats {
     // IANA names of every distinct timezone in use — drives the landing-page
     // world map. Aggregate-only; no per-user data.
     timezone_list: string[];
+    // IANA name -> 1..5, that timezone's share of all profiles. Sizes each dot
+    // on the world map. Levels, never counts: see timezoneLevels().
+    timezone_levels: Record<string, number>;
+}
+
+// What the SQL function actually returns. `timezone_counts` is exact and stays
+// inside the process — it is bucketed before anything is served.
+interface RawLandingStats extends Omit<LandingStats, "timezone_levels"> {
+    timezone_counts?: Record<string, number>;
+}
+
+// Share of all profiles at which a timezone moves up a level. Geometric, not
+// evenly spaced, because the real distribution is long-tailed: at 273 profiles
+// the largest timezone held 14% while 27 timezones held one profile each. Even
+// cuts would drop ~80% of dots into level 1 and the map would show no gradient
+// at all. Doubling at each step keeps every bucket populated.
+export const TZ_LEVEL_THRESHOLDS = [0.01, 0.02, 0.04, 0.08] as const;
+
+// The level whose radius matches the single size every dot used to be drawn at.
+// Used only when the DB has no counts to bucket — see getLandingStats.
+export const LEGACY_TZ_LEVEL = 3;
+
+// Buckets exact per-timezone counts into 1..5 by share of the total.
+//
+// This is the privacy boundary for the world map. /api/stats is public and
+// unauthenticated, and most timezones have a single profile — publishing the
+// counts would amount to "exactly one person uses this app in Pacific/Apia".
+// A level only narrows a timezone to a range, and the widest range (level 1)
+// is also the one nearly every small timezone lands in.
+export function timezoneLevels(
+    counts: Record<string, number>,
+): Record<string, number> {
+    const entries = Object.entries(counts).filter(
+        ([, n]) => typeof n === "number" && n > 0,
+    );
+    const total = entries.reduce((sum, [, n]) => sum + n, 0);
+    const levels: Record<string, number> = {};
+    if (total <= 0) return levels;
+    for (const [tz, n] of entries) {
+        const share = n / total;
+        let level = 1;
+        for (const threshold of TZ_LEVEL_THRESHOLDS) {
+            if (share >= threshold) level++;
+        }
+        levels[tz] = level;
+    }
+    return levels;
 }
 
 // Aggregate-only totals for the public landing page. Backed by the
@@ -1301,7 +1348,19 @@ export interface LandingStats {
 export async function getLandingStats(): Promise<LandingStats> {
     const { data, error } = await getSupabase().rpc("public_landing_stats");
     if (error) throw new Error(`Failed to get landing stats: ${error.message}`);
-    return data as LandingStats;
+    const { timezone_counts, ...rest } = data as RawLandingStats;
+    const timezone_levels = timezoneLevels(timezone_counts ?? {});
+    // Deploy-order safety. The app and the database ship separately, so this
+    // code can be live before the migration that adds `timezone_counts` has
+    // run. Without a fallback the map would render its land grid and not a
+    // single active dot; instead every timezone gets the level whose radius is
+    // the size they were all drawn at before, which looks exactly like today.
+    if (Object.keys(timezone_levels).length === 0) {
+        for (const tz of rest.timezone_list ?? []) {
+            timezone_levels[tz] = LEGACY_TZ_LEVEL;
+        }
+    }
+    return { ...rest, timezone_levels };
 }
 
 // ---------- Registered clients ----------

--- a/supabase/migrations/20260808120000_landing_stats_timezone_counts.sql
+++ b/supabase/migrations/20260808120000_landing_stats_timezone_counts.sql
@@ -1,0 +1,47 @@
+-- Adds per-timezone profile counts to the landing stats, so the world map can
+-- size each dot by that timezone's share of all profiles instead of drawing
+-- every dot at one radius.
+--
+-- Additive on purpose: `timezone_list` stays. Removing it here would break the
+-- landing page already in production the moment this runs, since the deployed
+-- JS reads that key — and browsers hold the old HTML for a while after a
+-- deploy. It can be dropped in a later migration once nothing reads it.
+--
+-- `timezone_counts` is exact and is NOT what the public endpoint serves:
+-- src/supabase.ts buckets it into five levels and exposes only those, because
+-- a raw count publishes "exactly one person uses this app in Pacific/Apia" on
+-- an unauthenticated route.
+create or replace function public.public_landing_stats()
+returns json
+language sql
+stable
+security definer
+set search_path = public
+as $$
+  select json_build_object(
+    'food_logs',      (select count(*) from public.meals),
+    'total_calories', (select coalesce(sum(calories), 0) from public.meals),
+    'total_protein_g',(select coalesce(sum(protein_g), 0) from public.meals),
+    'total_carbs_g',  (select coalesce(sum(carbs_g), 0) from public.meals),
+    'total_fat_g',    (select coalesce(sum(fat_g), 0) from public.meals),
+    'timezones',      (select count(distinct timezone) from public.profiles),
+    'timezone_list',  (select coalesce(json_agg(distinct timezone), '[]'::json) from public.profiles),
+    -- json_object_agg over zero rows yields NULL, not '{}', hence the coalesce.
+    'timezone_counts',(
+      select coalesce(json_object_agg(timezone, n), '{}'::json)
+      from (
+        select timezone, count(*)::int as n
+        from public.profiles
+        group by timezone
+      ) per_tz
+    )
+  );
+$$;
+
+comment on function public.public_landing_stats() is
+  'Aggregate-only stats for the public landing page. Exposes no per-user rows.';
+
+-- Only the server (service-role) calls this; it never needs to be reachable
+-- directly via the anon/authenticated PostgREST roles.
+revoke execute on function public.public_landing_stats() from public;
+grant execute on function public.public_landing_stats() to service_role;


### PR DESCRIPTION
Two changes to the "A growing global food log" section.

## 1. The stat row becomes an odometer

The five-across row had a layout bug and no hierarchy. `fmtKg()` emits `"1,015 kg"` as one string, and in a `repeat(5, 1fr)` grid that was the only cell too wide to fit — so it wrapped, dropping `kg` to a second line and dragging its caption out of line with the other four. Reproducible for any macro over 1,000 kg. Separately, `403 kg` was rendered at the same weight as `11M`, so size tracked nothing.

The section is titled *"A growing global food log"*, so growth is now the design: calories get a hero odometer whose digit reels are built from the real total, and the other four figures move to a supporting line. Nothing is dropped — the timezone count stays where it already was, in the map caption below.

Reels further right spin through more cycles and take longer, so leading digits settle while the tail is still turning. Reduced motion skips the reels and renders the plain number.

**One bug worth calling out:** the first implementation drove travel with `transform: translateY(calc(var(--n) * var(--cell) * -1))`. It rendered the correct number but never animated — changing an unregistered custom property inside `calc()` does not reliably start a transition, so every reel snapped. It looks identical in a screenshot; it was only caught by sampling the computed transform across frames. Travel is now a percentage of each strip's own height, which is an ordinary transform change and stays in register when the clamped font-size changes on resize.

## 2. Map dots sized by each timezone's share of profiles

Every dot was one radius, so the map showed where people are but not how many. Dots now take one of five radii by that timezone's share of all profiles — a dot map and a heatmap at once.

No count existed anywhere in the pipeline (`timezone_list` came from `json_agg(distinct timezone)`), so `public_landing_stats()` now also returns `timezone_counts`. It **keeps** `timezone_list`: dropping it would break the page already in production the moment the function is replaced, since browsers hold the old JS after a deploy.

### The counts are not what `/api/stats` serves

That route is public and unauthenticated, and 27 of 62 timezones hold a single profile — a raw count would publish *"exactly one person uses this app in Pacific/Apia"*. `getLandingStats()` buckets the counts into levels and exposes only those. `timezoneLevels()` is pure and covered by 7 new tests (boundaries, saturation, zero/malformed counts, and that levels are shares rather than ranks).

### Why the thresholds are geometric

Thresholds are 1/2/4/8% of all profiles, not evenly spaced. The distribution is long-tailed — the largest timezone holds 14% while 27 hold one profile each — so even cuts put ~80% of dots in level 1 and the map shows no gradient. Against current data the geometric cuts give **39 / 12 / 5 / 4 / 2** across the five levels.

Radii step by roughly √2 in area, since a circle is read by its area, and level 3 is the old fixed size so a typical dot is unchanged.

### Also fixed

`GMT` and `Etc/Greenwich` were missing from `UTC_TZS` even though `gen-map-data.ts` parks them on null island — a profile on either would have drawn a dot in the middle of the Atlantic.

## Migration

`supabase/migrations/20260808120000_landing_stats_timezone_counts.sql` is **already applied to production** (remote version `20260808080404`). It is additive, so DB-ahead-of-app is safe: production still serves `timezone_list` and uniform dots until this merges. If this code had gone live first, every timezone would fall back to the level matching the old uniform dot rather than the map losing all its markers.

Verified post-apply: counts sum to 273 = total profiles, so shares are computed against a denominator that drops nobody.

## Testing

- 477 tests pass, prettier clean
- Odometer: reels land on the exact total; roll animates (193 distinct positions over ~1.9s); reduced motion renders plain text with zero reels; dark theme and 390px mobile verified; stats-fetch failure still hides the block
- Map: rendered radii histogram matches the level histogram exactly (39@5.5, 12@7, 5@9, 4@11.5, 2@14.5); zero dots at null island; levels of `99`, `0` and `null` clamp instead of emitting `r="undefined"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)