### PR TITLE
fix(time): give clockless hosts a way to ask what time it is

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,8 @@ Read the story behind it: [How I Replaced MyFitnessPal and Other Apps with a Sin
 | `get_meal_patterns`        | Pre-aggregated behavioural patterns (breakfast effect, late dinner, weekend vs weekday, outliers)                                                |
 | `export_meals`             | Export all meals as a CSV and return a 60-minute download link                                                                                   |
 | `set_timezone`             | Set the user's IANA timezone (e.g. `America/Los_Angeles`)                                                                                        |
-| `get_timezone`             | Get the user's configured timezone                                                                                                               |
+| `get_timezone`             | Get the user's configured timezone, plus their current local date and time                                                                       |
+| `get_current_time`         | Get the current date and time in the user's timezone, plus the UTC instant — for hosts with no clock in context                                  |
 | `set_widget_display`       | Enable or disable the in-chat visual widgets (dashboards, rings, charts); enabled by default                                                     |
 | `get_widget_display`       | Get whether the in-chat visual widgets are enabled                                                                                               |
 | `set_alcohol_tracking`     | Turn alcohol tracking on or off (off by default) and choose US standard drinks or UK units; turning it off hides alcohol rather than deleting it |

--- a/public/index.html
+++ b/public/index.html
@@ -897,7 +897,7 @@
                         ></span>
                         <span class="tools-cta-text">
                             <strong>Curious what it can actually do?</strong>
-                            Browse all 37 tools — logging, barcodes, water,
+                            Browse all 38 tools — logging, barcodes, water,
                             weight, goals, and trends — with a description and
                             an example prompt for each.
                         </span>

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -11,7 +11,7 @@ Most nutrition apps (MyFitnessPal, Cronometer, Lose It!, MacroFactor, Yazio, Lif
 ## Main pages
 
 - [Home](https://nutrition-mcp.com/): What Nutrition MCP is, how it works, install steps for Claude/ChatGPT/Cursor/VS Code, and examples.
-- [Tools reference](https://nutrition-mcp.com/tools): The full list of all 37 MCP tools (log_meal, lookup_barcode, start_meal_import, bulk_import_meals, get_nutrition_summary, log_weight, get_trends, and more) with descriptions and example prompts.
+- [Tools reference](https://nutrition-mcp.com/tools): The full list of all 38 MCP tools (log_meal, lookup_barcode, start_meal_import, bulk_import_meals, get_nutrition_summary, log_weight, get_trends, and more) with descriptions and example prompts.
 - [Alternatives overview](https://nutrition-mcp.com/alternatives): How Nutrition MCP compares to popular nutrition-tracking apps that have no MCP server.
 
 ## App comparisons

--- a/public/tools.html
+++ b/public/tools.html
@@ -1,12 +1,12 @@
 <!doctype html>
 <html lang="en">
     <head>
-        <title>Tools Reference: All 37 Tools — Nutrition MCP</title>
+        <title>Tools Reference: All 38 Tools — Nutrition MCP</title>
         <meta name="viewport" content="width=device-width, initial-scale=1" />
         <meta charset="utf-8" />
         <meta
             name="description"
-            content="All 37 tools the Nutrition MCP server gives your AI — log meals, scan barcodes, import your history from another app, track water and weight, set goals, and review trends. Full reference with descriptions and example prompts."
+            content="All 38 tools the Nutrition MCP server gives your AI — log meals, scan barcodes, import your history from another app, track water and weight, set goals, and review trends. Full reference with descriptions and example prompts."
         />
         <link rel="canonical" href="https://nutrition-mcp.com/tools" />
         <link rel="icon" href="/favicon.ico" />
@@ -14,11 +14,11 @@
         <meta name="theme-color" content="#4a7c59" />
         <meta
             property="og:title"
-            content="Tools Reference: All 37 Tools — Nutrition MCP"
+            content="Tools Reference: All 38 Tools — Nutrition MCP"
         />
         <meta
             property="og:description"
-            content="All 37 tools the Nutrition MCP server gives your AI, including a CSV importer for your history from another app — with descriptions and example prompts."
+            content="All 38 tools the Nutrition MCP server gives your AI, including a CSV importer for your history from another app — with descriptions and example prompts."
         />
         <meta property="og:type" content="website" />
         <meta property="og:url" content="https://nutrition-mcp.com/tools" />
@@ -461,7 +461,7 @@
                     </p>
                     <span class="count-pill"
                         ><i class="fa-solid fa-wrench" aria-hidden="true"></i
-                        ><b>37 tools</b> across 7 areas</span
+                        ><b>38 tools</b> across 7 areas</span
                     >
                 </div>
             </section>
@@ -2029,7 +2029,8 @@
                                     <span class="chip chip-view">View</span>
                                 </div>
                                 <p class="tool-desc">
-                                    Check the timezone you're configured for
+                                    Check the timezone you're configured for,
+                                    along with your current local date and time
                                     (defaults to UTC if unset).
                                 </p>
                                 <div class="tool-ex">
@@ -2037,6 +2038,29 @@
                                         >Try saying</span
                                     >
                                     <p>What timezone am I set to?</p>
+                                </div>
+                            </article>
+
+                            <article class="tool-card" id="get_current_time">
+                                <div class="tool-head">
+                                    <code class="tool-name"
+                                        >get_current_time</code
+                                    >
+                                    <span class="chip chip-view">View</span>
+                                </div>
+                                <p class="tool-desc">
+                                    Check the date and time right now in your
+                                    timezone, plus the UTC instant. Some apps
+                                    don't tell the assistant what time it is, so
+                                    this is how it works out what "this morning"
+                                    or "today" means without asking you
+                                    (defaults to UTC if no timezone is set).
+                                </p>
+                                <div class="tool-ex">
+                                    <span class="tool-ex-label"
+                                        >Try saying</span
+                                    >
+                                    <p>What time is it for me right now?</p>
                                 </div>
                             </article>
 

--- a/src/mcp.test.ts
+++ b/src/mcp.test.ts
@@ -49,7 +49,7 @@ import type {
     WaterEntry,
     WeightEntry,
 } from "./supabase.js";
-import { dateInTz } from "./tz.js";
+import { dateInTz, formatLocalDateTime, weekdayInTz } from "./tz.js";
 
 function meal(over: Partial<Meal> = {}): Meal {
     return {
@@ -3134,5 +3134,153 @@ describe("manual write tools resolve logged_at in the profile timezone", () => {
             );
             expect(loggedAtOf(db.inserted[0])).toBe("2026-07-20T19:00:00.000Z");
         });
+    });
+});
+
+// ---------- the server is the clock (issue #102) ----------
+//
+// Several hosts (Claude Desktop among them) keep the wall clock out of the
+// model's context. With no clock the model either interrogated the user ("what
+// time is it?") on every single log, or guessed — and a guessed time lands on
+// the wrong local day for anyone far from UTC. The server always knows both the
+// instant and the user's zone, so it says so.
+//
+// These read the real clock, so they assert SHAPE and ZONE, never a pinned
+// value: the date is compared against dateInTz sampled around the call, which
+// is both zone-sensitive and immune to a midnight rollover mid-test.
+describe("current-time disclosure", () => {
+    /** "Local time now: Sunday 2026-08-09 15:04:22 (Europe/Kyiv)." */
+    const clockRe = (tz: string) =>
+        new RegExp(
+            `Local time now: ([A-Z][a-z]+day) (\\d{4}-\\d{2}-\\d{2}) (\\d{2}:\\d{2}:\\d{2}) \\(${tz}\\)\\.`,
+        );
+    const UTC_NOW_RE =
+        /UTC now: (\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z)\./;
+
+    /** Assert the clock line names `tz`'s local day and weekday right now. */
+    function expectClockIn(text: string, tz: string, sampled: string[]): void {
+        const m = text.match(clockRe(tz));
+        expect(m).not.toBeNull();
+        const utc = text.match(UTC_NOW_RE);
+        expect(utc).not.toBeNull();
+        const instant = utc![1]!;
+        // The two halves are one instant rendered twice, so the zone is
+        // genuinely applied and not merely printed in the label — this holds at
+        // every hour, including the ones where tz and UTC share a date.
+        expect(`${m![2]} ${m![3]}`).toBe(formatLocalDateTime(instant, tz));
+        expect(m![1]).toBe(weekdayInTz(instant, tz));
+        // ...and that instant is now, not a fixture.
+        expect(sampled).toContain(dateInTz(instant, tz));
+    }
+
+    /** Local dates in `tz` before and after the call, to absorb a rollover. */
+    async function around(
+        tz: string,
+        run: () => Promise<string>,
+    ): Promise<{ text: string; sampled: string[] }> {
+        const before = dateInTz(new Date(), tz);
+        const text = await run();
+        const after = dateInTz(new Date(), tz);
+        return { text, sampled: [...new Set([before, after])] };
+    }
+
+    test("get_timezone reports the zone AND the user's current wall clock", async () => {
+        db.profile = { ...PROFILE_BASE, timezone: "Europe/Kyiv" };
+        await withTools(null, async (call) => {
+            const { text, sampled } = await around("Europe/Kyiv", async () =>
+                textOf(await call("get_timezone")),
+            );
+            expect(text).toContain("Timezone: Europe/Kyiv.");
+            expectClockIn(text, "Europe/Kyiv", sampled);
+            // The old line gave a date and no time, which is what left the
+            // model reconstructing an hour.
+            expect(text).not.toContain("Local today is");
+        });
+    });
+
+    test("get_timezone still gives a clock when no timezone is set", async () => {
+        db.profile = null;
+        await withTools(null, async (call) => {
+            const { text, sampled } = await around("UTC", async () =>
+                textOf(await call("get_timezone")),
+            );
+            expect(text).toContain("No timezone set yet (defaulting to UTC).");
+            expectClockIn(text, "UTC", sampled);
+            // Knowing the time must not cost the caller the nudge to configure
+            // a zone — UTC is a fallback, not the user's clock.
+            expect(text).toContain("set_timezone");
+        });
+    });
+
+    test("get_current_time answers in the profile's zone, and is measured", async () => {
+        db.profile = { ...PROFILE_BASE, timezone: "Asia/Tokyo" };
+        await withTools(null, async (call) => {
+            const { text, sampled } = await around("Asia/Tokyo", async () =>
+                textOf(await call("get_current_time")),
+            );
+            expectClockIn(text, "Asia/Tokyo", sampled);
+            expect(text).not.toContain("No timezone is set");
+        });
+
+        const rows = db.analyticsRows.filter(
+            (r) => r.tool_name === "get_current_time",
+        );
+        expect(rows).toHaveLength(1);
+        expect(rows[0]!.user_id).toBe("u1");
+        expect(rows[0]!.success).toBe(true);
+    });
+
+    // Without this the UTC fallback reads as the user's real local time, and a
+    // model would resolve "this morning" against a clock up to 14 hours off.
+    test("get_current_time flags that an unset zone means UTC, not local", async () => {
+        db.profile = null;
+        await withTools(null, async (call) => {
+            const { text, sampled } = await around("UTC", async () =>
+                textOf(await call("get_current_time")),
+            );
+            expectClockIn(text, "UTC", sampled);
+            expect(text).toContain("No timezone is set for this account");
+            expect(text).toContain("set_timezone");
+        });
+    });
+
+    // The shipped guidance is the actual fix: the three "log it now" tools used
+    // to tell the model to ask the user for the time before calling them. Now
+    // they tell it to omit the field and let the server stamp now.
+    test("log_meal, log_water and log_weight tell the model to omit logged_at, not to ask", async () => {
+        const server = new McpServer(
+            { name: "t", version: "0.0.0" },
+            { capabilities: { tools: {}, resources: {} } },
+        );
+        registerTools(server, "u1", true, null);
+        const [ct, st] = InMemoryTransport.createLinkedPair();
+        const client = new Client({ name: "c", version: "0.0.0" });
+        await Promise.all([server.connect(st), client.connect(ct)]);
+        try {
+            const { tools } = await client.listTools();
+            for (const name of ["log_meal", "log_water", "log_weight"]) {
+                const props = (
+                    tools.find((t) => t.name === name)?.inputSchema as {
+                        properties?: Record<string, { description?: string }>;
+                    }
+                )?.properties;
+                const desc = props?.logged_at?.description ?? "";
+                expect(desc).not.toBe("");
+                expect(desc).not.toContain(
+                    "ask the user before calling this tool",
+                );
+                // The only surviving mention of asking is the prohibition.
+                expect(
+                    desc.replaceAll("Do NOT ask the user what time it is.", ""),
+                ).not.toContain("ask the user");
+                expect(desc).toContain("omit this field entirely");
+                expect(desc).toContain("get_current_time");
+            }
+            // ...and the tool that replaces the question is actually reachable.
+            expect(tools.map((t) => t.name)).toContain("get_current_time");
+        } finally {
+            await client.close();
+            await server.close();
+        }
     });
 });

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -46,6 +46,8 @@ import {
     validateTz,
     shiftLocalDate,
     dateInTz,
+    formatLocalDateTime,
+    weekdayInTz,
     LoggedAtError,
     resolveWriteLoggedAt,
 } from "./tz.js";
@@ -112,6 +114,11 @@ const IMPORT_MEALS_WIDGET_URI = "ui://widget/import-meals.html";
 const SERVER_INSTRUCTIONS = `Nutrition tracking: meals, water, weight, goals, and trends, per-user with timezone support.
 
 All nutrition figures are estimates and this server does not provide medical or dietary advice.
+
+Knowing what time it is — some hosts put the current date and time in your context and some do not, but this server always knows both the clock and the user's timezone. Never ask the user what time it is.
+- Logging something that just happened: omit logged_at entirely. The server stamps the entry with the current time, which is more accurate than any time you could reconstruct.
+- Resolving a relative time ("this morning", "an hour ago", "last Monday") or working out what "today" means: call get_current_time, then pass the resolved local time as logged_at.
+- Only ask the user for a time when the entry is for some other moment they have not told you.
 
 Photo-based meal logging — when the user sends a photo of food, follow these steps in order:
 1. Pick the flow. A packaged product with a visible barcode: transcribe the digits printed under the barcode and call lookup_barcode. A plate, bowl, or prepared meal: continue below.
@@ -1037,6 +1044,27 @@ function formatWeightEntry(entry: WeightEntry, unit: WeightUnit): string {
 const LOGGED_AT_FORMS =
     'Accepts a full ISO 8601 timestamp with an offset or Z ("2026-01-05T08:30:00+02:00"), an offset-less local time ("2026-01-05T08:30"), or a bare date ("2026-01-05", anchored at local noon). Offset-less values are resolved in the user\'s saved timezone, so pass the local time exactly as the user gives it and do NOT convert it to UTC yourself.';
 
+// Appended to `logged_at` on the three "log it now" tools. This used to say
+// "ask the user" — which fired on every single log from any host that keeps the
+// wall clock out of the model's context (Claude Desktop among them), turning
+// "I just ate X" into an interrogation, or worse a guessed time on the wrong
+// day (issue #102). Omitting the field is strictly better than guessing: the
+// server stamps `new Date()` and it genuinely knows the time.
+const LOGGED_AT_OMIT_IF_NOW =
+    " Do NOT ask the user what time it is. If you don't know the current date or time, omit this field entirely and the server stamps the entry with the current time. Only supply it for an entry that happened at some other moment, and call get_current_time if you need the user's local clock to work that moment out.";
+
+// The one rendering of "what time is it for this user", shared by
+// get_current_time and get_timezone so the two can never disagree. The weekday
+// is there to make "last Monday" resolvable without a second round trip, and
+// the UTC instant so a caller can check its own clock against ours. Local time
+// is the repo-standard "YYYY-MM-DD HH:mm:ss" wall clock — deliberately not an
+// offset-less ISO string, which reads as a machine value a caller might echo
+// straight back into logged_at without noticing it has gone stale.
+function formatClockLine(tz: string): string {
+    const now = new Date();
+    return `Local time now: ${weekdayInTz(now, tz)} ${formatLocalDateTime(now, tz)} (${tz}). UTC now: ${now.toISOString()}.`;
+}
+
 // Resolve a caller-supplied `logged_at` to an absolute instant before it
 // reaches the timestamptz column. Without this an offset-less string is read in
 // the database session's zone (UTC), so a Kyiv user's 21:00 lands at midnight
@@ -1287,7 +1315,7 @@ export function registerTools(
                     .describe(
                         "When this actually happened (defaults to now). " +
                             LOGGED_AT_FORMS +
-                            " If you don't know the current date or time, ask the user before calling this tool.",
+                            LOGGED_AT_OMIT_IF_NOW,
                     ),
                 notes: z.string().optional().describe("Additional notes"),
                 idempotency_key: z
@@ -2826,7 +2854,7 @@ export function registerTools(
                     .describe(
                         "When this actually happened (defaults to now). " +
                             LOGGED_AT_FORMS +
-                            " If you don't know the current date or time, ask the user before calling this tool.",
+                            LOGGED_AT_OMIT_IF_NOW,
                     ),
                 notes: z
                     .string()
@@ -3040,7 +3068,7 @@ export function registerTools(
                     .describe(
                         "When this actually happened (defaults to now). " +
                             LOGGED_AT_FORMS +
-                            " If you don't know the current date or time, ask the user before calling this tool.",
+                            LOGGED_AT_OMIT_IF_NOW,
                     ),
                 notes: z
                     .string()
@@ -4111,7 +4139,7 @@ export function registerTools(
         {
             title: "Get Timezone",
             description:
-                "Get the user's configured IANA timezone. Returns UTC if no profile has been set.",
+                "Get the user's configured IANA timezone, along with their current local date and time. Returns UTC if no profile has been set.",
             annotations: {
                 readOnlyHint: true,
                 destructiveHint: false,
@@ -4129,7 +4157,7 @@ export function registerTools(
                             content: [
                                 {
                                     type: "text",
-                                    text: "No timezone set yet (defaulting to UTC). Call set_timezone to configure one so 'today' matches the user's local calendar day.",
+                                    text: `No timezone set yet (defaulting to UTC). ${formatClockLine("UTC")} Call set_timezone to configure one so 'today' matches the user's local calendar day.`,
                                 },
                             ],
                         };
@@ -4138,7 +4166,49 @@ export function registerTools(
                         content: [
                             {
                                 type: "text",
-                                text: `Timezone: ${profile.timezone}. Local today is ${todayInTz(profile.timezone)}.`,
+                                text: `Timezone: ${profile.timezone}. ${formatClockLine(profile.timezone)}`,
+                            },
+                        ],
+                    };
+                },
+                { userId },
+            );
+        },
+    );
+
+    // The clock is the server's to give, not the user's: a host that keeps the
+    // wall time out of the model's context otherwise leaves it with no way to
+    // resolve "this morning" except asking or guessing (issue #102).
+    // get_timezone answers this too, but only a model that already suspects a
+    // timezone problem thinks to call it — the tool NAME is the discoverable
+    // part, which is why this exists as well as the fuller line above.
+    server.registerTool(
+        "get_current_time",
+        {
+            title: "Get Current Time",
+            description:
+                "Get the current date and time in the user's timezone, plus the UTC instant. Call this whenever you need to know what time it is for this user — to resolve 'today', 'this morning', 'an hour ago' or 'last Monday' into a real timestamp — instead of asking the user or guessing. Not needed to log something that is happening now: omit logged_at and the server stamps the current time itself.",
+            annotations: {
+                readOnlyHint: true,
+                destructiveHint: false,
+                idempotentHint: false,
+                openWorldHint: false,
+            },
+        },
+        async () => {
+            return withAnalytics(
+                "get_current_time",
+                async () => {
+                    const profile = await getProfile(userId);
+                    const tz = profile?.timezone ?? "UTC";
+                    const unset = profile
+                        ? ""
+                        : " No timezone is set for this account, so this is UTC and may not be the user's actual local time — offer set_timezone.";
+                    return {
+                        content: [
+                            {
+                                type: "text",
+                                text: `${formatClockLine(tz)}${unset}`,
                             },
                         ],
                     };

--- a/src/tz.test.ts
+++ b/src/tz.test.ts
@@ -3,6 +3,7 @@ import {
     validateTz,
     dateInTz,
     formatLocalDateTime,
+    weekdayInTz,
     hourInTz,
     dowInTz,
     zonedDayStartUtc,
@@ -30,6 +31,30 @@ test("formatLocalDateTime renders wall-clock time, normalizing hour 24 to 00", (
     expect(
         formatLocalDateTime("2024-03-01T08:00:00Z", "America/Los_Angeles"),
     ).toBe("2024-03-01 00:00:00");
+});
+
+// The weekday the clock line prints is what lets a model resolve "last Monday"
+// without asking (issue #102), so it has to be the USER's weekday, not the
+// server's. One instant is two different weekdays depending on the zone.
+test("weekdayInTz names the local weekday, not the UTC one", () => {
+    // 23:30Z Friday is already Saturday in Tokyo (+9) and still Friday in LA.
+    const nearMidnight = "2024-03-01T23:30:00Z";
+    expect(weekdayInTz(nearMidnight, "UTC")).toBe("Friday");
+    expect(weekdayInTz(nearMidnight, "Asia/Tokyo")).toBe("Saturday");
+    expect(weekdayInTz(nearMidnight, "America/Los_Angeles")).toBe("Friday");
+
+    // Across the dateline the split is 25 hours wide, so it holds at midday
+    // UTC too: Kiritimati (+14) and Niue (-11) never share a weekday.
+    const midday = "2024-03-01T12:00:00Z";
+    expect(weekdayInTz(midday, "Pacific/Kiritimati")).toBe("Saturday");
+    expect(weekdayInTz(midday, "Pacific/Niue")).toBe("Friday");
+
+    // The name is the long English one, and it agrees with dowInTz's numbering.
+    expect(weekdayInTz(new Date(midday), "Pacific/Kiritimati")).toBe(
+        "Saturday",
+    );
+    expect(dowInTz(midday, "Pacific/Kiritimati")).toBe(6);
+    expect(dowInTz(midday, "Pacific/Niue")).toBe(5);
 });
 
 test("hourInTz and dowInTz reflect local time", () => {

--- a/src/tz.ts
+++ b/src/tz.ts
@@ -53,6 +53,15 @@ export function formatLocalDateTime(
     return `${get("year")}-${get("month")}-${get("day")} ${hour}:${get("minute")}:${get("second")}`;
 }
 
+/** Local weekday name ("Monday") of an absolute instant in the given IANA timezone. */
+export function weekdayInTz(instant: Date | string, tz: string): string {
+    const d = instant instanceof Date ? instant : new Date(instant);
+    return new Intl.DateTimeFormat("en-US", {
+        timeZone: tz,
+        weekday: "long",
+    }).format(d);
+}
+
 /** Local hour (0-23) of an absolute instant in the given IANA timezone. */
 export function hourInTz(instant: Date | string, tz: string): number {
     const d = instant instanceof Date ? instant : new Date(instant);


### PR DESCRIPTION
Fixes #102.

Logging "I just ate X" worked from the Claude mobile app and stalled from desktop. The difference is host-side — some clients put the wall clock in the model's context, some don't — but the server made it worse than it had to be: nothing here exposed the clock, and the `logged_at` guidance told the model to stop and ask for it.

## What changed

**A server-side source of truth for the clock**

- New tool **`get_current_time`** (read-only, no params) — returns the user's local weekday, date and time plus the UTC instant:
  `Local time now: Sunday 2026-08-09 18:36:36 (Europe/Kyiv). UTC now: 2026-08-09T15:36:36.704Z.`
  With no profile it returns UTC, says so, and offers `set_timezone`. The weekday is there so "last Monday" resolves without a second round trip.
- **`get_timezone`** now returns that same line instead of a bare `Local today is <date>`. Both render through one private `formatClockLine(tz)`, so they can't drift apart.
- New `weekdayInTz()` in `src/tz.ts`.

`get_timezone` alone would have been enough mechanically, but only a model that already suspects a timezone problem thinks to call it — the tool *name* is the discoverable part, which is why both exist.

**The guidance is inverted**

The sentence "If you don't know the current date or time, ask the user before calling this tool" fired on *every* log from a clockless host — exactly the reported behaviour. Not knowing the time is precisely the case for **omitting** `logged_at`: it's optional and `insertMeal` already stamps `new Date()` on a server that genuinely knows. Now a shared `LOGGED_AT_OMIT_IF_NOW` across `log_meal` / `log_water` / `log_weight`: don't ask, omit; only supply it for some other moment, and call `get_current_time` to work that moment out.

`update_meal` / `update_weight` keep their existing text — editing an entry to a specific time is when the field belongs.

**Server instructions** gained a "Knowing what time it is" block ahead of any tool description, so it lands on hosts that surface instructions but not every schema.

## Notes

The clock line prints the repo-standard `YYYY-MM-DD HH:mm:ss` wall clock rather than an offset-less ISO string — an ISO-looking value reads as machine input a caller might echo straight back into `logged_at` without noticing it has gone stale.

## Tests

`weekdayInTz` across the dateline; `get_timezone` and `get_current_time` with and without a profile; an analytics row for the new tool; and a regression test reading the shipped descriptions via `listTools()` to keep the old "ask the user" sentence dead. Assertions pin shape, not a clock value, and check the printed local date against `dateInTz` sampled either side of the call so a midnight rollover can't flake them.

`bun test` — 557 pass, 0 fail. `bun run typecheck` and `bun run format:check` clean.

## Docs

New card in `public/tools.html`, README table row, and the tool count bumped 37 → 38 in `tools.html` (title, meta, OG, hero pill), `public/llms.txt` and `public/index.html`. `grep -c 'class="tool-card"'` matches at 38.

## Acceptance

- [x] "I just ate X" from a clockless host no longer asks for the time — the model omits `logged_at` and the server stamps the actual current instant.
- [x] Backfill still resolves through the saved timezone: `parseLoggedAt` / `resolveWriteLoggedAt` are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)