### PR TITLE
fix(widgets): let every metric on the strip open the meals behind it

### DIFF
--- a/public/widgets/STYLE_GUIDE.md
+++ b/public/widgets/STYLE_GUIDE.md
@@ -475,8 +475,9 @@ one function:
 // wording: { under: "left" | "under", over: "over" } — default "left" / "over".
 //          trends uses { under: "under" } ("421 kcal under"). FLOORS only;
 //          a ceiling always reads "under" / "over" / "at limit".
-// meals:   optional per-meal breakdown rows → the calorie row and the three
-//          macro bars become tappable. Omit them and the strip is fully static.
+// meals:   optional per-meal breakdown rows → every tile some meal actually
+//          contributed to becomes tappable, the limits row included. Omit them
+//          and the strip is fully static.
 // opts:    optional {
 //            drinkUnit: "us" | "uk",     // alcohol's caption gloss; default "us"
 //            calLabel: string,           // label above the calorie figure;
@@ -681,10 +682,17 @@ screen readers either skip it or say "middle dot"). Do not shorten that name bac
 the action alone — a static tile reads out its numbers, and the interactive one
 beside it must not read out fewer.
 
-This applies to exactly four tiles: **the calorie row and the three macro bars**. A
-limit cell discloses nothing, so it is never a button (`macroLimit` passes
-`interactive = false`), and `macros.test.ts` asserts the set of buttons is
-`calories, protein_g, carbs_g, fat_g` and nothing else. The alternative — moving
+This applies to **every tile with meals behind it** — the calorie row, the three
+macro bars and the limits row alike. The gate is per tile and data-driven, not per
+kind: `macroHasDetail(m, ctx)` asks whether any meal contributed a positive amount
+of that metric, so a sugar or caffeine cell is a button on the same terms a protein
+bar is, while an alcohol cell reading "none logged" stays static rather than opening
+an empty list. Water is never a button and needs no special case — water is logged
+separately, so no meal row carries `water_ml`. `macros.test.ts` pins both halves.
+Every metric on the strip is in `MEAL_BREAKDOWN_ITEM` (`src/mcp.ts`), which is what
+makes the uniform rule possible; the breakdown gives grams a tenth even where the
+tile above rounds them whole, and keeps kcal and caffeine's milligrams whole. The
+alternative — moving
 `role="button"` to an inner element so the values stay exposed — was rejected: the
 whole tile is the tap target, so the button would either be smaller than what
 responds to a tap or would nest a second target inside the first.

--- a/public/widgets/macros.test.ts
+++ b/public/widgets/macros.test.ts
@@ -27,7 +27,7 @@ const macrosApi = await (async () => {
     const factory = new Function(
         "fmt",
         "esc",
-        `${src}\nreturn { macroBits, MACROS, macroPanel, macroLimit, macroCtxOf, dayHasData };`,
+        `${src}\nreturn { macroBits, MACROS, macroPanel, macroLimit, macroCtxOf, dayHasData, mealList };`,
     );
     return factory(fmt, esc) as {
         macroBits: (
@@ -44,7 +44,7 @@ const macrosApi = await (async () => {
             meals?: unknown[],
             opts?: { drinkUnit?: string },
         ) => string;
-        macroLimit: (m: Macro, ctx: unknown) => string;
+        macroLimit: (m: Macro, ctx: unknown, interactive?: boolean) => string;
         macroCtxOf: (
             vals: Vals,
             goal?: Vals | null,
@@ -53,6 +53,7 @@ const macrosApi = await (async () => {
             opts?: { drinkUnit?: string },
         ) => unknown;
         dayHasData: (day: Vals) => boolean;
+        mealList: (m: Macro, meals: unknown[]) => string;
     };
 })();
 
@@ -161,8 +162,35 @@ const GOALS = {
     caffeine_mg: 400,
     water_ml: 2500,
 };
+// Two meals carrying every metric the strip shows — except alcohol, which both
+// record as a real 0. That is not padding: it makes this fixture cover both
+// halves of the per-tile gate at once, since a tile is a button only when some
+// meal actually contributed to it.
 const MEALS = [
-    { description: "Porridge", calories: 400, protein_g: 12, carbs_g: 60 },
+    {
+        description: "Porridge",
+        meal_type: "breakfast",
+        calories: 400,
+        protein_g: 12,
+        carbs_g: 60,
+        fat_g: 8,
+        fiber_g: 9.4,
+        sugar_g: 12.2,
+        alcohol_g: 0,
+        caffeine_mg: null,
+    },
+    {
+        description: "Flat white",
+        meal_type: "snack",
+        calories: 120,
+        protein_g: 6,
+        carbs_g: 9,
+        fat_g: 6,
+        fiber_g: 0,
+        sugar_g: 8.1,
+        alcohol_g: 0,
+        caffeine_mg: 185,
+    },
 ];
 
 // Every tile that is a button, by macro key → its accessible name.
@@ -185,14 +213,83 @@ test("an interactive tile names its value and goal state, then the action", () =
     expect(labels.carbs_g).toBe(
         "Carbs 205 g, of 220 g, 15 g left. Show the meals that contributed.",
     );
-    // The calorie row and the three macro bars, and nothing else — a limit
-    // cell discloses nothing, so it is never a button.
+    // A limit cell is a button on the same terms as a macro bar — every metric
+    // on the strip is in MEAL_BREAKDOWN_ITEM, so "tap a metric" means any of
+    // them. Its name carries the ceiling and the distance to it.
+    expect(labels.sugar_g).toBe(
+        "Sugar 58.2 g, limit 45 g, 13.2 g over. Show the meals that contributed.",
+    );
+    expect(labels.caffeine_mg).toBe(
+        "Caffeine 185 mg, limit 400 mg, 215 mg under. Show the meals that contributed.",
+    );
+    // Alcohol is the exception, and not by type: both meals recorded a real 0,
+    // so there is nothing behind that cell and it stays the static cell it
+    // always was rather than a button onto an empty list.
     expect(Object.keys(labels).sort()).toEqual([
+        "caffeine_mg",
         "calories",
         "carbs_g",
         "fat_g",
+        "fiber_g",
         "protein_g",
+        "sugar_g",
     ]);
+});
+
+// The gate is per tile, not per strip: the same panel can hold a button and a
+// static cell of the same kind, decided only by whether a meal contributed.
+test("a limit cell is a button only when meals are behind it", () => {
+    const withAlcohol = [
+        { ...MEALS[0], description: "Pinot", alcohol_g: 12.5 },
+    ];
+    expect(
+        tileLabels(macrosApi.macroPanel(VALS, GOALS, undefined, withAlcohol))
+            .alcohol_g,
+    ).toBe(
+        "Alcohol 12.5 g, limit 20 g, 7.5 g under. Show the meals that contributed.",
+    );
+    // …and a metric no meal touched is not tappable even though its cell is on
+    // screen: a recorded 0 earns alcohol and caffeine a cell (that is the whole
+    // point of their null signal), but never a button onto nothing.
+    const zeroed = { ...VALS, alcohol_g: 0, caffeine_mg: 0 };
+    const html = macrosApi.macroPanel(zeroed, GOALS, undefined, [
+        { ...MEALS[0], alcohol_g: 0, caffeine_mg: 0 },
+    ]);
+    expect(html).toContain("none logged");
+    expect(tileLabels(html).alcohol_g).toBeUndefined();
+    expect(tileLabels(html).caffeine_mg).toBeUndefined();
+});
+
+// A single meal contributes a fraction of the day, so the breakdown needs a
+// finer figure than the strip above it — but only where the unit has one. Both
+// halves matter: without the tenth a 12.2 g and an 8.1 g meal sort into an
+// order the list does not explain, and with it caffeine reads "185.0 mg".
+test("the breakdown gives grams a tenth and keeps whole units whole", () => {
+    const list = (key: string, meals: unknown[] = MEALS) =>
+        macrosApi.mealList(macroOf(key), meals);
+    const val = (key: string, v: number) =>
+        list(key, [{ description: "One meal", [key]: v }]);
+    // Grams to a tenth, whatever the strip above rounds them to: the macro
+    // bars show whole grams, the limits row a tenth, and the breakdown under
+    // both is at meal scale.
+    expect(val("protein_g", 42.4)).toContain(
+        '42.4<span class="md-unit">g</span>',
+    );
+    expect(val("sugar_g", 12.24)).toContain(
+        '12.2<span class="md-unit">g</span>',
+    );
+    // Whole units stay whole — kcal, and the milligrams the payload happens to
+    // round to a tenth.
+    expect(val("caffeine_mg", 185.4)).toContain(
+        '185<span class="md-unit">mg</span>',
+    );
+    expect(val("calories", 400)).toContain(
+        '400<span class="md-unit">kcal</span>',
+    );
+    // Sorted largest-first, and a meal that contributed none of the metric is
+    // left out entirely rather than listed as a 0.
+    expect(list("caffeine_mg")).toContain("Flat white");
+    expect(list("caffeine_mg")).not.toContain("Porridge");
 });
 
 // Hover and a cursor are the whole affordance on a pointer device, and a
@@ -242,11 +339,18 @@ test("every interactive tile carries its formatted value, and none is spoken as 
         );
         expect(Object.keys(labels).length).toBeGreaterThan(0);
         for (const [key, label] of Object.entries(labels)) {
-            const m = macroOf(key) as Macro & { label: string; unit: string };
-            // Hero and ring tiles — the only interactive ones — are whole
-            // numbers, so the value reads exactly as it does on screen.
+            const m = macroOf(key) as Macro & {
+                label: string;
+                unit: string;
+                decimals: number;
+            };
+            // At the tile's own precision, so the spoken value reads exactly
+            // as the one on screen — a tenth for the limits row, whole for
+            // calories, the macro bars and caffeine's milligrams.
             expect(
-                label.startsWith(`${m.label} ${fmt(vals[key]!, 0)} ${m.unit},`),
+                label.startsWith(
+                    `${m.label} ${fmt(vals[key]!, m.decimals)} ${m.unit},`,
+                ),
             ).toBe(true);
             // "·" is decoration a screen reader either skips or calls
             // "middle dot"; the spoken name separates with a comma.
@@ -447,7 +551,9 @@ test("caffeine is milligrams alone — the drink gloss is alcohol's only", () =>
 
 // Caffeine carries zero kcal, so it is a limit cell and nothing else: never a
 // macro bar, never a segment of an energy split, and never evidence that a day
-// was logged.
+// was logged. Being tappable does not change that — the limits row discloses
+// its meals exactly like the bars above it while staying a different kind of
+// thing.
 test("caffeine is a limit, not a macro", () => {
     const m = macroOf("caffeine_mg") as Macro & {
         role: string;
@@ -455,9 +561,10 @@ test("caffeine is a limit, not a macro", () => {
     };
     expect(m.role).toBe("limit");
     expect(m.parent).toBeUndefined();
-    expect(macrosApi.macroPanel(VALS, GOALS, undefined, MEALS)).not.toContain(
-        'data-macro="caffeine_mg"',
-    );
+    const html = macrosApi.macroPanel(VALS, GOALS, undefined, MEALS);
+    // limitKeys drops the first three names, which are the macro bars — so
+    // finding Caffeine here is proof it is not one of them.
+    expect(limitKeys(html)).toContain("Caffeine");
     expect(macrosApi.dayHasData({ caffeine_mg: 185 })).toBe(false);
 });
 

--- a/public/widgets/src/shared/macros.js
+++ b/public/widgets/src/shared/macros.js
@@ -251,12 +251,24 @@ function ringMarkup(m, b) {
       </div>`;
 }
 
-// Is there anything behind this tile to disclose? Only the meals that
-// contributed to it — fiber and sugar used to hide inside the carbs
-// disclosure and now have cells of their own in the limits row, so a strip
-// built without meals is entirely static.
-function macroHasDetail(ctx) {
-    return !!ctx.meals;
+// Is there anything behind THIS tile to disclose? Two conditions, and both
+// matter:
+//
+//   1. the widget passed per-meal rows at all (trends does not, so its strip is
+//      entirely static), and
+//   2. at least one of those meals contributed a positive amount of this
+//      metric.
+//
+// The second is what keeps a tile from being a button that opens an empty list.
+// Every metric on the strip is in MEAL_BREAKDOWN_ITEM (src/mcp.ts) — the limits
+// row included — so the test is the same one for all of them: a limit cell is
+// tappable exactly when meals are behind it, and an alcohol cell reading "none
+// logged" stays the static cell it always was. Water is never interactive by
+// the same rule and needs no special case: water is logged separately and no
+// meal row carries `water_ml`.
+function macroHasDetail(m, ctx) {
+    if (!ctx.meals) return false;
+    return ctx.meals.some((meal) => (Number(meal?.[m.key]) || 0) > 0);
 }
 
 // The accessible name of an interactive tile — VALUE FIRST, action second.
@@ -370,7 +382,7 @@ function limitShown(m, ctx) {
 // gloss ("2.0 US drinks · limit 20 g"); caffeine has no second unit anyone
 // thinks in, so it is milligrams alone. A metric recorded as none reads that
 // way in words rather than as a 0 that looks like a measurement.
-function macroLimit(m, ctx) {
+function macroLimit(m, ctx, interactive) {
     // The gate again, so the cell builder is safe to call on its own and can
     // never invent a reading the strip would have suppressed.
     if (!limitShown(m, ctx)) return "";
@@ -398,7 +410,7 @@ function macroLimit(m, ctx) {
     if (b.deltaStr && (b.over || b.deltaStr === "at limit")) {
         cap = `${cap} · ${b.deltaStr}`;
     }
-    return macroTile(m, b, num, cap, false);
+    return macroTile(m, b, num, cap, interactive);
 }
 
 // Water — one line, in litres. The payload is millilitres because that is what
@@ -461,8 +473,9 @@ function gridCols(n) {
 //
 // `meals` is optional: when a non-empty array of per-meal breakdown rows is
 // passed (each { description, meal_type, date, calories, protein_g, carbs_g,
-// fat_g, ... }), the calorie row and the macro bars become tappable and reveal
-// the meals that contributed to that metric (see macroToggle).
+// fat_g, fiber_g, sugar_g, alcohol_g, caffeine_mg }), every tile some meal
+// contributed to becomes tappable and reveals those meals (see macroToggle) —
+// the limits row included, not just calories and the three bars.
 //
 // `opts` is optional: { drinkUnit: "us" | "uk", calLabel: string,
 // divided: boolean }.
@@ -483,10 +496,15 @@ function macroPanel(vals, goal, wording, meals, opts) {
         (m) => m.role === "bar" && (ctx.vals[m.key] ?? 0) > 0,
     );
 
-    const interactive = macroHasDetail(ctx);
+    // Per tile, not per strip: every metric on the strip has per-meal figures
+    // behind it, but only the ones some meal actually contributed to are worth
+    // opening. The strip itself is interactive if any of its tiles is — that is
+    // what earns the hint line and the region the breakdown renders into.
+    const tap = (m) => macroHasDetail(m, ctx);
+    const interactive = [cal, ...trio, ...limits].some(tap);
     const limitRow = limits.length
         ? `<div class="mgrid lim n${limits.length} psec" style="${gridCols(limits.length)}">${limits
-              .map((m) => macroLimit(m, ctx))
+              .map((m) => macroLimit(m, ctx, tap(m)))
               .join("")}
         </div>`
         : "";
@@ -507,10 +525,10 @@ function macroPanel(vals, goal, wording, meals, opts) {
     return `
       <div class="strip${ctx.divided ? " psec" : ""}"${interactive ? " data-macro-panel" : ""}>
         <div class="srow">
-          ${macroCal(cal, ctx, interactive)}
+          ${macroCal(cal, ctx, tap(cal))}
           <div class="sgrids">
             <div class="mgrid" style="${gridCols(3)}">${trio
-                .map((m) => macroBarTile(m, ctx, interactive))
+                .map((m) => macroBarTile(m, ctx, tap(m)))
                 .join("")}
             </div>
             ${limitRow}
@@ -530,7 +548,13 @@ let __macroCtx = null;
 // The list of meals that contributed a positive amount of one metric,
 // largest-first, capped so a long range stays readable.
 function mealList(m, meals) {
-    const decimals = m.key === "calories" ? 0 : 1;
+    // A single meal's contribution is a fraction of the day's, so grams get a
+    // tenth here even where the strip rounds them whole — a 3.4 g and a 3.1 g
+    // meal must not both read "3" in a list sorted by that very figure.
+    // Whole-unit metrics keep their unit: kcal and mg of caffeine are quoted
+    // whole at every scale (see the MACROS entries), and a tenth of a
+    // milligram is below anything anyone can act on.
+    const decimals = m.decimals === 0 && m.unit === "g" ? 1 : m.decimals;
     const rows = meals
         .map((meal) => ({ meal, v: Number(meal?.[m.key] ?? 0) || 0 }))
         .filter((r) => r.v > 0)

--- a/scripts/widget-harness.ts
+++ b/scripts/widget-harness.ts
@@ -242,8 +242,11 @@ function hostPage(widget: string, params: URLSearchParams): string {
             goals,
             totals,
             has_goals: true,
-            // Deliberately empty: with no per-meal rows only CARBS is tappable
-            // (for fiber + sugar), which is the other disclosure path.
+            // Deliberately empty, so one macro widget covers the strip's
+            // static path: with no per-meal rows behind them, no tile is a
+            // button, the "tap a metric" hint is absent and every cell reads
+            // as the plain figure it always was. The interactive path is
+            // meal-logged and nutrition-summary below, which carry meals.
             meals: [],
         },
         "meal-logged": {


### PR DESCRIPTION
## The bug

Every macro widget carries the line **"👆 Tap a metric for the meals behind it"** — but it was only true of four tiles. Calories, protein, carbs and fat opened a breakdown; sugar, alcohol, caffeine and fiber did nothing, so the hint promised a disclosure four sevenths of the strip did not have.

`macroLimit` hardcoded `interactive = false` when building its cell, while `macroCal` and `macroBarTile` both took the flag and passed it through.

## The fix

Nothing was missing from the payload — `MEAL_BREAKDOWN_ITEM` (`src/mcp.ts:400`) has carried per-meal `fiber_g`, `sugar_g`, `alcohol_g` and `caffeine_mg` all along. So this is client-side only:

- **`macroLimit` takes `interactive` and passes it through**, like the other two builders.
- **The gate moved from per strip to per tile.** `macroHasDetail` asked whether the widget passed meals at all; it now asks whether any meal contributed a positive amount of *this* metric. That is what keeps an alcohol cell reading "none logged" from becoming a button onto an empty list — a recorded 0 earns that cell its place (the whole point of its null signal) but never a disclosure. It fixes the same latent dead button on the macro bars, and water falls out non-interactive on its own with no special case: water is logged separately, so no meal row carries `water_ml`.
- **`mealList`'s decimals now come from the `MACROS` entry.** They were `calories ? 0 : 1`, written when only calories and the three bars could reach it — caffeine would have printed "185.0 mg". Grams get a tenth even where the tile above rounds them whole (a meal's contribution is a fraction of the day's, and the list is sorted by that very figure); kcal and caffeine's milligrams stay whole at every scale.

## Verified

In `bun run harness`, against the real assembled widgets:

- The a11y tree now exposes **seven** buttons instead of four, each naming its own value and goal state (`"Caffeine 185 mg, limit 400 mg, 215 mg under. Show the meals that contributed."`).
- Tapping caffeine opens `CAFFEINE BY MEAL → 470 mg · Double espresso · Snack`; alcohol opens across a multi-day range with its date tag.
- The iframe re-reports its height on open (323 → 376), so the host grows instead of clipping.
- Light and dark, and `goal-progress` (which the harness hands `meals: []`) still renders fully static with no hint line.

## Tests

`public/widgets/macros.test.ts` pinned the old contract explicitly — `asserts the set of buttons is calories, protein_g, carbs_g, fat_g and nothing else` — so that assertion is replaced, along with two tests that assumed only whole-number tiles could be interactive. The `MEALS` fixture now records a real 0 for alcohol, so one panel covers both halves of the gate. New tests cover the per-tile gate and the breakdown's decimals.

577 pass / 0 fail; `typecheck` and `format:check` clean.

Also corrects a `STYLE_GUIDE.md` section and a harness comment that both described a carbs disclosure which stopped existing when fiber and sugar moved into the limits row.

## Note on shipping

Merging to `main` deploys to production, so this reaches every client as soon as the deploy finishes. No version bump or tag is needed — widget assembly happens at server startup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
