### PR TITLE
fix(meals): recompute the auto: idempotency key on update_meal

### DIFF
--- a/src/supabase.test.ts
+++ b/src/supabase.test.ts
@@ -1,6 +1,7 @@
 import { test, expect, describe } from "bun:test";
 import {
     mealIdempotencyKey,
+    updatedMealIdempotencyKey,
     widgetsEnabledFromProfile,
     alcoholTrackingEnabledFromProfile,
     preferredDrinkUnitFromProfile,
@@ -8,6 +9,7 @@ import {
     fetchAllPages,
     timezoneLevels,
     TZ_LEVEL_THRESHOLDS,
+    type Meal,
     type MealInput,
     type Profile,
 } from "./supabase.js";
@@ -145,6 +147,109 @@ describe("mealIdempotencyKey", () => {
             caffeine_mg: 95,
         });
         expect(key(input)).toBe(`auto:${rowContentDigest(USER, input)}`);
+    });
+});
+
+function existingMeal(overrides: Partial<Meal> = {}): Meal {
+    return {
+        id: "33333333-3333-4333-8333-333333333333",
+        user_id: USER,
+        logged_at: LOGGED_AT,
+        meal_type: "breakfast",
+        description: "oat porridge with berries",
+        calories: 300,
+        protein_g: 12,
+        carbs_g: 45,
+        fat_g: 8,
+        fiber_g: null,
+        sugar_g: null,
+        alcohol_g: null,
+        caffeine_mg: null,
+        notes: "made with milk",
+        idempotency_key: key(meal()),
+        ...overrides,
+    };
+}
+
+describe("updatedMealIdempotencyKey", () => {
+    test("recomputes the digest when an edit changes content, for an auto: key", () => {
+        const existing = existingMeal();
+        const updated = updatedMealIdempotencyKey(USER, existing, {
+            calories: 600,
+        });
+
+        expect(updated).not.toBeNull();
+        // Differs from the pre-edit row's key...
+        expect(updated).not.toBe(existing.idempotency_key);
+        // ...and from what the ORIGINAL (pre-edit) content would still hash to
+        // — this is the #84 replay case: a replay of the original log_meal
+        // call must no longer dedupe onto the corrected row.
+        expect(updated).not.toBe(key(meal()));
+        // It matches recomputing over the merged (post-edit) content.
+        expect(updated).toBe(key(meal({ calories: 600 })));
+    });
+
+    test("a caller-supplied idempotency_key is left untouched", () => {
+        const existing = existingMeal({
+            idempotency_key: "client-supplied-key-123",
+        });
+        expect(
+            updatedMealIdempotencyKey(USER, existing, { calories: 600 }),
+        ).toBeNull();
+    });
+
+    test("a row with idempotency_key: null returns null", () => {
+        const existing = existingMeal({ idempotency_key: null });
+        expect(
+            updatedMealIdempotencyKey(USER, existing, { calories: 600 }),
+        ).toBeNull();
+    });
+
+    test("fields not passed in the update fall back to the existing row's content", () => {
+        const existing = existingMeal();
+        const updated = updatedMealIdempotencyKey(USER, existing, {
+            notes: "made with oat milk",
+        });
+
+        expect(updated).toBe(key(meal({ notes: "made with oat milk" })));
+    });
+
+    test("editing fiber_g/sugar_g/alcohol_g/caffeine_mg alone does not change the recomputed key", () => {
+        const existing = existingMeal();
+        const updated = updatedMealIdempotencyKey(USER, existing, {
+            fiber_g: 6.2,
+            sugar_g: 14.5,
+            alcohol_g: 3.1,
+            caffeine_mg: 95,
+        });
+
+        expect(updated).toBe(existing.idempotency_key);
+    });
+
+    test("editing logged_at changes the key to match the new timestamp", () => {
+        const existing = existingMeal();
+        const newLoggedAt = "2026-03-15T12:00:00.000Z";
+        const updated = updatedMealIdempotencyKey(USER, existing, {
+            logged_at: newLoggedAt,
+        });
+
+        expect(updated).toBe(key(meal(), USER, newLoggedAt));
+    });
+
+    test("an existing row's logged_at in PostgREST's +00:00 form recomputes the same key a fresh identical log_meal call would produce", () => {
+        // PostgREST renders timestamptz as "+00:00" (and drops an all-zero
+        // fractional part), never as the "Z"-suffixed, millisecond-padded
+        // form every write path hashes with. A row fetched back from the DB
+        // carries the former; verify the fallback canonicalizes it before
+        // hashing, rather than baking the DB's rendering into the key.
+        const existing = existingMeal({
+            logged_at: "2026-03-14T12:00:00+00:00",
+        });
+        const updated = updatedMealIdempotencyKey(USER, existing, {
+            calories: 600,
+        });
+
+        expect(updated).toBe(key(meal({ calories: 600 })));
     });
 });
 

--- a/src/supabase.ts
+++ b/src/supabase.ts
@@ -183,6 +183,58 @@ export function mealIdempotencyKey(
     ]);
 }
 
+/**
+ * The idempotency key updateMeal should persist for `fields` applied on top
+ * of `existing`, or null when the row's current key must be left alone.
+ *
+ * mealIdempotencyKey derives a content digest so retries dedupe without a
+ * client-supplied key — but updateMeal never recomputed it, so editing a
+ * meal's content left the digest describing the pre-edit content (#84): a
+ * replay of the ORIGINAL log_meal call then deduped onto the corrected row
+ * ("Meal already logged"), while re-logging the CORRECTED content created a
+ * duplicate. Recomputing over the merged (existing + changed) fields keeps
+ * the key describing what the row now says.
+ *
+ * Only when the current key is "auto:"-prefixed: a caller-supplied key
+ * encodes the caller's own request-level idempotency choice, which
+ * updateMeal must not override.
+ */
+export function updatedMealIdempotencyKey(
+    userId: string,
+    existing: Meal,
+    fields: Partial<MealInput>,
+): string | null {
+    if (!existing.idempotency_key?.startsWith("auto:")) return null;
+
+    const merged: MealInput = {
+        description: fields.description ?? existing.description,
+        meal_type:
+            (fields.meal_type as MealInput["meal_type"] | undefined) ??
+            (existing.meal_type as MealInput["meal_type"]),
+        calories:
+            fields.calories !== undefined
+                ? toStoredInteger(fields.calories)
+                : (existing.calories ?? undefined),
+        protein_g: fields.protein_g ?? existing.protein_g ?? undefined,
+        carbs_g: fields.carbs_g ?? existing.carbs_g ?? undefined,
+        fat_g: fields.fat_g ?? existing.fat_g ?? undefined,
+        notes: fields.notes ?? existing.notes ?? undefined,
+    };
+    // existing.logged_at came back through PostgREST, which renders
+    // timestamptz as "+00:00" (and drops an all-zero fractional part) —
+    // never as the "Z"-suffixed, millisecond-padded form every write path
+    // hashes (new Date().toISOString(), here and in insertMeal/importMeals).
+    // Re-serializing through Date canonicalizes it back to that shared
+    // format. Skipping this made every edit that leaves logged_at untouched
+    // — the common case — persist a key a fresh, identical log_meal call
+    // could never reproduce, silently reopening the "duplicate on re-log"
+    // half of #84.
+    const loggedAt =
+        fields.logged_at ?? new Date(existing.logged_at).toISOString();
+
+    return mealIdempotencyKey(userId, merged, loggedAt);
+}
+
 export async function insertMeal(
     userId: string,
     input: MealInput,
@@ -499,6 +551,17 @@ export async function updateMeal(
     id: string,
     fields: Partial<MealInput>,
 ): Promise<Meal> {
+    const sb = getSupabase();
+
+    const { data: existing, error: selErr } = await sb
+        .from("meals")
+        .select("*")
+        .eq("id", id)
+        .eq("user_id", userId)
+        .maybeSingle();
+    if (selErr) throw new Error(`Failed to update meal: ${selErr.message}`);
+    if (!existing) throw new Error("Failed to update meal: meal not found");
+
     const update: Record<string, unknown> = {};
     if (fields.description !== undefined)
         update.description = decodeEscapeSequences(fields.description);
@@ -521,7 +584,10 @@ export async function updateMeal(
                 ? decodeEscapeSequences(fields.notes)
                 : fields.notes;
 
-    const { data, error } = await getSupabase()
+    const newKey = updatedMealIdempotencyKey(userId, existing as Meal, fields);
+    if (newKey !== null) update.idempotency_key = newKey;
+
+    const { data, error } = await sb
         .from("meals")
         .update(update)
         .eq("id", id)


### PR DESCRIPTION
## Summary
- `updateMeal` never recomputed the content-derived `idempotency_key`, so correcting a meal's content (e.g. calories 500→600) left the digest describing the pre-edit content: a replay of the original `log_meal` call would then dedupe onto the corrected row ("Meal already logged"), and re-logging the corrected content would create a duplicate row.
- Added `updatedMealIdempotencyKey(userId, existing, fields)` — recomputes the `auto:` digest over the merged existing+edited fields, but only when the current key is itself server-derived (`"auto:"`-prefixed); a caller-supplied key is left untouched.
- `updateMeal` now fetches the existing row first and applies the recomputed key to the update patch when non-null; all prior field-copy logic is unchanged.
- Canonicalizes `logged_at` through `new Date(...).toISOString()` before hashing, since PostgREST renders `timestamptz` as `+00:00` rather than the `Z`-suffixed, millisecond-padded form every other write path hashes — skipping this would have silently reopened the duplicate-on-relog half of the bug for the common case of editing content without touching the timestamp.

Fixes #84.

## Test plan
- [x] `bun test` — 597 pass, 0 fail
- [x] `bun run typecheck` — clean
- [x] `bun run format:check` — clean
- [x] New tests in `src/supabase.test.ts` cover: recompute-on-edit, caller-supplied-key preservation, null-key rows, unedited fields falling back to existing content, fiber/sugar/alcohol/caffeine exclusion, `logged_at` edits, and the PostgREST timestamp-format round-trip

🤖 Generated with [Claude Code](https://claude.com/claude-code)