### PR TITLE
fix(profile): warn on unset timezone even when logged_at is omitted

### DIFF
--- a/src/mcp.test.ts
+++ b/src/mcp.test.ts
@@ -3266,6 +3266,28 @@ describe("manual write tools resolve logged_at in the profile timezone", () => {
         });
     });
 
+    // The most common call shape of all: no logged_at, because "I just ate
+    // this" never carries one. Found live — a meal logged this way with no
+    // profile timezone produced no warning, silently defeating #99's entire
+    // point for the overwhelming majority of real calls.
+    test("still warns when logged_at is omitted entirely and the timezone is unset", async () => {
+        db.profile = { ...PROFILE_BASE, timezone: null };
+        await withTools(null, async (call) => {
+            const text = textOf(await call("log_meal", oatmeal));
+            expect(text).toContain("set_timezone");
+            expect(text).toContain("no timezone set");
+            expect(loggedAtOf(db.inserted[0])).toBeUndefined();
+        });
+    });
+
+    test("no warning when logged_at is omitted and the timezone is configured", async () => {
+        db.profile = { ...PROFILE_BASE, timezone: "Europe/Kyiv" };
+        await withTools(null, async (call) => {
+            const text = textOf(await call("log_meal", oatmeal));
+            expect(text).not.toContain("set_timezone");
+        });
+    });
+
     // Water is bucketed into local days the same way meals are, so an
     // unresolved offset-less time moves a late-evening glass onto tomorrow's
     // hydration total.

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -1112,15 +1112,30 @@ function formatClockLine(tz: string): string {
 // UTC, an offset-less local time from a user east of UTC can resolve to a
 // future instant and be rejected, and "logged_at is in the future" on its own
 // names the wrong cause and gives the caller nothing to act on.
+//
+// It also has to fire when `raw` is omitted entirely — by far the most common
+// call shape, since "I just ate this" never carries a logged_at. The instant
+// itself doesn't need the timezone (the DB stamps "now" either way), but every
+// read path still buckets the entry into a local day using the same unset
+// profile, so staying silent here left the migration's whole warning
+// unreachable in practice (found live: a meal logged with no logged_at and no
+// profile timezone produced no warning at all).
 async function resolveWriteTimestamp(
     userId: string,
     raw: string | undefined,
 ): Promise<{ iso: string | undefined; note: string }> {
-    if (raw === undefined) return { iso: undefined, note: "" };
     const profile = await getProfile(userId);
     const tz = timezoneFromProfile(profile);
     const unsetTzNote = (value: string) =>
         `${JSON.stringify(value)} carries no UTC offset and this account has no timezone set, so it was read as UTC. Set one with set_timezone.`;
+
+    if (raw === undefined) {
+        const note =
+            tz === null
+                ? "\n\nNote: this account has no timezone set, so today's date is being read in UTC — set one with set_timezone."
+                : "";
+        return { iso: undefined, note };
+    }
 
     let resolved;
     try {


### PR DESCRIPTION
## Summary
- `resolveWriteTimestamp()` skipped the unset-timezone check entirely whenever `logged_at` was omitted — the default "log this now" call shape, and by far the most common one, since nobody passes `logged_at` for "I just ate this."
- Found live: after today's `nullable_profile_timezone` migration reset all 310 profiles to unset, logging a meal with no `logged_at` produced no warning at all, silently defeating #99's whole point for the overwhelming majority of real calls.
- Now the same unset-timezone note fires on the omitted-`logged_at` path too, matching the existing explicit-`logged_at` behavior.

## Test plan
- [x] `bun test` — 592 pass (added 2 new cases: warns when `logged_at` omitted + timezone unset, stays quiet when `logged_at` omitted + timezone configured)
- [x] `bun run typecheck` — clean
- [x] `bun run format` — unchanged
- [ ] Manual: log a meal/water/weight with no `logged_at` on an account with no timezone set, confirm the note appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)