### PR TITLE
test: pin the shutdown gate's position in the middleware chain

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,0 +1,156 @@
+import { test, expect, describe, afterEach } from "bun:test";
+import { app, setShuttingDownForTest } from "./index.js";
+
+// The shutdown gate (src/index.ts) exists because closing the MCP handler while
+// Bun.serve keeps accepting turns every in-flight POST /mcp into a 500 that a
+// connector reads as a tool failure. The fix is only worth anything if the gate
+// sits in the right place in the middleware chain: AFTER cors (so a browser
+// client sees the 503 instead of an opaque CORS error) and BEFORE
+// authenticateBearer and the /mcp route (so it answers without doing work).
+//
+// Position is not something a unit test of the middleware in isolation can
+// check, so these drive the real `app` — importing it is side-effect free
+// because the boot block is guarded on import.meta.main.
+//
+// Every assertion below is about ORDER. If someone later moves the gate under
+// app.route("/", createOAuthRouter()) or under the /mcp chain, the responses
+// change from 503 to 401/200 and these fail.
+
+afterEach(() => {
+    setShuttingDownForTest(false);
+});
+
+describe("the shutdown gate", () => {
+    test("is inert until shutdown begins", async () => {
+        // Baseline: without the flag, /mcp reaches authenticateBearer and is
+        // rejected for the missing token. This is what proves the 503s below
+        // come from the gate and not from something else refusing the request.
+        const r = await app.request("http://x/mcp", {
+            method: "POST",
+            headers: { "content-type": "application/json" },
+            body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "ping" }),
+        });
+        expect(r.status).toBe(401);
+    });
+
+    test("runs before authenticateBearer on /mcp", async () => {
+        setShuttingDownForTest(true);
+        const r = await app.request("http://x/mcp", {
+            method: "POST",
+            headers: { "content-type": "application/json" },
+            body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "ping" }),
+        });
+        // 503 rather than the 401 the same request gets above: the gate got
+        // there first. A gate registered after the /mcp chain would 401.
+        expect(r.status).toBe(503);
+        expect(r.headers.get("Retry-After")).toBe("1");
+    });
+
+    test("answers /mcp in the JSON-RPC envelope a client can surface", async () => {
+        setShuttingDownForTest(true);
+        const r = await app.request("http://x/mcp", {
+            method: "POST",
+            headers: { "content-type": "application/json" },
+            body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "ping" }),
+        });
+        const body = (await r.json()) as {
+            jsonrpc?: string;
+            id?: unknown;
+            error?: { code?: number; message?: string };
+        };
+        // The flat {"error": …} shape used elsewhere in index.ts is not
+        // something an MCP client can surface — it reports a bare transport
+        // failure with no reason.
+        expect(body.jsonrpc).toBe("2.0");
+        expect(body.id).toBeNull();
+        expect(body.error?.code).toBe(-32000);
+        expect(body.error?.message).toContain("shutting down");
+    });
+
+    test("runs before the OAuth router and the landing page", async () => {
+        setShuttingDownForTest(true);
+        for (const path of ["/", "/authorize", "/api/stats"]) {
+            const r = await app.request(`http://x${path}`);
+            expect({ path, status: r.status }).toEqual({ path, status: 503 });
+            expect(r.headers.get("Retry-After")).toBe("1");
+            expect(await r.json()).toEqual({ error: "shutting_down" });
+        }
+    });
+
+    test("gates /health too, so the load balancer stops routing here", async () => {
+        setShuttingDownForTest(true);
+        const r = await app.request("http://x/health");
+        // Deliberate: a health check that starts failing is how the platform
+        // learns to drain this instance. If someone exempts /health to keep it
+        // "green", the drain stops working and this test should stop them.
+        expect(r.status).toBe(503);
+    });
+
+    test("sits after cors, so the refusal still carries Allow-Origin", async () => {
+        setShuttingDownForTest(true);
+        const r = await app.request("http://x/mcp", {
+            method: "POST",
+            headers: {
+                "content-type": "application/json",
+                Origin: "http://localhost:3000",
+            },
+            body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "ping" }),
+        });
+        expect(r.status).toBe(503);
+        // Without this a browser client sees an opaque CORS error rather than
+        // the reason it was refused.
+        expect(r.headers.get("Access-Control-Allow-Origin")).toBe(
+            "http://localhost:3000",
+        );
+    });
+
+    test("lets cors answer preflights itself, gate or no gate", async () => {
+        setShuttingDownForTest(true);
+        const r = await app.request("http://x/mcp", {
+            method: "OPTIONS",
+            headers: {
+                Origin: "http://localhost:3000",
+                "Access-Control-Request-Method": "POST",
+                "Access-Control-Request-Headers": "Mcp-Param-Foo",
+            },
+        });
+        // cors() short-circuits OPTIONS without calling next(), so a preflight
+        // never reaches the gate. This is what keeps the browser's preflight
+        // from failing during a drain.
+        expect(r.status).toBe(204);
+    });
+});
+
+describe("CORS allow-headers", () => {
+    test("reflects the requested headers, covering the Mcp-Param-* family", async () => {
+        // A static allowHeaders list cannot cover Mcp-Param-*, which is
+        // open-ended by protocol. Reflection is safe here only because `origin`
+        // is a strict allowlist and credentials is false — if someone adds
+        // credentials:true, that pairing becomes unsafe and this test's comment
+        // is the warning.
+        const r = await app.request("http://x/mcp", {
+            method: "OPTIONS",
+            headers: {
+                Origin: "http://localhost:3000",
+                "Access-Control-Request-Method": "POST",
+                "Access-Control-Request-Headers":
+                    "Mcp-Param-Foo, Mcp-Method, Authorization",
+            },
+        });
+        expect(r.status).toBe(204);
+        expect(r.headers.get("Access-Control-Allow-Headers")).toBe(
+            "Mcp-Param-Foo,Mcp-Method,Authorization",
+        );
+    });
+
+    test("refuses an origin outside the allowlist", async () => {
+        const r = await app.request("http://x/mcp", {
+            method: "OPTIONS",
+            headers: {
+                Origin: "https://evil.example",
+                "Access-Control-Request-Method": "POST",
+            },
+        });
+        expect(r.headers.get("Access-Control-Allow-Origin")).toBeNull();
+    });
+});

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,5 +1,17 @@
 import { test, expect, describe, afterEach } from "bun:test";
-import { app, setShuttingDownForTest } from "./index.js";
+
+// index.ts calls createOAuthRouter() at module scope, and that throws when the
+// OAuth env is unset (src/oauth.ts). Bun auto-loads .env, so a static import
+// here passes on a dev machine and fails on CI, which has no .env — that is
+// exactly how this file first went red on Linux while green on macOS.
+//
+// The defaults have to be set BEFORE index.js is evaluated, and a static import
+// would hoist above these lines, so the import is dynamic. Same values as
+// src/oauth.test.ts, and ||= so a real .env still wins.
+process.env.OAUTH_CLIENT_ID ||= "test-client-id";
+process.env.OAUTH_CLIENT_SECRET ||= "test-client-secret";
+
+const { app, setShuttingDownForTest } = await import("./index.js");
 
 // The shutdown gate (src/index.ts) exists because closing the MCP handler while
 // Bun.serve keeps accepting turns every in-flight POST /mcp into a 500 that a

--- a/src/index.ts
+++ b/src/index.ts
@@ -114,6 +114,15 @@ app.use(
 // client sees the 503 rather than an opaque CORS error) and is still access
 // logged. OPTIONS preflights never reach it: cors() answers those itself.
 let shuttingDown = false;
+
+// Exported for src/index.test.ts. The gate's entire value is WHERE it sits — it
+// must run before authenticateBearer and before the /mcp route, which only the
+// real `app` can demonstrate. The test flips the flag directly rather than
+// calling shutdown(), which would exit the test runner.
+export function setShuttingDownForTest(value: boolean): void {
+    shuttingDown = value;
+}
+
 app.use("*", async (c, next) => {
     if (!shuttingDown) return next();
     const path = new URL(c.req.url).pathname;
@@ -317,14 +326,26 @@ app.onError((_err, c) => {
 
 const port = parseInt(process.env.PORT || "8080");
 
-console.log(`Nutrition MCP server listening on 0.0.0.0:${port}`);
+// Boot side effects run only when this file IS the entrypoint. src/index.test.ts
+// imports `app` to pin the shutdown gate's position in the middleware chain, and
+// an import must not start the export-sweep interval (which would hit Supabase
+// on a timer and hold the test process open) or register signal handlers.
+// `bun run src/index.ts` still takes this branch — verified: import.meta.main is
+// true for the entrypoint and false under `bun test`.
+if (import.meta.main) {
+    console.log(`Nutrition MCP server listening on 0.0.0.0:${port}`);
 
-// Assemble every MCP Apps widget from its source partials up front, so a broken
-// @include/partial fails fast at boot rather than on a client's first tool call.
-await warmWidgets();
+    // Assemble every MCP Apps widget from its source partials up front, so a
+    // broken @include/partial fails fast at boot rather than on a client's
+    // first tool call.
+    await warmWidgets();
 
-// Periodically delete expired meal-export files from the storage bucket.
-startExportCleanup();
+    // Periodically delete expired meal-export files from the storage bucket.
+    startExportCleanup();
+
+    process.on("SIGTERM", () => shutdown("SIGTERM"));
+    process.on("SIGINT", () => shutdown("SIGINT"));
+}
 
 // Exit cleanly on shutdown signals (e.g. deploys). /mcp is stateless — no
 // server-side sessions are held — so the only thing worth sequencing is the
@@ -352,8 +373,9 @@ function shutdown(signal: string): void {
         .catch((err) => console.error("Error closing MCP handler:", err))
         .finally(() => process.exit(0));
 }
-process.on("SIGTERM", () => shutdown("SIGTERM"));
-process.on("SIGINT", () => shutdown("SIGINT"));
+// Exported for src/index.test.ts, which drives the real route table through
+// app.request(). Bun serves from the default export below.
+export { app };
 
 export default {
     port,


### PR DESCRIPTION
Follow-up to #115. The graceful-shutdown gate shipped there had no test guarding the one property that makes it work.

## Why

The 503 gate's entire value is **where** it sits: after `cors` (so a browser client sees the refusal rather than an opaque CORS error) and before `authenticateBearer` and the `/mcp` route (so it answers without doing work). Nothing enforced that. A later edit moving it under the OAuth router or the `/mcp` chain would leave the gate registered and passing review while silently not covering the routes it exists for.

## What

- `src/index.ts` exports `app` so the test can drive the real route table.
- The boot block moves behind `import.meta.main`. An import must not start the export-sweep interval (a Supabase-hitting timer that would also hold the test process open) or register signal handlers.
- `src/index.test.ts` — 9 tests, all about ordering.

The load-bearing assertion: `POST /mcp` under shutdown returns **503 where the identical request returns 401 without it**. That difference is only possible if the gate precedes auth.

## Verification

**Mutation-tested.** Moving the gate below the `/mcp` route fails 4 of the 9; restoring it passes all 9. It catches the reorder it exists to catch.

**Production startup unaffected** — booted the entrypoint directly: listening line prints, `/health` → 200, CORS reflects, and `SIGTERM` still logs `Received SIGTERM, shutting down...` and exits cleanly. That last one matters, since the shutdown fix depends on a handler now registered inside the `import.meta.main` guard.

`import.meta.main` verified in Bun: `true` as entrypoint, `false` under `bun test`.

## Also pinned

- `/health` **is** gated during drain — deliberate. A failing health check is how the platform learns to stop routing here; exempting it to keep it "green" would break the drain.
- CORS header reflection (the `Mcp-Param-*` family cannot be listed statically) and that reflection stays paired with a strict origin allowlist.

## Gates

691 pass / 0 fail across 26 files (was 682/25). `typecheck` and `format:check` clean.

## Note

The real drain window still hasn't been observed in production. #115's deploy ran the *old* `process.exit(0)` shutdown, since that was the code receiving SIGTERM. The next merge to `main` is the first one that actually exercises the gate — worth watching for `Received SIGTERM` without a burst of 500s on `/mcp`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012hphsg3hVVUY5MPfTMKvKt