### PR TITLE
feat: record the negotiated protocol era on the access log

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -33,8 +33,14 @@ app.use("*", async (c, next) => {
     if (c.get("suppressAccessLog")) return;
     const ms = Math.round(performance.now() - start);
     const ip = maskIp(c.req.header("x-forwarded-for"));
+    // /mcp serves two protocol eras from one endpoint, and the only way to know
+    // when the 2025-11-25 leg can be retired is to count who still uses it.
+    // handleMcp publishes the era the SDK actually negotiated (not a guess from
+    // headers); requests refused before the factory runs carry none, and simply
+    // omit the field.
+    const era = c.get("mcpEra");
     console.log(
-        `[req] ${c.req.method} ${path} ${c.res.status} ${ms}ms ip=${ip}`,
+        `[req] ${c.req.method} ${path} ${c.res.status} ${ms}ms ip=${ip}${era ? ` era=${era}` : ""}`,
     );
 });
 

--- a/src/mcp.test.ts
+++ b/src/mcp.test.ts
@@ -4155,3 +4155,88 @@ describe("/mcp transport posture", () => {
         });
     });
 });
+
+// The access log in src/index.ts prints `era=…` from what handleMcp publishes on
+// the Hono context. It is the instrument for retiring the 2025-11-25 leg: when
+// nothing has logged era=legacy for a sustained window, flipping the SDK's
+// `legacy: "reject"` is safe. A guess derived from request headers would not be
+// trustworthy enough to make that call, so this asserts the value comes from the
+// era the SDK actually negotiated.
+describe("/mcp records the negotiated era for the access log", () => {
+    // Same wiring as appFor, plus the read the access log performs after the
+    // route resolves.
+    function recordingApp(userId: string, seen: (entry: string) => void) {
+        const app = new Hono();
+        app.all("/mcp", async (c) => {
+            c.set("userId", userId);
+            const res = await handleMcp(c);
+            seen(`${c.req.method}:${c.get("mcpEra") ?? "-"}`);
+            return res;
+        });
+        return app;
+    }
+
+    // Each entry is "METHOD:era" so the assertions can distinguish a request
+    // the SDK served from one this endpoint refused before the SDK saw it.
+    async function traceFor(mode: EraMode): Promise<string[]> {
+        const seen: string[] = [];
+        const app = recordingApp("era-user", (era) => seen.push(era));
+        const transport = new StreamableHTTPClientTransport(
+            new URL("http://test.local/mcp"),
+            { fetch: async (url, init) => app.request(String(url), init) },
+        );
+        const client = new Client(
+            { name: "t", version: "0" },
+            { versionNegotiation: { mode } },
+        );
+        await client.connect(transport);
+        try {
+            await client.listTools();
+        } finally {
+            await client.close();
+        }
+        return seen;
+    }
+
+    test("every served 2025-era request is recorded as legacy", async () => {
+        const seen = await traceFor("legacy");
+        const posts = seen.filter((s) => s.startsWith("POST:"));
+        // initialize, notifications/initialized (the 202) and tools/list. The
+        // 202 matters most: it is the marker that identifies a legacy client in
+        // the log, so it must carry the era like any other request.
+        expect(posts.length).toBeGreaterThanOrEqual(3);
+        expect(new Set(posts)).toEqual(new Set(["POST:legacy"]));
+    });
+
+    test("every served 2026-era request is recorded as modern", async () => {
+        const seen = await traceFor({ pin: "2026-07-28" });
+        const posts = seen.filter((s) => s.startsWith("POST:"));
+        expect(posts.length).toBeGreaterThan(0);
+        expect(new Set(posts)).toEqual(new Set(["POST:modern"]));
+    });
+
+    test("the refused GET stream carries no era, not a guessed one", async () => {
+        // A 2025-era client opens the standalone SSE stream with GET, which
+        // handleMcp answers 405 before the SDK runs — so nothing negotiates an
+        // era and the access log must omit the field.
+        const seen = await traceFor("legacy");
+        const gets = seen.filter((s) => s.startsWith("GET:"));
+        expect(gets.length).toBeGreaterThan(0);
+        expect(new Set(gets)).toEqual(new Set(["GET:-"]));
+    });
+
+    test("a request refused before the factory carries no era", async () => {
+        // 415: the SDK rejects on Content-Type before reading the body, so no
+        // server is built and nothing stamps the trace. Inventing an era here
+        // would corrupt the very count the legacy retirement decision rests on.
+        const seen: string[] = [];
+        const app = recordingApp("era-user", (era) => seen.push(era));
+        const r = await app.request("http://test.local/mcp", {
+            method: "POST",
+            headers: { "content-type": "text/plain" },
+            body: "not json",
+        });
+        expect(r.status).toBe(415);
+        expect(seen).toEqual(["POST:-"]);
+    });
+});

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -4482,8 +4482,23 @@ const IDENTITY_ONLY_METHODS = new Set([
 // The factory has no Hono context: the authenticated user arrives through the
 // `authInfo` pass-through (`extra.userId`, set in handleMcp from the bearer
 // middleware's verdict) and the public origin comes from the raw request.
+// Observability only, and the instrument that makes retiring the legacy leg a
+// measurable decision rather than a guess. The negotiated era is decided inside
+// the SDK and surfaces in exactly one place — `ctx.era` on the factory context —
+// so handleMcp passes a mutable holder down through the `authInfo` pass-through
+// for the factory to stamp on the way through. When no request has logged
+// era=legacy for a sustained window, flipping `legacy: "reject"` is safe.
+//
+// Requests refused before the factory runs (415, header/body mismatch,
+// unsupported revision) never get stamped, and log without an era rather than a
+// guessed one.
+export type McpEraTrace = { era?: "legacy" | "modern" };
+
 const mcpHandler = createMcpHandler(
     async (ctx: McpRequestContext) => {
+        const trace = ctx.authInfo?.extra?.trace as McpEraTrace | undefined;
+        if (trace) trace.era = ctx.era;
+
         const userId = ctx.authInfo?.extra?.userId;
         if (typeof userId !== "string" || userId.length === 0) {
             // handleMcp always sets it; reaching here means the /mcp route was
@@ -4602,14 +4617,21 @@ export const handleMcp = async (c: Context) => {
     // Nothing on the serve path reads it. The real bearer token is deliberately
     // NOT forwarded either — nothing downstream needs it, and keeping it out of
     // the SDK's context means no handler or error path can echo it.
-    return mcpHandler.fetch(c.req.raw, {
+    const trace: McpEraTrace = {};
+    const response = await mcpHandler.fetch(c.req.raw, {
         authInfo: {
             token: "",
             clientId: "",
             scopes: [],
-            extra: { userId },
+            extra: { userId, trace },
         },
     });
+
+    // Published for the access log in src/index.ts, which runs outermost and
+    // reads this after next() resolves. Set after fetch resolves, which is
+    // after the factory has run even when the response body is still streaming.
+    if (trace.era) c.set("mcpEra", trace.era);
+    return response;
 };
 
 // Aborts any in-flight 2026-era exchanges on shutdown. The legacy leg holds

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -12,6 +12,10 @@ declare module "hono" {
         userId: string;
         accessToken: string;
         suppressAccessLog: boolean;
+        // The protocol era /mcp actually negotiated for this request, set by
+        // handleMcp and read by the access log in index.ts. Optional: requests
+        // refused before the SDK builds a server never carry one.
+        mcpEra: "legacy" | "modern";
     }
 }
 import {


### PR DESCRIPTION
Makes retiring the 2025-11-25 leg a measurable decision instead of a guess.

`/mcp` serves two protocol eras from one endpoint. Dropping the legacy one is a **one-word change** — the SDK's `legacy: 'stateless'` → `'reject'` — so the hard part was never the code. It's knowing the moment it stops breaking people.

## What

The access line now carries the era:

```
[req] POST /mcp 200 134ms ip=1.2.3.x era=legacy
```

When nothing has logged `era=legacy` for a sustained window, flipping the SDK option is safe.

## Why it's the negotiated era, not a header guess

You don't stake a breaking change on a heuristic. The era surfaces in exactly one authoritative place — `ctx.era` on the server factory — so `handleMcp` passes a mutable holder through the `authInfo` pass-through and publishes what comes back on the Hono context. The access log, registered outermost, reads it after `next()` resolves.

## Requests that carry no era

Two paths are refused before a server is ever built, and they **omit** the field rather than inventing one:

- the SDK's 415 Content-Type gate
- the `GET` a 2025-era client uses to open the standalone SSE stream, which this endpoint answers 405 before the SDK sees it

Guessing there would corrupt the very count the retirement decision rests on.

## Tests

Both eras and both refusal paths. Note the `202` is asserted to carry the era like any other POST — `notifications/initialized` exists only in the 2025 handshake, so it's the marker that identifies a legacy client in the log, and it was the easiest one to miss.

## Gates

695 pass / 0 fail (was 691). `typecheck` and `format:check` clean. Log format verified by rendering it, not by reading the template string.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012hphsg3hVVUY5MPfTMKvKt