### PR TITLE
feat: name the MCP client on the access log

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -39,8 +39,13 @@ app.use("*", async (c, next) => {
     // headers); requests refused before the factory runs carry none, and simply
     // omit the field.
     const era = c.get("mcpEra");
+    // Which client is on which era. The era alone cannot tell a Claude surface
+    // from a third-party MCP client sharing an IP range, and that is the
+    // question the legacy retirement actually turns on. Absent when the
+    // protocol did not carry it — see the note on mcpClient in middleware.ts.
+    const client = c.get("mcpClient");
     console.log(
-        `[req] ${c.req.method} ${path} ${c.res.status} ${ms}ms ip=${ip}${era ? ` era=${era}` : ""}`,
+        `[req] ${c.req.method} ${path} ${c.res.status} ${ms}ms ip=${ip}${era ? ` era=${era}` : ""}${client ? ` client=${client}` : ""}`,
     );
 });
 

--- a/src/mcp.test.ts
+++ b/src/mcp.test.ts
@@ -4170,7 +4170,9 @@ describe("/mcp records the negotiated era for the access log", () => {
         app.all("/mcp", async (c) => {
             c.set("userId", userId);
             const res = await handleMcp(c);
-            seen(`${c.req.method}:${c.get("mcpEra") ?? "-"}`);
+            seen(
+                `${c.req.method}:${c.get("mcpEra") ?? "-"}:${c.get("mcpClient") ?? "-"}`,
+            );
             return res;
         });
         return app;
@@ -4178,17 +4180,22 @@ describe("/mcp records the negotiated era for the access log", () => {
 
     // Each entry is "METHOD:era" so the assertions can distinguish a request
     // the SDK served from one this endpoint refused before the SDK saw it.
-    async function traceFor(mode: EraMode): Promise<string[]> {
+    async function traceFor(
+        mode: EraMode,
+        identity: { name: string; version: string } = {
+            name: "t",
+            version: "0",
+        },
+    ): Promise<string[]> {
         const seen: string[] = [];
         const app = recordingApp("era-user", (era) => seen.push(era));
         const transport = new StreamableHTTPClientTransport(
             new URL("http://test.local/mcp"),
             { fetch: async (url, init) => app.request(String(url), init) },
         );
-        const client = new Client(
-            { name: "t", version: "0" },
-            { versionNegotiation: { mode } },
-        );
+        const client = new Client(identity, {
+            versionNegotiation: { mode },
+        });
         await client.connect(transport);
         try {
             await client.listTools();
@@ -4200,19 +4207,23 @@ describe("/mcp records the negotiated era for the access log", () => {
 
     test("every served 2025-era request is recorded as legacy", async () => {
         const seen = await traceFor("legacy");
-        const posts = seen.filter((s) => s.startsWith("POST:"));
+        const eras = seen
+            .filter((s) => s.startsWith("POST:"))
+            .map((s) => s.split(":")[1]);
         // initialize, notifications/initialized (the 202) and tools/list. The
         // 202 matters most: it is the marker that identifies a legacy client in
         // the log, so it must carry the era like any other request.
-        expect(posts.length).toBeGreaterThanOrEqual(3);
-        expect(new Set(posts)).toEqual(new Set(["POST:legacy"]));
+        expect(eras.length).toBeGreaterThanOrEqual(3);
+        expect(new Set(eras)).toEqual(new Set(["legacy"]));
     });
 
     test("every served 2026-era request is recorded as modern", async () => {
         const seen = await traceFor({ pin: "2026-07-28" });
-        const posts = seen.filter((s) => s.startsWith("POST:"));
-        expect(posts.length).toBeGreaterThan(0);
-        expect(new Set(posts)).toEqual(new Set(["POST:modern"]));
+        const eras = seen
+            .filter((s) => s.startsWith("POST:"))
+            .map((s) => s.split(":")[1]);
+        expect(eras.length).toBeGreaterThan(0);
+        expect(new Set(eras)).toEqual(new Set(["modern"]));
     });
 
     test("the refused GET stream carries no era, not a guessed one", async () => {
@@ -4220,9 +4231,78 @@ describe("/mcp records the negotiated era for the access log", () => {
         // handleMcp answers 405 before the SDK runs — so nothing negotiates an
         // era and the access log must omit the field.
         const seen = await traceFor("legacy");
-        const gets = seen.filter((s) => s.startsWith("GET:"));
+        const gets = seen
+            .filter((s) => s.startsWith("GET:"))
+            .map((s) => s.split(":")[1]);
         expect(gets.length).toBeGreaterThan(0);
-        expect(new Set(gets)).toEqual(new Set(["GET:-"]));
+        expect(new Set(gets)).toEqual(new Set(["-"]));
+    });
+
+    test("a 2026-era client is named on every request, from the envelope", async () => {
+        const seen = await traceFor(
+            { pin: "2026-07-28" },
+            {
+                name: "acme-client",
+                version: "9.9.9",
+            },
+        );
+        const clients = seen
+            .filter((s) => s.startsWith("POST:"))
+            .map((s) => s.split(":")[2]);
+        expect(clients.length).toBeGreaterThan(0);
+        // The modern envelope carries clientInfo on every request, so unlike the
+        // legacy leg there is no request that knows the era but not the client.
+        expect(new Set(clients)).toEqual(new Set(["acme-client/9.9.9"]));
+    });
+
+    test("a 2025-era client is named on initialize, the only request that carries it", async () => {
+        const seen = await traceFor("legacy", {
+            name: "acme-client",
+            version: "9.9.9",
+        });
+        const clients = seen
+            .filter((s) => s.startsWith("POST:"))
+            .map((s) => s.split(":")[2]);
+        // Documents a real limitation rather than papering over it: on the
+        // stateless legacy leg every request builds a fresh server and only
+        // `initialize` carries clientInfo, so the rest log no client. One named
+        // request per connection is still enough to answer who is on this leg.
+        expect(clients).toContain("acme-client/9.9.9");
+        expect(clients).toContain("-");
+    });
+
+    test("a client name cannot forge a log line", async () => {
+        // Same injection surface as the SDK error messages: this value is
+        // client-supplied and goes straight into the access line.
+        const seen = await traceFor(
+            { pin: "2026-07-28" },
+            {
+                name: "evil\n[req] POST /mcp 200 1ms ip=9.9.9.9",
+                version: "1.0",
+            },
+        );
+        const clients = seen
+            .filter((s) => s.startsWith("POST:"))
+            .map((s) => s.split(":")[2]);
+        for (const c of clients) {
+            expect(c).not.toContain("\n");
+            expect(c).not.toContain(" ");
+        }
+        expect(clients[0]).toBe("evil_[req]_POST_/mcp_200_1ms_ip=9.9.9.9/1.0");
+    });
+
+    test("an over-long client name cannot push the real fields off the line", async () => {
+        const seen = await traceFor(
+            { pin: "2026-07-28" },
+            {
+                name: "x".repeat(500),
+                version: "y".repeat(500),
+            },
+        );
+        const client = seen
+            .filter((s) => s.startsWith("POST:"))
+            .map((s) => s.split(":")[2])[0];
+        expect(client).toBe(`${"x".repeat(40)}/${"y".repeat(40)}`);
     });
 
     test("a request refused before the factory carries no era", async () => {
@@ -4237,6 +4317,6 @@ describe("/mcp records the negotiated era for the access log", () => {
             body: "not json",
         });
         expect(r.status).toBe(415);
-        expect(seen).toEqual(["POST:-"]);
+        expect(seen).toEqual(["POST:-:-"]);
     });
 });

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -4492,7 +4492,41 @@ const IDENTITY_ONLY_METHODS = new Set([
 // Requests refused before the factory runs (415, header/body mismatch,
 // unsupported revision) never get stamped, and log without an era rather than a
 // guessed one.
-export type McpEraTrace = { era?: "legacy" | "modern" };
+export type McpEraTrace = {
+    era?: "legacy" | "modern";
+    // The server built for this request, kept so handleMcp can read the client
+    // identity the SDK resolved. Only readable AFTER the exchange: on the modern
+    // leg the envelope backfills it per request, on the legacy leg only
+    // `initialize` carries clientInfo at all.
+    server?: McpServer;
+};
+
+// Client name and version are client-supplied strings that go straight into a
+// log line, which is the injection surface finding #3 was about — a raw value
+// could carry newlines and forge "[req] …" entries. Strip everything outside
+// printable ASCII, collapse whitespace so a value cannot fake a field break, and
+// cap the length so a long name cannot push the real fields off the line.
+function logSafeClient(
+    info:
+        | {
+              name?: string;
+              version?: string;
+          }
+        | undefined,
+): string | undefined {
+    const clean = (value: string) =>
+        value
+            // Non-printables become "_" rather than vanishing: a deleted
+            // newline silently welds the text on either side of it together,
+            // which hides what the client actually sent.
+            .replace(/[^\x20-\x7E]/g, "_")
+            .replace(/\s+/g, "_")
+            .slice(0, 40);
+    const name = info?.name ? clean(info.name) : "";
+    if (!name) return undefined;
+    const version = info?.version ? clean(info.version) : "";
+    return version ? `${name}/${version}` : name;
+}
 
 const mcpHandler = createMcpHandler(
     async (ctx: McpRequestContext) => {
@@ -4517,10 +4551,14 @@ const mcpHandler = createMcpHandler(
 
         const mcpMethod = ctx.requestInfo?.headers.get("mcp-method") ?? "";
         if (ctx.era === "modern" && IDENTITY_ONLY_METHODS.has(mcpMethod)) {
-            return newMcpServer(baseUrl);
+            const bare = newMcpServer(baseUrl);
+            if (trace) trace.server = bare;
+            return bare;
         }
 
-        return buildMcpServer(baseUrl, userId);
+        const server = await buildMcpServer(baseUrl, userId);
+        if (trace) trace.server = server;
+        return server;
     },
     {
         legacy: "stateless",
@@ -4631,6 +4669,8 @@ export const handleMcp = async (c: Context) => {
     // reads this after next() resolves. Set after fetch resolves, which is
     // after the factory has run even when the response body is still streaming.
     if (trace.era) c.set("mcpEra", trace.era);
+    const client = logSafeClient(trace.server?.server.getClientVersion());
+    if (client) c.set("mcpClient", client);
     return response;
 };
 

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -16,6 +16,10 @@ declare module "hono" {
         // handleMcp and read by the access log in index.ts. Optional: requests
         // refused before the SDK builds a server never carry one.
         mcpEra: "legacy" | "modern";
+        // Sanitized "name/version" of the MCP client, when the protocol carried
+        // it. Modern requests carry it in the envelope every time; 2025-era
+        // requests only on `initialize`.
+        mcpClient: string;
     }
 }
 import {


### PR DESCRIPTION
Follow-up to #118. `era=` tells you which protocol revision a request used, but not *who* was speaking it — and that turned out to be the gap that matters.

## Why

Right after #118 deployed, the logs showed Anthropic's IP range (`160.79.106.x`, ARIN: Anthropic, PBC) serving **both eras within the same minute**. So an IP no longer identifies a client. And a residential address could be any MCP client at all — Claude Desktop, Claude Code, Cursor, MCP Inspector, someone's script.

Retiring the 2025 leg means knowing which clients are still on it *by name*, not inferring it from netblocks.

```
[req] POST /mcp 200 134ms ip=160.79.106.x era=modern client=claude-ai/1.4.2
```

## Where the value comes from

The SDK's own resolution — `server.getClientVersion()` — not a header guess. Each era populates it differently, and that difference is visible in the output:

- **modern**: the envelope backfills client identity on **every** request
- **legacy**: only `initialize` carries `clientInfo`, and the stateless leg builds a fresh server per request

So a legacy connection names itself once and its remaining requests log no client. That's a real limitation; the tests assert it rather than hide it. One named request per connection still answers the question.

## Injection

Name and version are client-supplied strings landing straight in a log line — the same surface as the SDK error messages fixed in #115. They're sanitized: non-printables and whitespace collapse to `_`, each field capped at 40 chars.

Non-printables become `_` rather than being deleted, because a deleted newline silently welds together the text on either side and hides what the client actually sent. Both the forged-line and over-long cases are tested.

## Gates

699 pass / 0 fail (was 695). `typecheck` and `format:check` clean. Log format verified by rendering it, including the two absent-field cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012hphsg3hVVUY5MPfTMKvKt