### PR TITLE
chore: 1.26.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "nutrition-mcp",
-    "version": "1.25.0",
+    "version": "1.26.0",
     "description": "A remote MCP server for personal nutrition tracking. Log meals, track macros, and review nutrition history through Claude.",
     "author": "akutishevsky",
     "license": "MIT",

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
     "name": "io.github.akutishevsky/nutrition-mcp",
     "title": "Nutrition MCP",
     "description": "Personal nutrition tracking — log meals, track macros, review history, import from another app.",
-    "version": "1.25.0",
+    "version": "1.26.0",
     "websiteUrl": "https://nutrition-mcp.com/",
     "repository": {
         "url": "https://github.com/akutishevsky/nutrition-mcp",

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -4409,7 +4409,7 @@ function newMcpServer(baseUrl: string): McpServer {
     return new McpServer(
         {
             name: "nutrition-mcp",
-            version: "1.25.0",
+            version: "1.26.0",
             icons: [
                 {
                     src: `${baseUrl}/favicon.ico`,


### PR DESCRIPTION
Version bumped in all three required places: `package.json`, `server.json`, and the `McpServer` constructor in `src/mcp.ts`.

Only the **registry listing** needs this — production already runs everything below, since merging to `main` deploys.

## What the tag covers, since 1.25.0

- **MCP TypeScript SDK v2.** `@modelcontextprotocol/sdk` v1 is gone, replaced by `@modelcontextprotocol/server` at runtime with Zod 4 as an explicit dependency.
- **`/mcp` is dual-era** — `2026-07-28` natively, `2025-11-25` through the SDK's stateless legacy fallback, both from one server factory so the tool surface can't drift between them. Two wire changes clients see: advertised schemas are JSON Schema 2020-12 (v1 stamped draft-07), and a POST whose `Content-Type` isn't `application/json` is refused `415` before the body is read.
- **A graceful shutdown gate.** Closing the SDK handler while `Bun.serve` kept accepting answered every in-flight `/mcp` POST with a 500; new requests now get `503` + `Retry-After`, and the gate's position in the middleware chain is pinned by a test.
- **Error logging** that keeps stacks for genuine faults while escaping the client-controlled text the SDK interpolates into its rejection messages.
- **One forwarded-origin derivation** instead of three near-copies that had drifted.
- **Observability for the legacy retirement** — the access log names the negotiated era and calling client, and `tool_analytics` persists both, so dropping the 2025 leg becomes a query over distinct users rather than a guess.

## Gates

703 pass / 0 fail. `typecheck` and `format:check` clean. No test asserts the version string, so nothing else needed updating.

After merge I'll push `v1.26.0`, which triggers `.github/workflows/publish-mcp.yml` to verify the tag matches `server.json` and publish via OIDC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012hphsg3hVVUY5MPfTMKvKt