### PR TITLE
Fix translated nav labels wrapping to two lines

### DIFF
--- a/public/site.js
+++ b/public/site.js
@@ -152,8 +152,9 @@
             if (a) closeMenu(false);
         });
         // Leaving the phone layout with the sheet open would strand the
-        // inert flags, so close on the way out.
-        var wide = window.matchMedia("(min-width: 880px)");
+        // inert flags, so close on the way out. Matches styles.css's
+        // .head-nav/.site-menu breakpoint.
+        var wide = window.matchMedia("(min-width: 1120px)");
         wide.addEventListener("change", function (ev) {
             if (ev.matches && menuBtn.getAttribute("aria-expanded") === "true")
                 closeMenu(false);

--- a/public/styles.css
+++ b/public/styles.css
@@ -404,17 +404,18 @@ kbd,
     display: none;
     justify-self: center;
     align-items: center;
-    gap: 0.25rem;
+    gap: 0.1rem;
 }
 .head-nav a {
     position: relative;
     display: inline-block;
-    padding: 0.45rem 0.8rem;
-    font-size: 0.92rem;
+    padding: 0.45rem 0.55rem;
+    font-size: 0.85rem;
     font-weight: 500;
     color: var(--ink-2);
     text-decoration: none;
     border-radius: 999px;
+    white-space: nowrap;
     transition:
         color 0.2s ease,
         background 0.2s ease;
@@ -594,7 +595,14 @@ body.is-dark .theme-toggle .moon {
 .menu-btn[aria-expanded="true"] .burger::after {
     transform: translateY(-6px) rotate(-45deg);
 }
-@media (min-width: 880px) {
+/* 1120px, not the usual tablet breakpoint: below it the desktop nav's 6
+   items, translated, can overflow or wrap mid-phrase (e.g. Ukrainian
+   "Статистика наживо", Polish "Statystyki na żywo" are longer than their
+   English source) — matches .head-inner's own max-width, so nothing here
+   competes with translated labels for room below the width where they'd
+   fit anyway. Below it, the mobile sheet menu (one label per line, no
+   width contest) takes over instead. */
+@media (min-width: 1120px) {
     .head-nav {
         display: flex;
     }
@@ -723,7 +731,9 @@ body.is-dark .theme-toggle .moon {
 body.menu-open {
     overflow: hidden;
 }
-@media (min-width: 880px) {
+/* Matches the .head-nav breakpoint above — the mobile sheet is what's
+   shown below it. */
+@media (min-width: 1120px) {
     .site-menu {
         display: none;
     }


### PR DESCRIPTION
## Summary

Every non-English locale has at least one nav label longer than its English source (e.g. Ukrainian "Статистика наживо", Polish "Statystyki na żywo", German "So funktioniert's"), and the desktop nav's available width is capped regardless of viewport size — so at common desktop widths these labels wrapped mid-phrase into two lines, growing that nav item unevenly and looking broken (screenshot from the reporting user showed this on `/uk`).

- `.head-nav a`: `white-space: nowrap`, tightened padding/font-size to reclaim room — a small universal change, not locale-specific.
- Raised the breakpoint where the desktop nav takes over from the mobile sheet menu, `880px → 1120px` (both matching CSS media queries, plus `site.js`'s matching resize-driven auto-close threshold) — below that width there isn't room for all 6 translated items on one line, so the (already-fine) mobile menu takes over instead.

## Verification

- [x] Live-tested via chrome-devtools MCP across `es`/`de`/`pl`/`uk` (the longest labels) at the new breakpoint (1120px): no wrapping, no horizontal overflow
- [x] English at 1120px: layout essentially unchanged, just slightly tighter nav spacing
- [x] Just below the breakpoint (1000px): clean fallback to the mobile hamburger menu, opens/closes correctly
- [x] `bun run typecheck`, `bun run format:check`, `bun test` (712 pass) all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014RLEUoBCk7ZoFRRqv3qBQ8