### PR TITLE
Fix 320px horizontal overflow in install tabs and facts rows

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -1344,7 +1344,9 @@ body.is-dark .btn-primary:hover,
     display: flex;
     align-items: center;
     justify-content: center;
+    flex-wrap: wrap;
     gap: 0.45rem;
+    min-width: 0;
     min-height: 40px;
     font-size: 0.9rem;
     font-weight: 500;
@@ -1634,8 +1636,9 @@ html.js .facts-unit {
 }
 .facts-row {
     display: flex;
+    flex-wrap: wrap;
     align-items: baseline;
-    justify-content: space-between;
+    justify-content: flex-end;
     gap: 1rem;
     padding: 0.55rem 0;
     border-bottom: 1px solid var(--line);


### PR DESCRIPTION
## Summary
- `.seg label` (install-card tab) couldn't shrink below its content width as a CSS grid item, so a long translated "Other agents" label pushed the landing page past 320px viewport width. Fixed with `min-width: 0` + `flex-wrap: wrap`.
- `.facts-row` had no `flex-wrap`, so a delta pill next to a wide figure overflowed the Nutrition Facts panel's right edge at 320px. Fixed by mirroring the existing `.facts-cal` fix from #129: `flex-wrap: wrap` + `justify-content: flex-end`.

Fixes #134
Fixes #133

## Test plan
- [x] At 320px viewport, `document.documentElement.scrollWidth === clientWidth` on `/` and all 8 locale mirrors (de/es/fr/it/nl/pl/uk/ja) — no horizontal page overflow
- [x] No-delta `.facts-row` state is unchanged (same row height/no wrap) across all 9 locales, including long labels (German "Kohlenhydrate", Ukrainian "Записів їжі") — rules out the regression the issue explicitly flagged
- [x] With a wide delta pill injected (mirroring `showDelta()`'s DOM shape), `.facts-row` no longer overflows at 320px and wraps cleanly to a second line
- [x] Desktop widths (1280px) render identically before/after on both fixes
- [x] `bun run format:check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FkYyVu2qC7DZ9RJ9QwWUCv