### PR TITLE
Fix tool_analytics error categorization swallowing most failures as "unknown"

### DIFF
--- a/src/analytics.test.ts
+++ b/src/analytics.test.ts
@@ -1,0 +1,129 @@
+import { describe, test, expect } from "bun:test";
+import { categorizeError } from "./analytics.js";
+
+// Each case below is the literal (or representative) wording of a real throw
+// site, not an invented string — see the file/line noted in each comment.
+// This is the only guard against categorizeError silently drifting out of
+// sync when one of those messages gets reworded elsewhere.
+describe("categorizeError", () => {
+    test.each([
+        // src/tz.ts resolveWriteLoggedAt / src/mcp.ts unsetTzNote re-throw
+        [
+            'logged_at is invalid ("yesterday evening"): unrecognized format. Use "YYYY-MM-DD" for a date with no known time.',
+            "invalid_date_format",
+        ],
+        [
+            "logged_at is in the future (2026-08-27T16:30:49). Log the time the entry was actually recorded.",
+            "invalid_date_format",
+        ],
+        [
+            'logged_at is in the future (2026-08-27T16:30:49). "2026-08-27T16:30:49" carries no UTC offset and this account has no timezone set, so it was read as UTC. Set one with set_timezone.',
+            "invalid_date_format",
+        ],
+        // src/tz.ts shiftLocalDate / splitDate
+        ["Invalid date string: 2026-99-99", "invalid_date_format"],
+
+        // src/mcp.ts set_timezone
+        [
+            "Invalid timezone: Mars/Olympus_Mons. Use an IANA identifier like 'America/Los_Angeles' or 'Europe/London'.",
+            "invalid_timezone",
+        ],
+
+        // src/mcp.ts assertPlausibleWeight
+        [
+            "5000 kg is outside the plausible body-weight range (20–500 kg / 44–1102 lb). Double-check the number and unit.",
+            "invalid_numeric_value",
+        ],
+        // src/units.ts toGrams
+        ["Invalid weight value: NaN", "invalid_numeric_value"],
+        // src/alcohol.ts gramsFromDrink
+        ["Invalid drink volume (mL): -50", "invalid_numeric_value"],
+        [
+            "Invalid ABV (expected a percentage between 0 and 100): 250",
+            "invalid_numeric_value",
+        ],
+
+        // src/mcp.ts set_language
+        [
+            "Unsupported language: xx. Use one of: en, de, es, fr, nl, pl, it, uk, ja.",
+            "invalid_param_value",
+        ],
+        // src/mcp.ts set_weight_unit
+        [
+            "Invalid weight unit: stone. Use 'kg', 'lb', or null to clear.",
+            "invalid_param_value",
+        ],
+
+        // src/units.ts pickWriteUnit
+        [
+            "No weight unit given and no preference set. Pass unit ('kg' or 'lb'), or set a default first with set_weight_unit.",
+            "missing_required_param",
+        ],
+
+        // src/supabase.ts updateMeal / updateWeight not-found pre-checks
+        ["Failed to update meal: meal not found", "record_not_found"],
+        ["Failed to update weight: entry not found", "record_not_found"],
+
+        // src/supabase.ts / src/foods.ts missing config
+        [
+            "Missing SUPABASE_URL or SUPABASE_SECRET_KEY",
+            "service_misconfigured",
+        ],
+        [
+            "OFF_USER_AGENT is not configured — Open Food Facts requires a User-Agent like 'nutrition-mcp (you@example.com)'",
+            "service_misconfigured",
+        ],
+
+        // src/widgets.ts assembly
+        ["@inlinets source not found: src/missing.ts", "internal_asset_error"],
+        [
+            "widget source partial not found: shared/missing.js",
+            "internal_asset_error",
+        ],
+        ["@include cycle: a.html -> b.html -> a.html", "internal_asset_error"],
+        ["unknown widget: not-a-real-widget", "internal_asset_error"],
+
+        // src/export.ts / src/supabase.ts
+        ["Failed to upload export: storage quota exceeded", "export_error"],
+        ["Failed to create download link: unknown error", "export_error"],
+        [
+            "getAllMeals: fetched 5 meals but countMeals reported 10 — export would be truncated",
+            "export_error",
+        ],
+
+        // src/supabase.ts generic persistence failures — the regression case:
+        // these contain "token"/"auth" as our own noun, not as a signal, and
+        // must NOT be classified auth_expired.
+        ["Failed to insert meal: connection reset", "supabase_error"],
+        ["Failed to store token: duplicate key value", "supabase_error"],
+        ["Failed to delete auth codes: connection reset", "supabase_error"],
+        ["Failed to look up meal: connection reset", "supabase_error"],
+        ["Failed to count water: connection reset", "supabase_error"],
+        ["Failed to check existing meals: connection reset", "supabase_error"],
+        ["Failed to save profile: connection reset", "supabase_error"],
+
+        // Third-party auth text with no "Failed to " prefix of ours
+        ["JWT expired", "auth_expired"],
+        ["Auth session missing!", "auth_expired"],
+
+        // src/foods.ts Open Food Facts
+        ["Open Food Facts request failed: 429", "rate_limited"],
+        ["Open Food Facts request failed: 500", "unknown"],
+
+        // Native/third-party network errors
+        ["fetch failed", "network_error"],
+        ["connect ECONNREFUSED 127.0.0.1:5432", "network_error"],
+        ["The operation was aborted due to timeout", "network_error"],
+
+        // True last-resort fallback
+        ["Cannot read properties of undefined (reading 'x')", "unknown"],
+    ])("categorizes %j as %s", (message, expected) => {
+        expect(categorizeError(new Error(message))).toBe(expected);
+    });
+
+    test("non-Error values fall back to unknown", () => {
+        expect(categorizeError("plain string")).toBe("unknown");
+        expect(categorizeError(42)).toBe("unknown");
+        expect(categorizeError(new Error(""))).toBe("unknown");
+    });
+});

--- a/src/analytics.ts
+++ b/src/analytics.ts
@@ -44,13 +44,117 @@ interface AnalyticsContext {
     clientInfo?: () => { name?: string; version?: string } | undefined;
 }
 
-function categorizeError(error: unknown): string {
+/**
+ * Bucket a thrown error for `tool_analytics.error_category`.
+ *
+ * Checked in three tiers. Tier 1 matches the *literal, fixed wording* of
+ * validation/config errors this codebase throws itself (resolveWriteLoggedAt,
+ * set_timezone, assertPlausibleWeight, widget assembly, missing env config,
+ * …) — checked first so they don't get swallowed by tier 3's looser
+ * keyword heuristics. Tier 2 is every src/supabase.ts persistence throw,
+ * matched generically by its "Failed to <verb> <noun>: <cause>" prefix —
+ * this runs *before* tier 3's auth/rate/date keyword checks specifically so
+ * that a message like "Failed to store token" or "Failed to delete auth
+ * codes" (which legitimately contain "token"/"auth" as our own noun, not as
+ * a signal about the failure) is bucketed as `supabase_error`, not
+ * `auth_expired`, before tier 3 ever sees it. Tier 3 is for third-party text
+ * we didn't author (Postgres/PostgREST, native fetch/DNS errors) where only
+ * a keyword heuristic is possible.
+ */
+export function categorizeError(error: unknown): string {
     const msg =
         error instanceof Error ? error.message.toLowerCase() : String(error);
+
+    // ---- Tier 1: our own fixed message wording ----
+
+    // resolveWriteLoggedAt (src/tz.ts) and its unset-timezone re-throw
+    // (src/mcp.ts) — both always carry one of these phrases regardless of
+    // which parseLoggedAt failure reason produced them.
+    if (
+        msg.includes("logged_at is invalid") ||
+        msg.includes("logged_at is in the future") ||
+        msg.includes("carries no utc offset")
+    )
+        return "invalid_date_format";
+
+    // Thrown by set_timezone in src/mcp.ts (not src/tz.ts — that file only
+    // ever throws the logged_at-shaped messages matched above).
+    if (msg.includes("invalid timezone")) return "invalid_timezone";
+
+    // toGrams / gramsFromDrink (src/units.ts, src/alcohol.ts) and
+    // assertPlausibleWeight (src/mcp.ts) — a bad number, not a bad shape.
+    if (
+        msg.includes("outside the plausible body-weight range") ||
+        msg.includes("invalid weight value") ||
+        msg.includes("invalid drink volume") ||
+        msg.includes("invalid abv")
+    )
+        return "invalid_numeric_value";
+
+    if (
+        msg.includes("unsupported language") ||
+        msg.includes("invalid weight unit")
+    )
+        return "invalid_param_value";
+
+    // pickWriteUnit (src/units.ts) — semantically missing_required_param,
+    // but its wording doesn't contain "missing" or "required".
+    if (msg.includes("no weight unit given and no preference set"))
+        return "missing_required_param";
+
+    // updateMeal / updateWeight (src/supabase.ts) pre-checks — a stale or
+    // wrong id, not a DB outage, so it shouldn't share supabase_error's bucket.
+    if (msg.includes("meal not found") || msg.includes("entry not found"))
+        return "record_not_found";
+
+    // Deploy/env config problems, not user- or DB-caused. The only throw site
+    // for the first is the single literal "Missing SUPABASE_URL or
+    // SUPABASE_SECRET_KEY" (src/supabase.ts) — one substring check covers it.
+    if (
+        msg.includes("missing supabase_url or supabase_secret_key") ||
+        msg.includes("off_user_agent is not configured")
+    )
+        return "service_misconfigured";
+
+    // src/widgets.ts assembly — should only fire on a deploy defect, never
+    // in ordinary operation, so it gets its own bucket rather than "unknown".
+    if (
+        msg.includes("@inlinets") ||
+        msg.includes("widget source partial not found") ||
+        msg.includes("@include cycle") ||
+        msg.startsWith("unknown widget:")
+    )
+        return "internal_asset_error";
+
+    // export_all_data (src/export.ts / src/supabase.ts) — upload, signed-URL,
+    // and row-count-mismatch failures.
+    if (
+        msg.includes("failed to upload export") ||
+        msg.includes("failed to create download link") ||
+        msg.includes("export would be truncated")
+    )
+        return "export_error";
+
+    // ---- Tier 2: every src/supabase.ts persistence throw ----
+
+    // Every one follows "Failed to <verb> <noun>: <cause>" — match the prefix
+    // generically rather than enumerating verbs, or a verb added later (as
+    // happened with "look up", "resolve", "count", "check", "save", "store",
+    // "upload") silently falls through to "unknown" again. Deliberately
+    // checked *before* tier 3's auth/rate/date keywords below: our own nouns
+    // ("Failed to store token", "Failed to delete auth codes") would
+    // otherwise false-positive on tier 3's "token"/"auth" check.
+    if (msg.includes("failed to ") || msg.includes("supabase"))
+        return "supabase_error";
+
+    // ---- Tier 3: keyword heuristics for third-party error text ----
 
     if (
         msg.includes("auth") ||
         msg.includes("token") ||
+        msg.includes("jwt") ||
+        msg.includes("unauthorized") ||
+        msg.includes("invalid api key") ||
         msg.includes("expired")
     )
         return "auth_expired";
@@ -61,18 +165,11 @@ function categorizeError(error: unknown): string {
     if (msg.includes("required") || msg.includes("missing"))
         return "missing_required_param";
     if (
-        msg.includes("supabase") ||
-        msg.includes("failed to insert") ||
-        msg.includes("failed to get") ||
-        msg.includes("failed to delete") ||
-        msg.includes("failed to update") ||
-        msg.includes("failed to search")
-    )
-        return "supabase_error";
-    if (
         msg.includes("network") ||
         msg.includes("fetch") ||
-        msg.includes("ECONNREFUSED")
+        msg.includes("econnrefused") ||
+        msg.includes("timeout") ||
+        msg.includes("timed out")
     )
         return "network_error";
 
@@ -172,8 +269,12 @@ export async function withAnalytics<T>(
         const durationMs = Math.round(performance.now() - start);
         const errorCategory = categorizeError(error);
 
+        // The raw message never reaches tool_analytics (no column for it —
+        // error_category is the only stored signal), so this line is the
+        // only place a future "unknown" bucket is diagnosable from, and only
+        // for as long as the runtime log ring buffer retains it.
         console.warn(
-            `[analytics] ${toolName} error=${errorCategory} ${durationMs}ms user=${context.userId}`,
+            `[analytics] ${toolName} error=${errorCategory} ${durationMs}ms user=${context.userId}: ${error instanceof Error ? error.message : String(error)}`,
         );
 
         persistAnalytics({

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -48,7 +48,11 @@ import {
     type WaterEntry,
     type WeightEntry,
 } from "./supabase.js";
-import { DELETED_ACCOUNT_ANALYTICS_ID, withAnalytics } from "./analytics.js";
+import {
+    DELETED_ACCOUNT_ANALYTICS_ID,
+    withAnalytics,
+    categorizeError,
+} from "./analytics.js";
 import {
     todayInTz,
     validateTz,
@@ -1778,6 +1782,16 @@ export function registerTools(
             }),
         },
         async ({ barcode }) => {
+            // lookupBarcode's own failures (OFF down, timeout, bad config) are
+            // caught below and turned into a normal (non-isError) content
+            // response so the model can fall back to estimating — but that
+            // means withAnalytics never sees a thrown error. Without this flag
+            // an OFF outage silently records as `success: true`, which is how
+            // it stayed invisible to tool_analytics entirely.
+            // Safe only because withAnalytics awaits the handler to
+            // completion before reading this via `outcome` below — it is not
+            // read concurrently with the handler running.
+            let offFailure: string | null = null;
             return withAnalytics(
                 "lookup_barcode",
                 async () => {
@@ -1799,6 +1813,16 @@ export function registerTools(
                     } catch (err) {
                         const msg =
                             err instanceof Error ? err.message : String(err);
+                        // Route through the same categorizeError used for
+                        // thrown errors elsewhere, so a config problem
+                        // ("OFF_USER_AGENT is not configured") or an OFF rate
+                        // limit lands in service_misconfigured/rate_limited
+                        // instead of a generic bucket local to this tool.
+                        const category = categorizeError(err);
+                        offFailure =
+                            category === "unknown"
+                                ? "external_api_error"
+                                : category;
                         return {
                             content: [
                                 {
@@ -1831,6 +1855,12 @@ export function registerTools(
                 },
                 analytics,
                 { barcode },
+                {
+                    outcome: () =>
+                        offFailure
+                            ? { success: false, errorCategory: offFailure }
+                            : { success: true },
+                },
             );
         },
     );

--- a/src/supabase.ts
+++ b/src/supabase.ts
@@ -1261,16 +1261,23 @@ export async function updateWeight(
                 ? decodeEscapeSequences(fields.notes)
                 : fields.notes;
 
+    // No `.single()` here (unlike updateMeal, which pre-checks existence in a
+    // separate query): a stale/wrong/other-user's id then matches zero rows,
+    // which `.select()` reports as an empty array rather than PostgREST's
+    // opaque "JSON object requested, multiple (or no) rows returned" — one
+    // round trip, and no window between a check and the update itself where
+    // a concurrent delete could reintroduce that same opaque error.
     const { data, error } = await getSupabase()
         .from("weight_log")
         .update(update)
         .eq("id", id)
         .eq("user_id", userId)
-        .select()
-        .single();
+        .select();
 
     if (error) throw new Error(`Failed to update weight: ${error.message}`);
-    return data as WeightEntry;
+    if (!data || data.length === 0)
+        throw new Error("Failed to update weight: entry not found");
+    return data[0] as WeightEntry;
 }
 
 /** Returns true if an entry was deleted, false if no matching row was found. */


### PR DESCRIPTION
## Summary
- `categorizeError()` only matched a handful of hardcoded verbs/keywords, so ~46% of logged tool-call failures landed in `unknown` (and a chunk of the "Supabase error" bucket was miscategorized) — including a dead `ECONNREFUSED` check that could never match, and "Failed to store token"/"Failed to delete auth codes" being misfiled as `auth_expired` purely because they contain "token"/"auth".
- Rewrote `categorizeError` with a three-tier scheme (our own literal wording → generic `Failed to X:` Supabase prefix → third-party keyword heuristics) and added `record_not_found`, `invalid_timezone`, `invalid_numeric_value`, `invalid_param_value`, `service_misconfigured`, `internal_asset_error`, and `export_error` categories for errors that previously matched nothing.
- `updateWeight` now gets the same not-found pre-check `updateMeal` already had, folded into a single query (no TOCTOU window, no extra round trip) instead of relying on PostgREST's opaque "no rows returned" error.
- `lookup_barcode` now routes its own failures through the same `categorizeError` (instead of a disconnected local regex) and reports Open Food Facts outages to `tool_analytics` as failures instead of silent successes.
- The raw error message is now logged alongside the category, so a future `unknown` is diagnosable from server logs without a schema change.
- Added `src/analytics.test.ts` (39 cases keyed to the literal wording of real throw sites across the codebase) so message rewording elsewhere can't silently break a category again — this exact class of drift caused the original gap.

## Test plan
- [x] `bun run typecheck`
- [x] `bun test` (797 pass)
- [x] `bun run format:check`
- [x] Reviewed via `/code-review`; findings (auth-categorization reorder regression, `lookup_barcode`/`categorizeError` disconnect, `updateWeight` TOCTOU race, dead clause, doc comment misattribution, missing test coverage) addressed in this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y1uB4K7P2QJVcYRQCuLqhW