### PR TITLE
Bump version to 1.27.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "nutrition-mcp",
-    "version": "1.27.1",
+    "version": "1.27.2",
     "description": "A remote MCP server for personal nutrition tracking. Log meals, track macros, and review nutrition history through Claude.",
     "author": "akutishevsky",
     "license": "MIT",

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
     "name": "io.github.akutishevsky/nutrition-mcp",
     "title": "Nutrition MCP",
     "description": "Personal nutrition tracking — log meals, track macros, review history, import from another app.",
-    "version": "1.27.1",
+    "version": "1.27.2",
     "websiteUrl": "https://nutrition-mcp.com/",
     "repository": {
         "url": "https://github.com/akutishevsky/nutrition-mcp",

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -4441,7 +4441,7 @@ function newMcpServer(baseUrl: string): McpServer {
     return new McpServer(
         {
             name: "nutrition-mcp",
-            version: "1.27.1",
+            version: "1.27.2",
             icons: [
                 {
                     src: `${baseUrl}/favicon.ico`,


### PR DESCRIPTION
## Summary
- Bumps version in `package.json`, `server.json`, and `src/mcp.ts` (McpServer constructor) to `1.27.2`, to refresh the MCP Registry listing after the tool_analytics error categorization fix (#137).

## Test plan
- [x] `bun run typecheck`
- [x] `bun run format:check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y1uB4K7P2QJVcYRQCuLqhW