### PR TITLE
Validate redirect_uri at /authorize against an allowlist

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,22 +132,23 @@ Requires Bun 1.x (matches the Dockerfile's `oven/bun:1` base image; no exact min
 
 ### 2. Environment variables
 
-| Variable                | Description                                                                                                                                                    |
-| ----------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `SUPABASE_URL`          | Your Supabase project URL                                                                                                                                      |
-| `SUPABASE_SECRET_KEY`   | Supabase service role key (bypasses RLS)                                                                                                                       |
-| `OAUTH_CLIENT_ID`       | Random string for OAuth client identification                                                                                                                  |
-| `OAUTH_CLIENT_SECRET`   | Random string for OAuth client authentication                                                                                                                  |
-| `ALLOWED_ORIGINS`       | _(optional)_ Comma-separated list of extra browser origins allowed to call `/mcp` via CORS — `localhost`/`127.0.0.1` on any port are always allowed regardless |
-| `GOOGLE_CLIENT_ID`      | _(optional)_ Google OAuth client ID for "Sign in with Google"                                                                                                  |
-| `GOOGLE_CLIENT_SECRET`  | _(optional)_ Google OAuth client secret                                                                                                                        |
-| `OFF_USER_AGENT`        | Open Food Facts User-Agent for barcode lookups, in the form `AppName (email)`                                                                                  |
-| `PATREON_CLIENT_ID`     | _(optional)_ Patreon OAuth client ID, for showing recent posts on the landing page's Support section                                                           |
-| `PATREON_CLIENT_SECRET` | _(optional)_ Patreon OAuth client secret                                                                                                                       |
-| `PATREON_CAMPAIGN_ID`   | _(optional)_ Patreon campaign ID to fetch posts from                                                                                                           |
-| `PATREON_ACCESS_TOKEN`  | _(optional)_ Creator's Access Token from Patreon's client management page — one-time bootstrap seed, see below                                                 |
-| `PATREON_REFRESH_TOKEN` | _(optional)_ Creator's Refresh Token from the same page — one-time bootstrap seed, see below                                                                   |
-| `PORT`                  | Server port (default: `8080`)                                                                                                                                  |
+| Variable                | Description                                                                                                                                                                                                              |
+| ----------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `SUPABASE_URL`          | Your Supabase project URL                                                                                                                                                                                                |
+| `SUPABASE_SECRET_KEY`   | Supabase service role key (bypasses RLS)                                                                                                                                                                                 |
+| `OAUTH_CLIENT_ID`       | Random string for OAuth client identification                                                                                                                                                                            |
+| `OAUTH_CLIENT_SECRET`   | Random string for OAuth client authentication                                                                                                                                                                            |
+| `ALLOWED_ORIGINS`       | _(optional)_ Comma-separated list of extra browser origins allowed to call `/mcp` via CORS — `localhost`/`127.0.0.1` on any port are always allowed regardless                                                           |
+| `ALLOWED_REDIRECT_URIS` | _(optional)_ Comma-separated list of extra OAuth `redirect_uri` values `/authorize` will issue a code to. The Claude connector callbacks are allowed by default, as is loopback on any port; everything else is rejected |
+| `GOOGLE_CLIENT_ID`      | _(optional)_ Google OAuth client ID for "Sign in with Google"                                                                                                                                                            |
+| `GOOGLE_CLIENT_SECRET`  | _(optional)_ Google OAuth client secret                                                                                                                                                                                  |
+| `OFF_USER_AGENT`        | Open Food Facts User-Agent for barcode lookups, in the form `AppName (email)`                                                                                                                                            |
+| `PATREON_CLIENT_ID`     | _(optional)_ Patreon OAuth client ID, for showing recent posts on the landing page's Support section                                                                                                                     |
+| `PATREON_CLIENT_SECRET` | _(optional)_ Patreon OAuth client secret                                                                                                                                                                                 |
+| `PATREON_CAMPAIGN_ID`   | _(optional)_ Patreon campaign ID to fetch posts from                                                                                                                                                                     |
+| `PATREON_ACCESS_TOKEN`  | _(optional)_ Creator's Access Token from Patreon's client management page — one-time bootstrap seed, see below                                                                                                           |
+| `PATREON_REFRESH_TOKEN` | _(optional)_ Creator's Refresh Token from the same page — one-time bootstrap seed, see below                                                                                                                             |
+| `PORT`                  | Server port (default: `8080`)                                                                                                                                                                                            |
 
 Generate OAuth credentials:
 

--- a/src/oauth.test.ts
+++ b/src/oauth.test.ts
@@ -113,7 +113,9 @@ test("a Google sign-in failure re-renders the error in the session's locale", as
     const authorizeRes = await fire(
         app,
         "GET",
-        `/authorize?response_type=code&client_id=${encodeURIComponent(process.env.OAUTH_CLIENT_ID!)}&redirect_uri=https://example.com/cb&state=xyz&locale=de`,
+        // Loopback, because /authorize now rejects unregistered redirect_uris
+        // and this test is about locale, not about the allowlist.
+        `/authorize?response_type=code&client_id=${encodeURIComponent(process.env.OAUTH_CLIENT_ID!)}&redirect_uri=${encodeURIComponent("http://localhost:9876/cb")}&state=xyz&locale=de`,
         "198.51.100.1",
     );
     expect(authorizeRes.status).toBe(200);
@@ -138,6 +140,82 @@ test("a Google sign-in failure re-renders the error in the session's locale", as
         "Die Anmeldung mit Google ist fehlgeschlagen. Bitte versuche es erneut.",
     );
     expect(errorHtml).not.toContain("Google sign-in failed");
+});
+
+// ---------- redirect_uri allowlist ----------
+
+// The bug these guard: /authorize used to accept any redirect_uri and
+// finishAuthorization delivered the authorization code to it. /register hands
+// client_id and client_secret to anyone, and PKCE binds the code to whoever
+// started the flow — the attacker — so a single crafted link was enough to
+// collect a victim's code and trade it for a year-long token.
+function authorizePath(redirectUri: string): string {
+    return `/authorize?response_type=code&client_id=${encodeURIComponent(
+        process.env.OAUTH_CLIENT_ID!,
+    )}&redirect_uri=${encodeURIComponent(redirectUri)}&state=xyz`;
+}
+
+test("/authorize refuses an unregistered redirect_uri", async () => {
+    _resetBuckets();
+    const { app } = buildTestApp();
+
+    const res = await fire(
+        app,
+        "GET",
+        authorizePath("https://evil.example/collect"),
+        "203.0.113.20",
+    );
+
+    expect(res.status).toBe(400);
+    expect(await res.json()).toMatchObject({ error: "invalid_request" });
+    // Never a 302: a redirect here is the vulnerability, whatever the body says.
+    expect(res.headers.get("location")).toBeNull();
+});
+
+// A prefix or substring test on the allowed host would let this through, which
+// is the same class of mistake as having no check at all.
+test("/authorize refuses a lookalike host that merely starts with an allowed one", async () => {
+    _resetBuckets();
+    const { app } = buildTestApp();
+
+    const res = await fire(
+        app,
+        "GET",
+        authorizePath("https://claude.ai.evil.example/api/mcp/auth_callback"),
+        "203.0.113.21",
+    );
+
+    expect(res.status).toBe(400);
+    expect(res.headers.get("location")).toBeNull();
+});
+
+test("/authorize accepts the Claude connector callback", async () => {
+    _resetBuckets();
+    const { app } = buildTestApp();
+
+    const res = await fire(
+        app,
+        "GET",
+        authorizePath("https://claude.ai/api/mcp/auth_callback"),
+        "203.0.113.22",
+    );
+
+    expect(res.status).toBe(200);
+});
+
+// The MCP Inspector and locally-run clients bind an ephemeral port, so loopback
+// has to be allowed on any port rather than enumerated.
+test("/authorize accepts loopback on an arbitrary port", async () => {
+    _resetBuckets();
+    const { app } = buildTestApp();
+
+    for (const uri of [
+        "http://localhost:6274/oauth/callback",
+        "http://127.0.0.1:51789/cb",
+    ]) {
+        const res = await fire(app, "GET", authorizePath(uri), "203.0.113.23");
+        expect(res.status).toBe(200);
+    }
 });
 
 // ---------- OAuth rate-limit scoping ----------

--- a/src/oauth.ts
+++ b/src/oauth.ts
@@ -25,6 +25,58 @@ import { chromeFor } from "./copy/chrome.js";
 
 const SESSION_TTL_MS = 10 * 60 * 1000;
 
+// Redirect URIs /authorize is willing to deliver an authorization code to.
+//
+// Nothing else constrains that destination: /register hands the same client_id
+// and client_secret to any anonymous caller, and PKCE binds the code to whoever
+// *started* the flow — which, in the attack this closes, is the attacker, so
+// they hold the verifier themselves. /token's existing check compares the
+// presented redirect_uri against the one stored alongside the code, so it only
+// ever confirms the value agrees with itself. This list is therefore the only
+// thing standing between a crafted /authorize link and someone else's account.
+//
+// The defaults are the Claude connector callbacks this server exists to serve.
+const DEFAULT_ALLOWED_REDIRECT_URIS = [
+    "https://claude.ai/api/mcp/auth_callback",
+    "https://claude.com/api/mcp/auth_callback",
+];
+
+// Additional clients, comma-separated — same shape and reasoning as
+// ALLOWED_ORIGINS in src/index.ts, so a self-hoster pointing another MCP client
+// at their instance configures it rather than patching this file.
+function resolveAllowedRedirectUris(): Set<string> {
+    const extra =
+        process.env.ALLOWED_REDIRECT_URIS?.split(",")
+            .map((u) => u.trim())
+            .filter(Boolean) ?? [];
+    return new Set([...DEFAULT_ALLOWED_REDIRECT_URIS, ...extra]);
+}
+
+// Loopback is always allowed, on any port and path: the MCP Inspector and
+// locally-run clients bind an ephemeral port, so there is no fixed value to
+// list. Mirrors the localhost exemption the CORS origin check already makes.
+//
+// Parsed rather than pattern-matched, and compared on `hostname` alone, because
+// a substring or prefix test admits "https://localhost.evil.example" — the same
+// class of mistake as the missing check itself.
+function isLoopbackRedirect(uri: string): boolean {
+    let parsed: URL;
+    try {
+        parsed = new URL(uri);
+    } catch {
+        return false;
+    }
+    if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+        return false;
+    }
+    return (
+        parsed.hostname === "localhost" ||
+        parsed.hostname === "127.0.0.1" ||
+        // URL.hostname keeps the brackets on an IPv6 literal.
+        parsed.hostname === "[::1]"
+    );
+}
+
 interface OAuthSession {
     state: string;
     redirectUri: string;
@@ -255,6 +307,11 @@ export function createOAuthRouter() {
         throw new Error("Missing OAUTH_CLIENT_ID or OAUTH_CLIENT_SECRET");
     }
 
+    // Resolved here rather than at module load, so it reads the environment at
+    // the same moment clientId does — a test (or a caller) that sets
+    // ALLOWED_REDIRECT_URIS before building the router gets what it set.
+    const allowedRedirectUris = resolveAllowedRedirectUris();
+
     // Dynamic client registration (required by MCP spec)
     oauth.post("/register", async (c) => {
         const body = await c.req.json();
@@ -292,6 +349,20 @@ export function createOAuthRouter() {
         }
         if (reqClientId !== clientId) {
             return c.json({ error: "invalid_client" }, 400);
+        }
+        // Exact match, never a prefix: a prefix test on
+        // "https://claude.ai" also admits "https://claude.ai.evil.example".
+        if (
+            !allowedRedirectUris.has(redirectUri) &&
+            !isLoopbackRedirect(redirectUri)
+        ) {
+            return c.json(
+                {
+                    error: "invalid_request",
+                    error_description: "redirect_uri is not registered",
+                },
+                400,
+            );
         }
 
         cleanExpiredSessions();


### PR DESCRIPTION
Closes #148.

## What this fixes

`GET /authorize` accepted any `redirect_uri` and `finishAuthorization` delivered the authorization code to it. Nothing else constrained that destination:

- `POST /register` returns the same static `client_id` / `client_secret` to any anonymous caller, so client authentication is no obstacle.
- PKCE binds the code to whoever *started* the flow — the attacker — so they hold the verifier themselves.
- The `/token` check at `src/oauth.ts` compares the presented `redirect_uri` against the one stored alongside the code, so it only ever confirms the value agrees with itself.

One crafted `/authorize` link was therefore enough to collect a signed-in user's code from the server's own genuine login page, and trade it for a token valid for 365 days with no revocation endpoint.

## The change

`/authorize` now rejects an unregistered `redirect_uri` with `invalid_request`, immediately after the existing `client_id` check. Allowed:

- the Claude connector callbacks, as defaults
- loopback (`localhost` / `127.0.0.1` / `[::1]`) on any port and path, since the MCP Inspector and locally-run clients bind an ephemeral port — mirroring the localhost exemption the CORS origin check already makes
- anything listed in a new optional `ALLOWED_REDIRECT_URIS`, comma-separated — same shape and reasoning as `ALLOWED_ORIGINS` in `src/index.ts`, so a self-hoster pointing another client at their instance configures it rather than patching the source

Matching is exact, never prefix-based: a prefix test on `https://claude.ai` also admits `https://claude.ai.evil.example`, which is the same class of mistake as having no check at all.

The allowlist is resolved inside `createOAuthRouter()` alongside `clientId`, so it reads the environment at the same moment — a caller that sets the variable before building the router gets what it set.

## Please check the defaults before merging

`DEFAULT_ALLOWED_REDIRECT_URIS` is set to:

```
https://claude.ai/api/mcp/auth_callback
https://claude.com/api/mcp/auth_callback
```

I took these from Anthropic's documented callback plus the `claude.com` variant, but I can't see what the hosted instance actually receives. **Worth confirming against a real `[req] GET /authorize` line in your production logs before this merges**, since a wrong value here would break the connector for everyone. If Claude uses something else, it's a one-line change to the constant — or `ALLOWED_REDIRECT_URIS` covers it without a redeploy of the code.

## Tests

Four cases added to `src/oauth.test.ts`:

- an unregistered `redirect_uri` is refused, and the response carries no `Location` (a redirect here is the vulnerability, whatever the body says)
- a lookalike host that merely *starts with* an allowed one is refused — the prefix-matching regression guard
- the Claude connector callback is accepted
- loopback on an arbitrary port is accepted

Verified they're real guards: with the `/authorize` change stashed, the two negative cases fail and the rest pass.

One existing test needed updating — the Google-locale test used `https://example.com/cb` purely as a placeholder; it now uses loopback, since that test is about locale rendering rather than the allowlist.

`bun test` 830 pass / 0 fail, `bun run typecheck` clean, `bun run format:check` clean. The `README.md` diff is larger than the one added row because Prettier re-pads the env table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
